### PR TITLE
Fix the (a?) calo clustering segmentation fault

### DIFF
--- a/RecCalorimeter/src/components/CaloTowerTool.cpp
+++ b/RecCalorimeter/src/components/CaloTowerTool.cpp
@@ -457,5 +457,6 @@ void CaloTowerTool::attachCells(float eta, float phi, uint halfEtaFin, uint half
       }
     }
   }
+  m_cellsInTowers.clear();
   return;
 }

--- a/RecCalorimeter/src/components/CaloTowerTool.cpp
+++ b/RecCalorimeter/src/components/CaloTowerTool.cpp
@@ -193,9 +193,7 @@ tower CaloTowerTool::towersNumber() {
 
 uint CaloTowerTool::buildTowers(std::vector<std::vector<float>>& aTowers) {
   uint totalNumberOfCells = 0;
-  for (auto& towerInMap : m_cellsInTowers) {
-    towerInMap.second.clear();
-  }
+  m_cellsInTowers.clear();
   // 1. ECAL barrel
   // Get the input collection with calorimeter cells
   const edm4hep::CalorimeterHitCollection* ecalBarrelCells = m_ecalBarrelCells.get();


### PR DESCRIPTION
This line was creating a segmentation fault:
https://github.com/HEP-FCC/k4RecCalorimeter/blob/main/RecCalorimeter/src/components/CaloTowerTool.cpp#L197
Both clears seem to be necessary to avoid the problem, not exactly sure why... Explanations and opinions on how to best fix this would be very welcome!