### PR TITLE
Fix cluster duplicates

### DIFF
--- a/RecCalorimeter/src/components/CreateCaloClustersSlidingWindow.cpp
+++ b/RecCalorimeter/src/components/CreateCaloClustersSlidingWindow.cpp
@@ -59,6 +59,7 @@ StatusCode CreateCaloClustersSlidingWindow::execute() {
   }
 
   // preclusters with phi, eta weighted position and transverse energy
+  m_preClusters.clear();
   int halfEtaPos = floor(m_nEtaPosition / 2.);
   int halfPhiPos = floor(m_nPhiPosition / 2.);
   float posEta = 0;


### PR DESCRIPTION
This prevents to store, in the new event, the clusters from the previous events. Not sure why/if it was working in the previous fccedm implementation...