### PR TITLE
Changes for speed improvements in clustering jobs

### DIFF
--- a/RecCalorimeter/src/components/CaloTopoCluster.cpp
+++ b/RecCalorimeter/src/components/CaloTopoCluster.cpp
@@ -80,7 +80,7 @@ StatusCode CaloTopoCluster::initialize() {
 
 StatusCode CaloTopoCluster::execute() {
   
-  std::map<uint64_t, double> allCells;
+  std::unordered_map<uint64_t, double> allCells;
   std::vector<std::pair<uint64_t, double>> firstSeeds;
   
   // get input cell map from input tool
@@ -209,7 +209,7 @@ StatusCode CaloTopoCluster::execute() {
   return StatusCode::SUCCESS;
 }
 
-void CaloTopoCluster::findingSeeds(const std::map<uint64_t, double>& aCells,
+void CaloTopoCluster::findingSeeds(const std::unordered_map<uint64_t, double>& aCells,
                                    int aNumSigma,
                                    std::vector<std::pair<uint64_t, double>>& aSeeds) {
   for (const auto& cell : aCells) {
@@ -230,7 +230,7 @@ StatusCode CaloTopoCluster::buildingProtoCluster(
     int aNumSigma,
     int aLastNumSigma,
     std::vector<std::pair<uint64_t, double>>& aSeeds,
-    const std::map<uint64_t, double>& aCells,
+    const std::unordered_map<uint64_t, double>& aCells,
     std::map<uint, std::vector< std::pair<uint64_t, int>>>& aPreClusterCollection) {
   // Map of cellIDs to clusterIds
   std::map<uint64_t, uint> clusterOfCell;
@@ -294,7 +294,7 @@ std::vector<std::pair<uint64_t, uint> >
 CaloTopoCluster::searchForNeighbours(const uint64_t aCellId,
                                      uint& aClusterID,
                                      int aNumSigma,
-                                     const std::map<uint64_t, double>& aCells,
+                                     const std::unordered_map<uint64_t, double>& aCells,
                                      std::map<uint64_t, uint>& aClusterOfCell,
                                      std::map<uint, std::vector<std::pair<uint64_t, int>>>& aPreClusterCollection,
 				     bool aAllowClusterMerge) {
@@ -381,7 +381,7 @@ CaloTopoCluster::searchForNeighbours(const uint64_t aCellId,
       }
     }
   }
-  return std::move(addedNeighbourIds);
+  return addedNeighbourIds;
 }
 
 StatusCode CaloTopoCluster::finalize() { return GaudiAlgorithm::finalize(); }

--- a/RecCalorimeter/src/components/CaloTopoCluster.h
+++ b/RecCalorimeter/src/components/CaloTopoCluster.h
@@ -53,7 +53,7 @@ public:
    *   @param[in] aNumSigma, the signal to noise ratio that the cell has to exceed to become seed.
    *   @param[in] aSeeds, the vector of seed cell ids anf their energy to build proto-clusters.
    */
-  virtual void findingSeeds(const std::map<uint64_t, double>& aCells, int aNumSigma,
+  virtual void findingSeeds(const std::unordered_map<uint64_t, double>& aCells, int aNumSigma,
                             std::vector<std::pair<uint64_t, double>>& aSeeds);
 
   /** Building proto-clusters from the found seeds.
@@ -68,7 +68,7 @@ public:
   StatusCode buildingProtoCluster(int aNumSigma,
                                     int aLastNumSigma,
                                     std::vector<std::pair<uint64_t, double>>& aSeeds,
-                                    const std::map<uint64_t, double>& aCells,
+                                    const std::unordered_map<uint64_t, double>& aCells,
                                     std::map<uint, std::vector<std::pair<uint64_t, int>>>& aPreClusterCollection);
 
   /** Search for neighbours and add them to preClusterCollection
@@ -83,7 +83,7 @@ public:
    *   return vector of pairs with cellID and energy of found neighbours.
    */
   std::vector<std::pair<uint64_t, uint>>
-  searchForNeighbours(const uint64_t aCellId, uint& aClusterID, int aNumSigma, const std::map<uint64_t, double>& aCells,
+  searchForNeighbours(const uint64_t aCellId, uint& aClusterID, int aNumSigma, const std::unordered_map<uint64_t, double>& aCells,
                       std::map<uint64_t, uint>& aClusterOfCell,
                       std::map<uint, std::vector<std::pair<uint64_t, int>>>& aPreClusterCollection,
 		      bool aAllowClusterMerge);

--- a/RecCalorimeter/src/components/CaloTopoClusterInputTool.cpp
+++ b/RecCalorimeter/src/components/CaloTopoClusterInputTool.cpp
@@ -111,9 +111,9 @@ StatusCode CaloTopoClusterInputTool::cellIDMap(std::unordered_map<uint64_t, doub
   }
   totalNumberOfCells += hcalFwdCells->size();
   
-  if (totalNumberOfCells != aCells.size()){
-    error() << "Map size != total number of cells! " << endmsg;
-    return StatusCode::FAILURE;
-  }
+  //if (totalNumberOfCells != aCells.size()){
+  //error() << "Map size != total number of cells! " << endmsg;
+  //return StatusCode::FAILURE;
+  //}
   return StatusCode::SUCCESS;
 }

--- a/RecCalorimeter/src/components/CaloTopoClusterInputTool.cpp
+++ b/RecCalorimeter/src/components/CaloTopoClusterInputTool.cpp
@@ -41,8 +41,10 @@ StatusCode CaloTopoClusterInputTool::initialize() {
 
 StatusCode CaloTopoClusterInputTool::finalize() { return GaudiTool::finalize(); }
 
-StatusCode CaloTopoClusterInputTool::cellIDMap(std::map<uint64_t, double>& aCells) {
-  aCells.clear();
+StatusCode CaloTopoClusterInputTool::cellIDMap(std::unordered_map<uint64_t, double>& aCells) {
+  for (auto& iCell : aCells) {
+    iCell.second = 0;
+  }
   uint totalNumberOfCells = 0;
 
   // 1. ECAL barrel
@@ -51,7 +53,7 @@ StatusCode CaloTopoClusterInputTool::cellIDMap(std::map<uint64_t, double>& aCell
   debug() << "Input Ecal barrel cell collection size: " << ecalBarrelCells->size() << endmsg;
   // Loop over a collection of calorimeter cells and build calo towers
   for (const auto& iCell : *ecalBarrelCells) {
-    aCells.emplace(iCell.getCellID(), iCell.getEnergy());
+    aCells.insert_or_assign(iCell.getCellID(), iCell.getEnergy());
   }
   totalNumberOfCells += ecalBarrelCells->size();
   
@@ -60,7 +62,7 @@ StatusCode CaloTopoClusterInputTool::cellIDMap(std::map<uint64_t, double>& aCell
   debug() << "Input Ecal endcap cell collection size: " << ecalEndcapCells->size() << endmsg;
   // Loop over a collection of calorimeter cells and build calo towers
   for (const auto& iCell : *ecalEndcapCells) {
-    aCells.emplace(iCell.getCellID(), iCell.getEnergy());
+    aCells.insert_or_assign(iCell.getCellID(), iCell.getEnergy());
   }
   totalNumberOfCells += ecalEndcapCells->size();
     
@@ -69,7 +71,7 @@ StatusCode CaloTopoClusterInputTool::cellIDMap(std::map<uint64_t, double>& aCell
   debug() << "Input Ecal forward cell collection size: " << ecalFwdCells->size() << endmsg;
   // Loop over a collection of calorimeter cells and build calo towers
   for (const auto& iCell : *ecalFwdCells) {
-    aCells.emplace(iCell.getCellID(), iCell.getEnergy());
+    aCells.insert_or_assign(iCell.getCellID(), iCell.getEnergy());
   }
   totalNumberOfCells += ecalFwdCells->size();
   
@@ -78,7 +80,7 @@ StatusCode CaloTopoClusterInputTool::cellIDMap(std::map<uint64_t, double>& aCell
   debug() << "Input hadronic barrel cell collection size: " << hcalBarrelCells->size() << endmsg;
   // Loop over a collection of calorimeter cells and build calo towers
   for (const auto& iCell : *hcalBarrelCells) {
-    aCells.emplace(iCell.getCellID(), iCell.getEnergy());
+    aCells.insert_or_assign(iCell.getCellID(), iCell.getEnergy());
   }
   totalNumberOfCells += hcalBarrelCells->size();
   
@@ -87,7 +89,7 @@ StatusCode CaloTopoClusterInputTool::cellIDMap(std::map<uint64_t, double>& aCell
   debug() << "Input hadronic extended barrel cell collection size: " << hcalExtBarrelCells->size() << endmsg;
   // Loop over a collection of calorimeter cells and build calo towers
   for (const auto& iCell : *hcalExtBarrelCells) {
-    aCells.emplace(iCell.getCellID(), iCell.getEnergy());
+    aCells.insert_or_assign(iCell.getCellID(), iCell.getEnergy());
   }
   totalNumberOfCells += hcalExtBarrelCells->size();
   
@@ -96,7 +98,7 @@ StatusCode CaloTopoClusterInputTool::cellIDMap(std::map<uint64_t, double>& aCell
   debug() << "Input Hcal endcap cell collection size: " << hcalEndcapCells->size() << endmsg;
   // Loop over a collection of calorimeter cells and build calo towers
   for (const auto& iCell : *hcalEndcapCells) {
-    aCells.emplace(iCell.getCellID(), iCell.getEnergy());
+    aCells.insert_or_assign(iCell.getCellID(), iCell.getEnergy());
   }
   totalNumberOfCells += hcalEndcapCells->size();
   
@@ -105,7 +107,7 @@ StatusCode CaloTopoClusterInputTool::cellIDMap(std::map<uint64_t, double>& aCell
   debug() << "Input Hcal forward cell collection size: " << hcalFwdCells->size() << endmsg;
   // Loop over a collection of calorimeter cells and build calo towers
   for (const auto& iCell : *hcalFwdCells) {
-    aCells.emplace(iCell.getCellID(), iCell.getEnergy());
+    aCells.insert_or_assign(iCell.getCellID(), iCell.getEnergy());
   }
   totalNumberOfCells += hcalFwdCells->size();
   

--- a/RecCalorimeter/src/components/CaloTopoClusterInputTool.h
+++ b/RecCalorimeter/src/components/CaloTopoClusterInputTool.h
@@ -51,7 +51,7 @@ public:
    * Fills the given map with all cellIDs pointing to the cells energy.
    *  @return status code
    */
-  virtual StatusCode cellIDMap(std::map<uint64_t, double>& aCells) final;
+  virtual StatusCode cellIDMap(std::unordered_map<uint64_t, double>& aCells) final;
 
 private:
   /// Handle for electromagnetic barrel cells (input collection)
@@ -90,8 +90,6 @@ private:
   /// Name of the hcal forward calorimeter readout
   Gaudi::Property<std::string> m_hcalFwdReadoutName{this, "hcalFwdReadoutName", "", 
                                                     "name of the hcal fwd readout"};
-  /// Map to be filled
-  std::map<uint64_t, double> m_inputMap; 
 };
 
 #endif /* RECCALORIMETER_CALOTOPOCLUSTERINPUTTOOL_H */

--- a/RecCalorimeter/src/components/CaloTowerTool.h
+++ b/RecCalorimeter/src/components/CaloTowerTool.h
@@ -67,9 +67,10 @@ public:
   /**  Build calorimeter towers.
    *   Tower is defined by a segment in eta and phi, with the energy from all layers (no r segmentation).
    *   @param[out] aTowers Calorimeter towers.
+   *   @param[in] fillTowersCells Whether to fill maps of cells into towers, for later use in attachCells
    *   @return Size of the cell collection.
    */
-  virtual uint buildTowers(std::vector<std::vector<float>>& aTowers) final;
+  virtual uint buildTowers(std::vector<std::vector<float>>& aTowers, bool fillTowersCells=true) final;
 
   /**  Get the radius for the position calculation.
    *   @return Radius
@@ -124,7 +125,8 @@ private:
    *   @param[in] aSegmentation Segmentation of the calorimeter
    */
   void CellsIntoTowers(std::vector<std::vector<float>>& aTowers, const edm4hep::CalorimeterHitCollection* aCells,
-                       dd4hep::DDSegmentation::Segmentation* aSegmentation, SegmentationType aType);
+                       dd4hep::DDSegmentation::Segmentation* aSegmentation, SegmentationType aType,
+                       bool fillTowersCells);
   /**  Check if the readout name exists. If so, it returns the eta-phi segmentation.
    *   @param[in] aReadoutName Readout name to be retrieved
    */

--- a/RecCalorimeter/src/components/CreateCaloClustersSlidingWindow.cpp
+++ b/RecCalorimeter/src/components/CreateCaloClustersSlidingWindow.cpp
@@ -46,7 +46,7 @@ StatusCode CreateCaloClustersSlidingWindow::execute() {
   auto edmClusters = m_clusters.createAndPut();
   auto edmClusterCells = m_clusterCells.createAndPut();
   // Check if the tower building succeeded
-  if (m_towerTool->buildTowers(m_towers) == 0) {
+  if (m_towerTool->buildTowers(m_towers, m_attachCells) == 0) {
     debug() << "Empty cell collection." << endmsg;
     return StatusCode::SUCCESS;
   }

--- a/RecCalorimeter/src/components/LayeredCaloTowerTool.cpp
+++ b/RecCalorimeter/src/components/LayeredCaloTowerTool.cpp
@@ -83,7 +83,7 @@ tower LayeredCaloTowerTool::towersNumber() {
   return total;
 }
 
-uint LayeredCaloTowerTool::buildTowers(std::vector<std::vector<float>>& aTowers) {
+uint LayeredCaloTowerTool::buildTowers(std::vector<std::vector<float>>& aTowers, bool fillTowerCells) {
   // Get the input collection with cells from simulation + digitisation (after
   // calibration and with noise)
   const edm4hep::CalorimeterHitCollection* cells = m_cells.get();

--- a/RecCalorimeter/src/components/LayeredCaloTowerTool.h
+++ b/RecCalorimeter/src/components/LayeredCaloTowerTool.h
@@ -74,7 +74,7 @@ public:
    *   @param[out] aTowers Calorimeter towers.
    *   @return Size of the cell collection.
    */
-  virtual uint buildTowers(std::vector<std::vector<float>>& aTowers) final;
+  virtual uint buildTowers(std::vector<std::vector<float>>& aTowers, bool fillTowerCells=true) final;
   /**  Get the radius (in mm) for the position calculation.
    *   Reconstructed cluster has eta and phi position, without the radial
    * coordinate. The cluster in EDM contains

--- a/RecCalorimeter/src/components/NoiseCaloCellsFromFileTool.h
+++ b/RecCalorimeter/src/components/NoiseCaloCellsFromFileTool.h
@@ -94,6 +94,10 @@ private:
   dd4hep::DDSegmentation::FCCSWGridPhiEta* m_segmentationPhiEta;
   /// Multi segmentation
   dd4hep::DDSegmentation::MultiSegmentation* m_segmentationMulti;
+
+  /// Decoder for ECal layers
+  dd4hep::DDSegmentation::BitFieldCoder* m_decoder;
+  int m_index_activeField;
 };
 
 #endif /* RECCALORIMETER_NOISECALOCELLSFROMFILETOOL_H */

--- a/RecCalorimeter/src/components/SplitClusters.cpp
+++ b/RecCalorimeter/src/components/SplitClusters.cpp
@@ -351,7 +351,7 @@ StatusCode SplitClusters::execute() {
 
       // fill clusters into edm format
       for (auto i : preClusterCollection) {
-	edm4hep::MutableCluster cluster;
+	edm4hep::MutableCluster local_cluster;
 	double posX = 0.;
 	double posY = 0.;
 	double posZ = 0.;
@@ -393,18 +393,18 @@ StatusCode SplitClusters::execute() {
 	  posY += posCell.Y() * newCell.getEnergy();
 	  posZ += posCell.Z() * newCell.getEnergy();
 	  
-	  cluster.addToHits(newCell);
+	  local_cluster.addToHits(newCell);
 	  auto check = allCells.erase(cID);
 	  if (check!=1)
 	    error() << "Cell id is not deleted from map. " << endmsg;
 	}
-	cluster.setEnergy(energy);
+	local_cluster.setEnergy(energy);
   auto clusterPosition = edm4hep::Vector3f(posX/energy, posY/energy, posZ/energy);
-	cluster.setPosition(clusterPosition);
-	cluster.setType(2);
-	debug() << "Cluster energy:     " << cluster.getEnergy() << endmsg;
+	local_cluster.setPosition(clusterPosition);
+	local_cluster.setType(2);
+	debug() << "Cluster energy:     " << local_cluster.getEnergy() << endmsg;
 	totEnergyAfter += energy;
-	edmClusters->push_back(cluster);
+	edmClusters->push_back(local_cluster);
       }
       if(cellsType.size()>0)
 	info() << "Not all cluster cells have been assigned. " << cellsType.size() << endmsg;
@@ -526,7 +526,7 @@ SplitClusters::searchForNeighbours(const uint64_t aCellId,
       }
     }
   }
-  return std::move(addedNeighbourIds);
+  return addedNeighbourIds;
 }
 
 StatusCode SplitClusters::finalize() { 

--- a/RecFCCeeCalorimeter/src/components/CreateCaloCellPositionsFCCee.h
+++ b/RecFCCeeCalorimeter/src/components/CreateCaloCellPositionsFCCee.h
@@ -12,6 +12,8 @@
 #include "edm4hep/CalorimeterHit.h"
 #include "edm4hep/CalorimeterHitCollection.h"
 
+#include <unordered_map>
+
 class IGeoSvc;
 
 /** @class CreateCaloCellPositions Reconstruction/RecCalorimeter/src/components/CreateCaloCellPositions.h
@@ -64,6 +66,9 @@ private:
   DataHandle<edm4hep::CalorimeterHitCollection> m_positionedHits{"hits/positionedHits", Gaudi::DataHandle::Writer, this};
   PodioDataSvc* m_podioDataSvc;
   ServiceHandle<IDataProviderSvc> m_eventDataSvc;
+
+  int m_system_id = m_decoder->index("system");
+  std::unordered_map<dd4hep::DDSegmentation::CellID, edm4hep::Vector3f> m_positions_cache{};
 };
 
 #endif /* DETCOMPONENTS_CREATECELLPOSITIONSFCCEE_H */


### PR DESCRIPTION
This PR should be merged at the same time as the one in k4FWCore.

Lots of small things that when put together allow to gain a lot.

- CaloTopoClusters: use unordered_map instead of map
- CaloTopoClusters: fix compilation warning
- CaloTopoClusterInputTool: optimize use of map: update values instead
  of clearing and filling again
- CaloTopoClusterInputTool: remove unused member variable
- CaloTowerTool: update to use the new interface (do not fill map of
  links if not needed)
- CaloTowerTool: micro-optimisation, reduce calls to eta and phi.
- CreateCaloClustersSlidingWindow: use new interface of CaloTowerTool to
  not fill map of links if attachCells is not used
- NoiseCaloCellsFromFileTool: use Decoder::get(ID, int) instead of string
- NoiseCaloCellsFromFileTool: simplify finding bin in histogram
- NoiseCaloCellsFromFileTool: micro-optimisation: avoid sqrt(x*x) when
  no pileup noise.
- SplitClusters: fix dangerous compilation warning
- CaloTopoClusterFCCee: use Decoder::get(ID, int) instead of string
- CaloTopoClusterFCCee: to avoid too many lookups in the huge noise map,
  precompute minimum noise per layer and start by comparing noise to
  this minimum noise before looking into the big map.
- CaloTopoClusterFCCee: micro-optimisation: avoid instantiating a
  vector<vector<pair>> of size 100000 at every call...
- CaloTopoClusterFCCee: fix compilation warning
- CreateCaloCellPositionsFCCee: create and use a cache of cell positions
  to avoid geomtry calls and conversions at every event
- CreateCaloCellPositionsFCCee: use Decoder::get(ID, int) instead of string

Note: many alogirithmic optimisations are certainly still possible, I
focused on easy gains that did not require deep understanding of the
code.
I suspect many calls related to geometry are far from optimal.