### PR TITLE
Use new MetaDataHandles to be compliant with Frame based I/O

### DIFF
--- a/RecCalorimeter/src/components/CreateCaloCells.cpp
+++ b/RecCalorimeter/src/components/CreateCaloCells.cpp
@@ -15,7 +15,7 @@
 DECLARE_COMPONENT(CreateCaloCells)
 
 CreateCaloCells::CreateCaloCells(const std::string& name, ISvcLocator* svcLoc) :
-GaudiAlgorithm(name, svcLoc), m_geoSvc("GeoSvc", name), m_eventDataSvc("EventDataSvc", "CreateCaloCells") {
+GaudiAlgorithm(name, svcLoc), m_geoSvc("GeoSvc", name) {
   declareProperty("hits", m_hits, "Hits from which to create cells (input)");
   declareProperty("cells", m_cells, "The created calorimeter cells (output)");
 
@@ -63,12 +63,9 @@ StatusCode CreateCaloCells::initialize() {
   if (m_addPosition){
     m_volman = m_geoSvc->lcdd()->volumeManager();
   }
-  StatusCode sc_dataSvc = m_eventDataSvc.retrieve();
-  m_podioDataSvc = dynamic_cast<PodioDataSvc*>(m_eventDataSvc.get());
-  if (sc_dataSvc == StatusCode::FAILURE) {
-    error() << "Error retrieving Event Data Service" << endmsg;
-    return StatusCode::FAILURE;
-  }
+
+  // Copy over the CellIDEncoding string from the input collection to the output collection
+  m_cellsCellIDEncoding.put(m_hitsCellIDEncoding.get());
 
   return StatusCode::SUCCESS;
 }
@@ -131,9 +128,6 @@ StatusCode CreateCaloCells::execute() {
 
   // push the CaloHitCollection to event store
   m_cells.put(edmCellsCollection);
-  // Ship the metadata to the new collection
-  auto& coll_md = m_podioDataSvc->getProvider().getCollectionMetaData(m_cells.get()->getID());
-  coll_md.setValue("CellIDEncodingString", m_hits.getCollMetadataCellID(hits->getID()));
 
   debug() << "Output Cell collection size: " << edmCellsCollection->size() << endmsg;
 

--- a/RecCalorimeter/src/components/CreateCaloCells.h
+++ b/RecCalorimeter/src/components/CreateCaloCells.h
@@ -3,6 +3,7 @@
 
 // FCCSW
 #include "k4FWCore/DataHandle.h"
+#include "k4FWCore/MetaDataHandle.h"
 #include "k4Interface/ICalibrateCaloHitsTool.h"
 #include "k4Interface/ICalorimeterTool.h"
 #include "k4Interface/INoiseCaloCellsTool.h"
@@ -75,8 +76,11 @@ private:
 
   /// Handle for calo hits (input collection)
   DataHandle<edm4hep::SimCalorimeterHitCollection> m_hits{"hits", Gaudi::DataHandle::Reader, this};
+  /// Handle for the cellID encoding string of the input collection
+  MetaDataHandle<std::string> m_hitsCellIDEncoding{m_hits, "CellIDEncodingString", Gaudi::DataHandle::Reader, this};
   /// Handle for calo cells (output collection)
   DataHandle<edm4hep::CalorimeterHitCollection> m_cells{"cells", Gaudi::DataHandle::Writer, this};
+  MetaDataHandle<std::string> m_cellsCellIDEncoding{m_cells, "CellIDEncodingString", Gaudi::DataHandle::Writer, this};
   /// Name of the detector readout
   Gaudi::Property<std::string> m_readoutName{this, "readoutName", "ECalBarrelPhiEta", "Name of the detector readout"};
   /// Name of active volumes
@@ -105,8 +109,6 @@ private:
   /// Use only volume ID? If false, using PhiEtaSegmentation
   bool m_useVolumeIdOnly;
 
-  PodioDataSvc* m_podioDataSvc;
-  ServiceHandle<IDataProviderSvc> m_eventDataSvc;
   /// Pointer to the geometry service
   ServiceHandle<IGeoSvc> m_geoSvc;
   dd4hep::VolumeManager m_volman;

--- a/RecCalorimeter/src/components/CreateCaloCells.h
+++ b/RecCalorimeter/src/components/CreateCaloCells.h
@@ -77,10 +77,10 @@ private:
   /// Handle for calo hits (input collection)
   DataHandle<edm4hep::SimCalorimeterHitCollection> m_hits{"hits", Gaudi::DataHandle::Reader, this};
   /// Handle for the cellID encoding string of the input collection
-  MetaDataHandle<std::string> m_hitsCellIDEncoding{m_hits, "CellIDEncodingString", Gaudi::DataHandle::Reader, this};
+  MetaDataHandle<std::string> m_hitsCellIDEncoding{m_hits, "CellIDEncodingString", Gaudi::DataHandle::Reader};
   /// Handle for calo cells (output collection)
   DataHandle<edm4hep::CalorimeterHitCollection> m_cells{"cells", Gaudi::DataHandle::Writer, this};
-  MetaDataHandle<std::string> m_cellsCellIDEncoding{m_cells, "CellIDEncodingString", Gaudi::DataHandle::Writer, this};
+  MetaDataHandle<std::string> m_cellsCellIDEncoding{m_cells, "CellIDEncodingString", Gaudi::DataHandle::Writer};
   /// Name of the detector readout
   Gaudi::Property<std::string> m_readoutName{this, "readoutName", "ECalBarrelPhiEta", "Name of the detector readout"};
   /// Name of active volumes

--- a/RecFCCeeCalorimeter/src/components/CreateCaloCellPositionsFCCee.h
+++ b/RecFCCeeCalorimeter/src/components/CreateCaloCellPositionsFCCee.h
@@ -3,6 +3,7 @@
 
 // FCCSW
 #include "k4FWCore/DataHandle.h"
+#include "k4FWCore/MetaDataHandle.h"
 #include "k4Interface/ICellPositionsTool.h"
 
 // Gaudi
@@ -91,10 +92,10 @@ private:
   dd4hep::DDSegmentation::BitFieldCoder* m_decoder = new dd4hep::DDSegmentation::BitFieldCoder("system:4");
   /// Input collection
   DataHandle<edm4hep::CalorimeterHitCollection> m_hits{"hits/hits", Gaudi::DataHandle::Reader, this};
+  MetaDataHandle<std::string> m_hitsCellIDEncoding{m_hits, "CellIDEncodingString", Gaudi::DataHandle::Reader, this};
   /// Output collection
   DataHandle<edm4hep::CalorimeterHitCollection> m_positionedHits{"hits/positionedHits", Gaudi::DataHandle::Writer, this};
-  PodioDataSvc* m_podioDataSvc;
-  ServiceHandle<IDataProviderSvc> m_eventDataSvc;
+  MetaDataHandle<std::string> m_positionedHitsCellIDEncoding{m_positionedHits, "CellIDEncodingString", Gaudi::DataHandle::Reader, this};
 
   int m_system_id = m_decoder->index("system");
   std::unordered_map<dd4hep::DDSegmentation::CellID, edm4hep::Vector3f> m_positions_cache{};

--- a/RecFCCeeCalorimeter/src/components/CreateCaloCellPositionsFCCee.h
+++ b/RecFCCeeCalorimeter/src/components/CreateCaloCellPositionsFCCee.h
@@ -92,10 +92,10 @@ private:
   dd4hep::DDSegmentation::BitFieldCoder* m_decoder = new dd4hep::DDSegmentation::BitFieldCoder("system:4");
   /// Input collection
   DataHandle<edm4hep::CalorimeterHitCollection> m_hits{"hits/hits", Gaudi::DataHandle::Reader, this};
-  MetaDataHandle<std::string> m_hitsCellIDEncoding{m_hits, "CellIDEncodingString", Gaudi::DataHandle::Reader, this};
+  MetaDataHandle<std::string> m_hitsCellIDEncoding{m_hits, "CellIDEncodingString", Gaudi::DataHandle::Reader};
   /// Output collection
   DataHandle<edm4hep::CalorimeterHitCollection> m_positionedHits{"hits/positionedHits", Gaudi::DataHandle::Writer, this};
-  MetaDataHandle<std::string> m_positionedHitsCellIDEncoding{m_positionedHits, "CellIDEncodingString", Gaudi::DataHandle::Reader, this};
+  MetaDataHandle<std::string> m_positionedHitsCellIDEncoding{m_positionedHits, "CellIDEncodingString", Gaudi::DataHandle::Reader};
 
   int m_system_id = m_decoder->index("system");
   std::unordered_map<dd4hep::DDSegmentation::CellID, edm4hep::Vector3f> m_positions_cache{};


### PR DESCRIPTION
https://github.com/key4hep/k4FWCore/pull/100 makes the default DataSvc use the Frame, and some of the interfaces for accessing meta data (e.g. cellID strings) will change. This PR changes the access / writing of the cell ID encoding strings to use the new `MetaDataHandle` interface.