### PR TITLE
cmake: set CMAKE_CXX_STANDARD before finding dd4hep

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,22 +2,10 @@ CMAKE_MINIMUM_REQUIRED(VERSION 3.15)
 
 project(k4RecCalorimeter)
 
-find_package(ROOT COMPONENTS RIO Tree)
-
-#---------------------------------------------------------------
-# Load macros and functions for Gaudi-based projects
-find_package(Gaudi)
-find_package(k4FWCore) # implicit: Gaudi
-find_package(EDM4HEP) # implicit: Podio
-find_package(DD4hep)
-find_package(FCCDetectors)
-#---------------------------------------------------------------
-
-
-
 include(GNUInstallDirs)
 include(CTest)
 
+# Set default for install prefix
 if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
   set(CMAKE_INSTALL_PREFIX ${CMAKE_SOURCE_DIR}/InstallArea/ CACHE PATH
     "Install path prefix, prepended onto install directories." FORCE )
@@ -26,12 +14,21 @@ endif()
 # Set up C++ Standard
 # ``-DCMAKE_CXX_STANDARD=<standard>`` when invoking CMake
 set(CMAKE_CXX_STANDARD 17 CACHE STRING "")
-
 if(NOT CMAKE_CXX_STANDARD MATCHES "14|17")
   message(FATAL_ERROR "Unsupported C++ standard: ${CMAKE_CXX_STANDARD}")
 endif()
 
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake ${CMAKE_MODULE_PATH})
+
+
+#---------------------------------------------------------------
+find_package(ROOT COMPONENTS RIO Tree)
+find_package(Gaudi)
+find_package(k4FWCore) # implicit: Gaudi
+find_package(EDM4HEP) # implicit: Podio
+find_package(DD4hep)
+find_package(FCCDetectors)
+#---------------------------------------------------------------
 
 
 add_subdirectory(RecCalorimeter)


### PR DESCRIPTION
This avoids an error with cmake > 3.18, dd4hep <= 1.20.1 related to an unquoted argument.