### PR TITLE
cmake: fix some link targets

### DIFF
--- a/RecCalorimeter/CMakeLists.txt
+++ b/RecCalorimeter/CMakeLists.txt
@@ -6,7 +6,18 @@
 file(GLOB _module_sources src/components/*.cpp)
 gaudi_add_module(k4RecCalorimeterPlugins
                  SOURCES ${_module_sources}
-                 LINK k4FWCore::k4FWCore GaudiAlgLib  GaudiKernel DD4hep::DDCore EDM4HEP::edm4hep  k4FWCore::k4Interface FCCDetectors::DetSegmentation DD4hep::DDG4 ROOT::Core ROOT::Hist FCCDetectors::DetCommon)
+                 LINK k4FWCore::k4FWCore
+                      k4FWCore::k4Interface
+                      Gaudi::GaudiAlgLib
+                      Gaudi::GaudiKernel
+                      DD4hep::DDCore
+                      DD4hep::DDG4
+                      EDM4HEP::edm4hep
+                      ROOT::Core
+                      ROOT::Hist
+                      FCCDetectors::DetSegmentation
+                      FCCDetectors::DetCommon
+                      )
 
 install(TARGETS k4RecCalorimeterPlugins
   EXPORT k4RecCalorimeterTargets

--- a/RecFCCeeCalorimeter/CMakeLists.txt
+++ b/RecFCCeeCalorimeter/CMakeLists.txt
@@ -5,7 +5,17 @@
 file(GLOB _module_sources src/components/*.cpp)
 gaudi_add_module(k4RecFCCeeCalorimeterPlugins
                  SOURCES ${_module_sources}
-                 LINK k4FWCore::k4FWCorePlugins GaudiAlgLib  GaudiKernel DD4hep::DDCore EDM4HEP::edm4hep  k4FWCore::k4Interface FCCDetectors::DetSegmentation DD4hep::DDG4 ROOT::Core ROOT::Hist)
+                 LINK k4FWCore::k4FWCore
+                      k4FWCore::k4Interface
+                      Gaudi::GaudiAlgLib
+                      Gaudi::GaudiKernel
+                      DD4hep::DDCore
+                      EDM4HEP::edm4hep
+                      FCCDetectors::DetSegmentation
+                      DD4hep::DDG4
+                      ROOT::Core
+                      ROOT::Hist
+                      )
 
 install(TARGETS k4RecFCCeeCalorimeterPlugins
   EXPORT k4RecCalorimeterTargets

--- a/RecFCChhCalorimeter/CMakeLists.txt
+++ b/RecFCChhCalorimeter/CMakeLists.txt
@@ -5,7 +5,18 @@
 file(GLOB _module_sources src/components/*.cpp)
 gaudi_add_module(k4RecFCChhCalorimeterPlugins
                  SOURCES ${_module_sources}
-                 LINK k4FWCore::k4FWCorePlugins GaudiAlgLib  GaudiKernel DD4hep::DDCore EDM4HEP::edm4hep  k4FWCore::k4Interface FCCDetectors::DetSegmentation FCCDetectors::DetCommon DD4hep::DDG4 ROOT::Core ROOT::Hist)
+                 LINK k4FWCore::k4FWCore
+                      k4FWCore::k4Interface
+                      Gaudi::GaudiAlgLib
+                      Gaudi::GaudiKernel
+                      DD4hep::DDCore
+                      EDM4HEP::edm4hep
+                      FCCDetectors::DetSegmentation
+                      FCCDetectors::DetCommon
+                      DD4hep::DDG4
+                      ROOT::Core
+                      ROOT::Hist
+                      )
 
 install(TARGETS k4RecFCChhCalorimeterPlugins
   EXPORT k4RecCalorimeterTargets


### PR DESCRIPTION
Gaudi targets have a Gaudi:: namespace since v35, and k4FWCorePlugins does not need to be linked.