### PR TITLE
Adapt to new podio generated class names

### DIFF
--- a/RecCalorimeter/src/components/CaloTopoCluster.cpp
+++ b/RecCalorimeter/src/components/CaloTopoCluster.cpp
@@ -113,7 +113,7 @@ StatusCode CaloTopoCluster::execute() {
   double checkTotEnergy = 0.;
   int clusterWithMixedCells = 0;
   for (auto i : preClusterCollection) {
-    edm4hep::Cluster cluster;
+    edm4hep::MutableCluster cluster;
     //auto& clusterCore = cluster.core();
     double posX = 0.;
     double posY = 0.;

--- a/RecCalorimeter/src/components/CaloTowerTool.cpp
+++ b/RecCalorimeter/src/components/CaloTowerTool.cpp
@@ -6,6 +6,7 @@
 // datamodel
 #include "edm4hep/CalorimeterHitCollection.h"
 #include "edm4hep/Cluster.h"
+#include "edm4hep/MutableCluster.h"
 
 // DD4hep
 #include "DD4hep/Detector.h"
@@ -434,7 +435,7 @@ std::pair<dd4hep::DDSegmentation::Segmentation*, CaloTowerTool::SegmentationType
   return std::make_pair(segmentation, SegmentationType::kWrong);
 }
 
-void CaloTowerTool::attachCells(float eta, float phi, uint halfEtaFin, uint halfPhiFin, edm4hep::Cluster& aEdmCluster, edm4hep::CalorimeterHitCollection* aEdmClusterCells, bool aEllipse) {
+void CaloTowerTool::attachCells(float eta, float phi, uint halfEtaFin, uint halfPhiFin, edm4hep::MutableCluster& aEdmCluster, edm4hep::CalorimeterHitCollection* aEdmClusterCells, bool aEllipse) {
   int etaId = idEta(eta);
   int phiId = idPhi(phi);
   int num1 = 0;

--- a/RecCalorimeter/src/components/CaloTowerTool.h
+++ b/RecCalorimeter/src/components/CaloTowerTool.h
@@ -103,7 +103,7 @@ public:
    *   @param[out] aEdmCluster Cluster where cells are attached to
    */
   virtual void attachCells(float aEta, float aPhi, uint aHalfEtaFinal, uint aHalfPhiFinal,
-                           edm4hep::Cluster& aEdmCluster, edm4hep::CalorimeterHitCollection* aEdmClusterCells, bool aEllipse = false) final;
+                           edm4hep::MutableCluster& aEdmCluster, edm4hep::CalorimeterHitCollection* aEdmClusterCells, bool aEllipse = false) final;
 
 private:
   /// Type of the segmentation
@@ -213,7 +213,7 @@ private:
   int m_nPhiTower;
   /// map to cells contained within a tower so they can be attached to a reconstructed cluster (note that fraction of
   /// their energy assigned to a cluster is not acknowledged)
-  std::map<std::pair<uint, uint>, std::vector<edm4hep::ConstCalorimeterHit>> m_cellsInTowers;
+  std::map<std::pair<uint, uint>, std::vector<edm4hep::CalorimeterHit>> m_cellsInTowers;
   /// Use only half of calorimeter
   Gaudi::Property<bool> m_useHalfTower{this, "halfTower", false, "Use half tower"};
 };

--- a/RecCalorimeter/src/components/ConeSelection.cpp
+++ b/RecCalorimeter/src/components/ConeSelection.cpp
@@ -77,7 +77,7 @@ StatusCode ConeSelection::execute() {
   }
 
   for (const auto& cell : m_cellsMap) {
-    edm4hep::CalorimeterHit newCell = edmCellsCollection->create();
+    auto newCell = edmCellsCollection->create();
     newCell.setEnergy(cell.second);
     newCell.setCellID(cell.first);
   }

--- a/RecCalorimeter/src/components/CorrectCaloClusters.cpp
+++ b/RecCalorimeter/src/components/CorrectCaloClusters.cpp
@@ -166,7 +166,7 @@ edm4hep::ClusterCollection* CorrectCaloClusters::initializeOutputClusters(
   edm4hep::ClusterCollection* outClusters = m_outClusters.createAndPut();
 
   for (auto const& inCluster: *inClusters) {
-    edm4hep::Cluster outCluster = outClusters->create();
+    auto outCluster = outClusters->create();
 
     outCluster.setPosition(inCluster.getPosition());
     verbose() << "Cluster position:" << endmsg;
@@ -307,7 +307,7 @@ StatusCode CorrectCaloClusters::applyDownstreamCorr(const edm4hep::ClusterCollec
 }
 
 
-double CorrectCaloClusters::getEnergyInLayer(edm4hep::ConstCluster cluster,
+double CorrectCaloClusters::getEnergyInLayer(edm4hep::Cluster cluster,
                                              const std::string& readoutName,
                                              size_t systemID,
                                              size_t layerID) {
@@ -330,7 +330,7 @@ double CorrectCaloClusters::getEnergyInLayer(edm4hep::ConstCluster cluster,
 }
 
 
-double CorrectCaloClusters::getClusterTheta(edm4hep::ConstCluster cluster) {
+double CorrectCaloClusters::getClusterTheta(edm4hep::Cluster cluster) {
   double rxy = std::sqrt(std::pow(cluster.getPosition().x, 2) + std::pow(cluster.getPosition().y, 2));
   double theta = ::fabs(std::atan2(rxy, cluster.getPosition().z));
   theta = 180 * theta / M_PI;

--- a/RecCalorimeter/src/components/CorrectCaloClusters.h
+++ b/RecCalorimeter/src/components/CorrectCaloClusters.h
@@ -19,7 +19,7 @@ class ITHistSvc;
 // EDM4HEP
 namespace edm4hep {
   class Cluster;
-  class ConstCluster;
+  class MutableCluster;
   class ClusterCollection;
   class CalorimeterHitCollection;
   class MCParticleCollection;
@@ -113,7 +113,7 @@ private:
    *
    * @return                   Energy in layer.
    */
-  double getEnergyInLayer(edm4hep::ConstCluster cluster,
+  double getEnergyInLayer(edm4hep::Cluster cluster,
                           const std::string& readoutName,
                           size_t systemID,
                           size_t layerID);
@@ -125,7 +125,7 @@ private:
    *
    * @return              theta angle value.
    */
-  double getClusterTheta(edm4hep::ConstCluster cluster);
+  double getClusterTheta(edm4hep::Cluster cluster);
 
   /// Handle for input calorimeter clusters collection
   DataHandle<edm4hep::ClusterCollection> m_inClusters {

--- a/RecCalorimeter/src/components/CorrectECalBarrelSliWinCluster.cpp
+++ b/RecCalorimeter/src/components/CorrectECalBarrelSliWinCluster.cpp
@@ -254,7 +254,7 @@ StatusCode CorrectECalBarrelSliWinCluster::execute() {
     }
 
     // 0. Create new cluster, copy information from input
-    edm4hep::Cluster newCluster = correctedClusters->create();
+    edm4hep::MutableCluster newCluster = correctedClusters->create();
     double energy = 0;
     newCluster.setPosition(cluster.getPosition());
     for (auto cell = cluster.hits_begin(); cell != cluster.hits_end(); cell++) {

--- a/RecCalorimeter/src/components/CorrectECalBarrelSliWinCluster.cpp
+++ b/RecCalorimeter/src/components/CorrectECalBarrelSliWinCluster.cpp
@@ -254,7 +254,7 @@ StatusCode CorrectECalBarrelSliWinCluster::execute() {
     }
 
     // 0. Create new cluster, copy information from input
-    edm4hep::MutableCluster newCluster = correctedClusters->create();
+    auto newCluster = correctedClusters->create();
     double energy = 0;
     newCluster.setPosition(cluster.getPosition());
     for (auto cell = cluster.hits_begin(); cell != cluster.hits_end(); cell++) {

--- a/RecCalorimeter/src/components/CreateCaloCells.cpp
+++ b/RecCalorimeter/src/components/CreateCaloCells.cpp
@@ -104,7 +104,7 @@ StatusCode CreateCaloCells::execute() {
   edm4hep::CalorimeterHitCollection* edmCellsCollection = new edm4hep::CalorimeterHitCollection();
   for (const auto& cell : m_cellsMap) {
     if (m_addCellNoise || (!m_addCellNoise && cell.second != 0)) {
-      edm4hep::CalorimeterHit newCell = edm4hep::CalorimeterHit();
+      auto newCell = edmCellsCollection->create();
       newCell.setEnergy(cell.second);
       uint64_t cellid = cell.first;
       newCell.setCellID(cellid);
@@ -117,7 +117,6 @@ StatusCode CreateCaloCells::execute() {
         edm4hep::Vector3f position = edm4hep::Vector3f(outGlobal[0] / dd4hep::mm, outGlobal[1] / dd4hep::mm, outGlobal[2] / dd4hep::mm);
         newCell.setPosition(position);
       }
-      edmCellsCollection->push_back(newCell);
     }
   }
 

--- a/RecCalorimeter/src/components/CreateCaloCellsNoise.cpp
+++ b/RecCalorimeter/src/components/CreateCaloCellsNoise.cpp
@@ -104,7 +104,7 @@ StatusCode CreateCaloCellsNoise::execute() {
   edm4hep::CalorimeterHitCollection* edmCellsCollection = new edm4hep::CalorimeterHitCollection();
   for (const auto& cell : m_cellsMap) {
     if (m_addCellNoise || (!m_addCellNoise && cell.second != 0)) {
-      edm4hep::CalorimeterHit newCell = edm4hep::CalorimeterHit();
+      auto newCell = edmCellsCollection->create();
       newCell.setEnergy(cell.second);
       uint64_t cellid = cell.first;
       newCell.setCellID(cellid);
@@ -117,7 +117,6 @@ StatusCode CreateCaloCellsNoise::execute() {
         edm4hep::Vector3f position = edm4hep::Vector3f(outGlobal[0] / dd4hep::mm, outGlobal[1] / dd4hep::mm, outGlobal[2] / dd4hep::mm);
         newCell.setPosition(position);
       }
-      edmCellsCollection->push_back(newCell);
     }
   }
 

--- a/RecCalorimeter/src/components/CreateCaloClusters.cpp
+++ b/RecCalorimeter/src/components/CreateCaloClusters.cpp
@@ -239,14 +239,14 @@ StatusCode CreateCaloClusters::execute() {
 	totClusterEnergy += cluster.getEnergy();
 	
 	// Building new calibrated cluster
-	edm4hep::Cluster newCluster;
+	edm4hep::MutableCluster newCluster;
 	double posX = 0.;
 	double posY = 0.;
 	double posZ = 0.;
 	double energy = 0.;
 	// Add cells to cluster
 	for (uint it = 0; it < cluster.hits_size(); it++){
-	  edm4hep::CalorimeterHit newCell;
+	  auto newCell = edmClusterCells->create();
 	  
 	  auto cellId = cluster.getHits(it).getCellID();
 	  auto cellEnergy = cluster.getHits(it).getEnergy();

--- a/RecCalorimeter/src/components/LayeredCaloTowerTool.cpp
+++ b/RecCalorimeter/src/components/LayeredCaloTowerTool.cpp
@@ -1,12 +1,15 @@
 #include "LayeredCaloTowerTool.h"
 
-// FCCSW
+// k4FWCore
 #include "k4Interface/IGeoSvc.h"
 
 
 // DD4hep
 #include "DD4hep/Detector.h"
 #include "DD4hep/Readout.h"
+
+// EDM4hep
+#include "edm4hep/MutableCluster.h"
 
 DECLARE_COMPONENT(LayeredCaloTowerTool)
 
@@ -208,7 +211,7 @@ uint LayeredCaloTowerTool::phiNeighbour(int aIPhi) const {
 float LayeredCaloTowerTool::radiusForPosition() const { return m_radius; }
 
 void LayeredCaloTowerTool::attachCells(float eta, float phi, uint halfEtaFin, uint halfPhiFin,
-                                       edm4hep::Cluster& aEdmCluster, edm4hep::CalorimeterHitCollection* aEdmClusterCells, bool) {
+                                       edm4hep::MutableCluster& aEdmCluster, edm4hep::CalorimeterHitCollection* aEdmClusterCells, bool) {
   const edm4hep::CalorimeterHitCollection* cells = m_cells.get();
   for (const auto& cell : *cells) {
     float etaCell = m_segmentation->eta(cell.getCellID());

--- a/RecCalorimeter/src/components/LayeredCaloTowerTool.h
+++ b/RecCalorimeter/src/components/LayeredCaloTowerTool.h
@@ -14,6 +14,7 @@ class IGeoSvc;
 namespace edm4hep {
 class CalorimeterHitCollection;
 class Cluster;
+class MutableCluster;
 }
 
 namespace dd4hep {
@@ -125,7 +126,7 @@ public:
    *   @param[out] aEdmCluster Cluster where cells are attached to
    */
   virtual void attachCells(float aEta, float aPhi, uint aHalfEtaFinal, uint aHalfPhiFinal,
-                           edm4hep::Cluster& aEdmCluster, edm4hep::CalorimeterHitCollection* aEdmClusterCells, bool aEllipse = false) final;
+                           edm4hep::MutableCluster& aEdmCluster, edm4hep::CalorimeterHitCollection* aEdmClusterCells, bool aEllipse = false) final;
   std::shared_ptr<dd4hep::DDSegmentation::BitFieldCoder> m_decoder;
 
 private:

--- a/RecCalorimeter/src/components/MassInv.cpp
+++ b/RecCalorimeter/src/components/MassInv.cpp
@@ -431,7 +431,7 @@ StatusCode MassInv::execute() {
     }
 
     // 0. Create new cluster, copy information from input
-    edm4hep::Cluster newCluster = correctedClusters->create();
+    auto newCluster = correctedClusters->create();
     double energy = 0;
     newCluster.setPosition(cluster.getPosition());
     for (auto cell = cluster.hits_begin(); cell != cluster.hits_end(); cell++) {

--- a/RecCalorimeter/src/components/SplitClusters.cpp
+++ b/RecCalorimeter/src/components/SplitClusters.cpp
@@ -304,7 +304,7 @@ StatusCode SplitClusters::execute() {
 	warning() << "NUMBER OF CELLS BEFORE " << cluster.hits_size() << " AND AFTER CLUSTER SPLITTING (map) " << clusterOfCell.size() << "!!" << endmsg;
 	warning() << "Elements in cells types after sub-cluster building: " << cellsType.size() << endmsg;                                                                        
 	
-	edm4hep::Cluster cluster;
+	auto l_cluster = edmClusters->create();
 	double posX = 0.;
         double posY = 0.;
         double posZ = 0.;
@@ -340,19 +340,18 @@ StatusCode SplitClusters::execute() {
 	  newCell.setType(4);
 	  energy += fNEnergy.second;
 	}
-	cluster.setType(3);
-	cluster.setEnergy(energy);
+	l_cluster.setType(3);
+	l_cluster.setEnergy(energy);
         auto clusterPosition = edm4hep::Vector3f(posX/energy, posY/energy, posZ/energy);
-        cluster.setPosition(clusterPosition);
+        l_cluster.setPosition(clusterPosition);
         totEnergyAfter += energy;
 
-        edmClusters->push_back(cluster);
-	debug() << "Left-over cluster energy:     " << cluster.getEnergy() << endmsg;
+	debug() << "Left-over cluster energy:     " << l_cluster.getEnergy() << endmsg;
       }
 
       // fill clusters into edm format
       for (auto i : preClusterCollection) {
-	edm4hep::Cluster cluster;
+	edm4hep::MutableCluster cluster;
 	double posX = 0.;
 	double posY = 0.;
 	double posZ = 0.;
@@ -417,7 +416,7 @@ StatusCode SplitClusters::execute() {
     
     else{
       // fill cluster without changes
-      edm4hep::Cluster clu = cluster.clone();
+      auto clu = cluster.clone();
       clu.setType(1);
       totEnergyAfter += clu.getEnergy();
       edmClusters->push_back(clu);


### PR DESCRIPTION
- Replace some dedicated types with `auto` and rename others (Cluster -> MutableCluster, ConstCluster -> Cluster) to adapt to the new naming scheme introduced in AIDASoft/podio#205.
- The necessary changes in EDM4hep: key4hep/EDM4hep#132 would break this otherwise. Due to the explict use of Mutable* (in attachCells) this now requires a new version of edm4hep.
- Due to the change in the interface of attachClusters this also now requires a new version of k4fwcore.