### PR TITLE
Combined ECAL+HCAL topoclustering

### DIFF
--- a/RecCalorimeter/src/components/ConstNoiseTool.cpp
+++ b/RecCalorimeter/src/components/ConstNoiseTool.cpp
@@ -34,12 +34,12 @@ StatusCode ConstNoiseTool::initialize() {
   m_systemNoiseConstMap.emplace(11, m_HCalFwdThreshold );
 
   m_systemNoiseOffsetMap.emplace(5, 0. );
-  m_systemNoiseOffsetMap.emplace(6, 0.  );
+  m_systemNoiseOffsetMap.emplace(6, 0. );
   m_systemNoiseOffsetMap.emplace(7, 0. );
-  m_systemNoiseOffsetMap.emplace(8, 0.  );
-  m_systemNoiseOffsetMap.emplace(9, 0.  );
-  m_systemNoiseOffsetMap.emplace(10,0.  );
-  m_systemNoiseOffsetMap.emplace(11,0.  );
+  m_systemNoiseOffsetMap.emplace(8, 0. );
+  m_systemNoiseOffsetMap.emplace(9, 0. );
+  m_systemNoiseOffsetMap.emplace(10,0. );
+  m_systemNoiseOffsetMap.emplace(11,0. );
 
   // Get GeoSvc
   m_geoSvc = service("GeoSvc");
@@ -67,10 +67,10 @@ double ConstNoiseTool::getNoiseConstantPerCell(uint64_t aCellId) {
   dd4hep::DDSegmentation::CellID cID = aCellId;
   unsigned cellSystem = m_decoder->get(cID, "system");
   // cell noise in system
-  if (m_systemNoiseConstMap[cellSystem])
+  if (m_systemNoiseConstMap.count(cellSystem))
     Noise = m_systemNoiseConstMap[cellSystem];
   else
-    warning() << "No noise constants set for this subsystem! Noise of cell set to 0. " << endmsg;
+    warning() << "No noise constant set for subsystem " << cellSystem << "! Noise constant of cell set to 0. " << endmsg;
   return Noise;
 }
 
@@ -81,9 +81,9 @@ double ConstNoiseTool::getNoiseOffsetPerCell(uint64_t aCellId) {
   dd4hep::DDSegmentation::CellID cID = aCellId;
   unsigned cellSystem = m_decoder->get(cID, "system");
   // cell noise in system
-  if (m_systemNoiseOffsetMap[cellSystem])
+  if (m_systemNoiseOffsetMap.count(cellSystem))
     Noise = m_systemNoiseOffsetMap[cellSystem];
   else
-    warning() << "No noise constants set for this subsystem! Noise of cell set to 0. " << endmsg;
+    warning() << "No noise offset set for subsystem " << cellSystem << "! Noise offset of cell set to 0. " << endmsg;
   return Noise;
 }

--- a/RecFCCeeCalorimeter/src/components/CellPositionsECalBarrelPhiThetaSegTool.cpp
+++ b/RecFCCeeCalorimeter/src/components/CellPositionsECalBarrelPhiThetaSegTool.cpp
@@ -1,0 +1,96 @@
+#include "CellPositionsECalBarrelPhiThetaSegTool.h"
+
+// EDM
+#include "edm4hep/CalorimeterHitCollection.h"
+
+DECLARE_COMPONENT(CellPositionsECalBarrelPhiThetaSegTool)
+
+CellPositionsECalBarrelPhiThetaSegTool::CellPositionsECalBarrelPhiThetaSegTool(const std::string& type, const std::string& name,
+                                                         const IInterface* parent)
+    : GaudiTool(type, name, parent) {
+  declareInterface<ICellPositionsTool>(this);
+}
+
+StatusCode CellPositionsECalBarrelPhiThetaSegTool::initialize() {
+  StatusCode sc = GaudiTool::initialize();
+  if (sc.isFailure()) return sc;
+  m_geoSvc = service("GeoSvc");
+  if (!m_geoSvc) {
+    error() << "Unable to locate Geometry service." << endmsg;
+    return StatusCode::FAILURE;
+  }
+  // get phi-theta segmentation
+  m_segmentation = dynamic_cast<dd4hep::DDSegmentation::FCCSWGridPhiTheta_k4geo*>(
+      m_geoSvc->getDetector()->readout(m_readoutName).segmentation().segmentation());
+  if (m_segmentation == nullptr) {
+    error() << "There is no phi-theta segmentation!!!!" << endmsg;
+    return StatusCode::FAILURE;
+  }
+  // Take readout bitfield decoder from GeoSvc
+  m_decoder = m_geoSvc->getDetector()->readout(m_readoutName).idSpec().decoder();
+  m_volman = m_geoSvc->getDetector()->volumeManager();
+  // check if decoder contains "layer"
+  std::vector<std::string> fields;
+  for (uint itField = 0; itField < m_decoder->size(); itField++) {
+    fields.push_back((*m_decoder)[itField].name());
+  }
+  auto iter = std::find(fields.begin(), fields.end(), "layer");
+  if (iter == fields.end()) {
+    error() << "Readout does not contain field: 'layer'" << endmsg;
+  }
+  return sc;
+}
+
+void CellPositionsECalBarrelPhiThetaSegTool::getPositions(const edm4hep::CalorimeterHitCollection& aCells,
+                                               edm4hep::CalorimeterHitCollection& outputColl) {
+
+  debug() << "Input collection size : " << aCells.size() << endmsg;
+  // Loop through cell collection
+  for (const auto& cell : aCells) {
+    auto outSeg = CellPositionsECalBarrelPhiThetaSegTool::xyzPosition(cell.getCellID());
+    auto edmPos = edm4hep::Vector3f();
+    edmPos.x = outSeg.x() / dd4hep::mm;
+    edmPos.y = outSeg.y() / dd4hep::mm;
+    edmPos.z = outSeg.z() / dd4hep::mm;
+
+    auto positionedHit = cell.clone();
+    positionedHit.setPosition(edmPos);
+    outputColl.push_back(positionedHit);
+
+    // Debug information about cell position
+    debug() << "Cell energy (GeV) : " << positionedHit.getEnergy() << "\tcellID " << positionedHit.getCellID() << endmsg;
+    debug() << "Position of cell (mm) : \t" << outSeg.x() / dd4hep::mm << "\t" << outSeg.y() / dd4hep::mm << "\t"
+            << outSeg.z() / dd4hep::mm << "\n"
+            << endmsg;
+  }
+  debug() << "Output positions collection size: " << outputColl.size() << endmsg;
+}
+
+dd4hep::Position CellPositionsECalBarrelPhiThetaSegTool::xyzPosition(const uint64_t& aCellId) const {
+  double radius;
+  dd4hep::DDSegmentation::CellID volumeId = aCellId;
+  m_decoder->set(volumeId, "phi", 0);
+  m_decoder->set(volumeId, "theta", 0);
+  auto detelement = m_volman.lookupDetElement(volumeId);
+  const auto& transformMatrix = detelement.nominal().worldTransformation();
+  double outGlobal[3];
+  double inLocal[] = {0, 0, 0};
+  transformMatrix.LocalToMaster(inLocal, outGlobal);
+  //debug() << "Position of volume (mm) : \t" << outGlobal[0] / dd4hep::mm << "\t" << outGlobal[1] / dd4hep::mm << "\t"
+  //        << outGlobal[2] / dd4hep::mm << endmsg;
+  // radius calculated from segmenation + z postion of volumes
+  auto inSeg = m_segmentation->position(aCellId);
+  radius = std::sqrt(std::pow(outGlobal[0], 2) + std::pow(outGlobal[1], 2));
+  dd4hep::Position outSeg(inSeg.x() * radius, inSeg.y() * radius, inSeg.z() * radius);
+
+  return outSeg;
+}
+
+int CellPositionsECalBarrelPhiThetaSegTool::layerId(const uint64_t& aCellId) {
+  int layer;
+  dd4hep::DDSegmentation::CellID cID = aCellId;
+  layer = m_decoder->get(cID, "layer");
+  return layer;
+}
+
+StatusCode CellPositionsECalBarrelPhiThetaSegTool::finalize() { return GaudiTool::finalize(); }

--- a/RecFCCeeCalorimeter/src/components/CellPositionsECalBarrelPhiThetaSegTool.h
+++ b/RecFCCeeCalorimeter/src/components/CellPositionsECalBarrelPhiThetaSegTool.h
@@ -1,0 +1,65 @@
+#ifndef RECCALORIMETER_CELLPOSITIONSECALBARRELPHITHETASEGTOOL_H
+#define RECCALORIMETER_CELLPOSITIONSECALBARRELPHITHETASEGTOOL_H
+
+// GAUDI
+#include "GaudiAlg/GaudiTool.h"
+#include "GaudiKernel/ServiceHandle.h"
+
+// FCCSW
+#include "detectorCommon/DetUtils_k4geo.h"
+#include "k4Interface/IGeoSvc.h"
+#include "detectorSegmentations/FCCSWGridPhiTheta_k4geo.h"
+#include "k4FWCore/DataHandle.h"
+#include "k4Interface/ICellPositionsTool.h"
+
+// DD4hep
+#include "DD4hep/Readout.h"
+#include "DD4hep/Volumes.h"
+#include "DDSegmentation/Segmentation.h"
+#include "TGeoManager.h"
+
+class IGeoSvc;
+namespace DD4hep {
+namespace DDSegmentation {
+class Segmentation;
+}
+}
+
+/** @class CellPositionsECalBarrelPhiThetaSegTool k4RecCalorimeter/RecFCCeeCalorimeter/src/components/CellPositionsECalBarrelPhiThetaSegTool.h
+ * CellPositionsECalBarrelPhiThetaSegTool.h
+ *
+ *  Tool to determine each Calorimeter cell position.
+ *
+ *   For the FCCee Barrel ECAL with phi-theta segmentation, determined from the placed volumes and the segmentation.   
+ * 
+ *  @author Giovanni Marchiori
+ */
+
+class CellPositionsECalBarrelPhiThetaSegTool : public GaudiTool, virtual public ICellPositionsTool {
+public:
+  CellPositionsECalBarrelPhiThetaSegTool(const std::string& type, const std::string& name, const IInterface* parent);
+  ~CellPositionsECalBarrelPhiThetaSegTool() = default;
+
+  virtual StatusCode initialize() final;
+
+  virtual StatusCode finalize() final;
+
+  virtual void getPositions(const edm4hep::CalorimeterHitCollection& aCells, edm4hep::CalorimeterHitCollection& outputColl) final;
+
+  virtual dd4hep::Position xyzPosition(const uint64_t& aCellId) const final;
+
+  virtual int layerId(const uint64_t& aCellId) final;
+
+private:
+  /// Pointer to the geometry service
+  SmartIF<IGeoSvc> m_geoSvc;
+  /// Name of the electromagnetic calorimeter readout
+  Gaudi::Property<std::string> m_readoutName{this, "readoutName", "ECalBarrelPhiTheta"};
+  /// Eta-phi segmentation
+  dd4hep::DDSegmentation::FCCSWGridPhiTheta_k4geo* m_segmentation;
+  /// Cellid decoder
+  dd4hep::DDSegmentation::BitFieldCoder* m_decoder;
+  /// Volume manager
+  dd4hep::VolumeManager m_volman;
+};
+#endif /* RECCALORIMETER_CELLPOSITIONSECALBARRELPHITHETASEGTOOL_H */

--- a/RecFCCeeCalorimeter/src/components/CreateFCCeeCaloNeighbours.h
+++ b/RecFCCeeCalorimeter/src/components/CreateFCCeeCaloNeighbours.h
@@ -50,23 +50,24 @@ private:
   /// Pointer to the geometry service
   SmartIF<IGeoSvc> m_geoSvc;
 
-  /// Names of the detector readout for volumes with theta-module segmentation
-  Gaudi::Property<std::vector<std::string>> m_readoutNamesSegmented{this, "readoutNames", {"ECalBarrelModuleThetaMerged"}};
+  /// Names of the detector readout for the volumes
+  Gaudi::Property<std::vector<std::string>> m_readoutNamesSegmented{this, "readoutNames", {"ECalBarrelModuleThetaMerged", "BarHCal_Readout_phitheta"}};
   /// Name of the fields describing the segmented volume
-  Gaudi::Property<std::vector<std::string>> m_fieldNamesSegmented{this, "systemNames", {"system"}};
+  Gaudi::Property<std::vector<std::string>> m_fieldNamesSegmented{this, "systemNames", {"system", "system"}};
   /// Values of the fields describing the segmented volume
-  Gaudi::Property<std::vector<int>> m_fieldValuesSegmented{this, "systemValues", {5}};
-  /// Names of the active volume in geometry along radial axis (e.g. layer), the others are "module"/"phi", "theta"
-  Gaudi::Property<std::vector<std::string>> m_activeFieldNamesSegmented{this, "activeFieldNames", {"layer"}};
-  /// Number of layers in the segmented volume
-  Gaudi::Property<std::vector<unsigned int>> m_activeVolumesNumbersSegmented{this, "activeVolumesNumbers", {12}};
-  // Radii of layers in the segmented volume
-  Gaudi::Property<std::vector<double>> m_activeVolumesTheta{this, "activeVolumesTheta"};
-  /// Whether to create the geant4 geometry or not
+  Gaudi::Property<std::vector<int>> m_fieldValuesSegmented{this, "systemValues", {4, 8}};
+  /// Names of the active volume in geometry along radial axis (e.g. layer), the others are "module" or "phi", "theta"
+  Gaudi::Property<std::vector<std::string>> m_activeFieldNamesSegmented{this, "activeFieldNames", {"layer", "layer"}};
+  /// Number of layers in the segmented volumes
+  Gaudi::Property<std::vector<unsigned int>> m_activeVolumesNumbersSegmented{this, "activeVolumesNumbers", {12, 13}};
+  // Theta ranges of layers in the segmented volumes
+  Gaudi::Property<std::vector<std::vector<double>>> m_activeVolumesTheta{this, "activeVolumesTheta"};
+  /// Whether to consider diagonal cells as neighbours or not
   Gaudi::Property<bool> m_includeDiagonalCells{this, "includeDiagonalCells", false, "If True will consider also diagonal neighbours in volumes with theta-module segmentation"};
-  
-  /// Name of output file
-  std::string m_outputFileName;
+
+  // System ID of ECAL and HCAL barrels
+  Gaudi::Property<uint> m_ecalBarrelSysId{this, "ecalBarrelSysId", 4};
+  Gaudi::Property<uint> m_hcalBarrelSysId{this, "hcalBarrelSysId", 8};
 
   // For combination of barrels: flag if ECal and HCal barrels should be merged
   Gaudi::Property<bool> m_connectBarrels{this, "connectBarrels", true};
@@ -78,6 +79,9 @@ private:
   Gaudi::Property<double> m_hCalRinner{this, "hCalRinner", 2850};
   // For combination of barrels: offset of HCal modules in phi (lower edge)
   Gaudi::Property<double> m_hCalPhiOffset{this, "hCalPhiOffset"};
+
+  /// Name of output file
+  std::string m_outputFileName;
 };
 
 #endif /* RECFCCEECALORIMETER_CREATEFCCEECALONEIGHBOURS_H */

--- a/RecFCCeeCalorimeter/src/components/CreateFCCeeCaloNoiseLevelMap.cpp
+++ b/RecFCCeeCalorimeter/src/components/CreateFCCeeCaloNoiseLevelMap.cpp
@@ -10,109 +10,230 @@
 
 DECLARE_COMPONENT(CreateFCCeeCaloNoiseLevelMap)
 
-CreateFCCeeCaloNoiseLevelMap::CreateFCCeeCaloNoiseLevelMap(const std::string& aName, ISvcLocator* aSL)
-    : base_class(aName, aSL) {
-  declareProperty("ECalBarrelNoiseTool", m_ecalBarrelNoiseTool, "Handle for the cells noise tool of Barrel ECal");
-  declareProperty("HCalBarrelNoiseTool", m_hcalBarrelNoiseTool, "Handle for the cells noise tool of Barrel HCal");
-  declareProperty( "outputFileName", m_outputFileName, "Name of the output file");
+CreateFCCeeCaloNoiseLevelMap::CreateFCCeeCaloNoiseLevelMap(const std::string &aName, ISvcLocator *aSL)
+    : base_class(aName, aSL)
+{
+  declareProperty("ECalBarrelNoiseTool", m_ecalBarrelNoiseTool, "Handle for the cell noise tool of Barrel ECal");
+  declareProperty("HCalBarrelNoiseTool", m_hcalBarrelNoiseTool, "Handle for the cell noise tool of Barrel HCal");
+  declareProperty("outputFileName", m_outputFileName, "Name of the output file");
 }
 
 CreateFCCeeCaloNoiseLevelMap::~CreateFCCeeCaloNoiseLevelMap() {}
 
-StatusCode CreateFCCeeCaloNoiseLevelMap::initialize() {
+StatusCode CreateFCCeeCaloNoiseLevelMap::initialize()
+{
   // Initialize necessary Gaudi components
-  if (Service::initialize().isFailure()) {
-    error() << "Unable to initialize Service()" << endmsg;
+  if (Service::initialize().isFailure())
+  {
     return StatusCode::FAILURE;
   }
   m_geoSvc = service("GeoSvc");
-  if (!m_geoSvc) {
+  if (!m_geoSvc)
+  {
     error() << "Unable to locate Geometry Service. "
             << "Make sure you have GeoSvc and SimSvc in the right order in the configuration." << endmsg;
     return StatusCode::FAILURE;
   }
 
-  if (!m_ecalBarrelNoiseTool.retrieve()) {
+  if (!m_ecalBarrelNoiseTool.retrieve())
+  {
     error() << "Unable to retrieve the ECAL noise tool!!!" << endmsg;
     return StatusCode::FAILURE;
   }
 
-  if (!m_hcalBarrelNoiseTool.empty()){
-    if (!m_hcalBarrelNoiseTool.retrieve()) {
+  if (!m_hcalBarrelNoiseTool.empty())
+  {
+    if (!m_hcalBarrelNoiseTool.retrieve())
+    {
       error() << "Unable to retrieve the HCAL noise tool!!!" << endmsg;
       return StatusCode::FAILURE;
     }
   }
-  
-  std::unordered_map<uint64_t, std::pair<double,double>> map;
 
-  for (uint iSys = 0; iSys < m_readoutNamesSegmented.size(); iSys++) {
+  std::unordered_map<uint64_t, std::pair<double, double>> map;
+
+  for (uint iSys = 0; iSys < m_readoutNamesSegmented.size(); iSys++)
+  {
     // Check if readouts exist
     info() << "Readout: " << m_readoutNamesSegmented[iSys] << endmsg;
-    if (m_geoSvc->getDetector()->readouts().find(m_readoutNamesSegmented[iSys]) == m_geoSvc->getDetector()->readouts().end()) {
+    if (m_geoSvc->getDetector()->readouts().find(m_readoutNamesSegmented[iSys]) == m_geoSvc->getDetector()->readouts().end())
+    {
       error() << "Readout <<" << m_readoutNamesSegmented[iSys] << ">> does not exist." << endmsg;
       return StatusCode::FAILURE;
     }
+
     // get segmentation
-    dd4hep::DDSegmentation::FCCSWGridModuleThetaMerged_k4geo* segmentation;
-    segmentation = dynamic_cast<dd4hep::DDSegmentation::FCCSWGridModuleThetaMerged_k4geo*>(
-        m_geoSvc->getDetector()->readout(m_readoutNamesSegmented[iSys]).segmentation().segmentation());
-    if (segmentation == nullptr) {
-      error() << "There is no Module-theta segmentation!!!!" << endmsg;
+    dd4hep::DDSegmentation::Segmentation *aSegmentation = m_geoSvc->getDetector()->readout(m_readoutNamesSegmented[iSys]).segmentation().segmentation();
+    std::string segmentationType = aSegmentation->type();
+    info() << "Segmentation type : " << segmentationType << endmsg;
+    
+    dd4hep::DDSegmentation::GridTheta_k4geo *segmentation = nullptr;
+    dd4hep::DDSegmentation::FCCSWGridPhiTheta_k4geo *phiThetaSegmentation = nullptr;
+    dd4hep::DDSegmentation::FCCSWGridModuleThetaMerged_k4geo *moduleThetaSegmentation = nullptr;
+    if (segmentationType == "FCCSWGridModuleThetaMerged_k4geo")
+    {
+      segmentation = dynamic_cast<dd4hep::DDSegmentation::GridTheta_k4geo *>(aSegmentation);
+      moduleThetaSegmentation = dynamic_cast<dd4hep::DDSegmentation::FCCSWGridModuleThetaMerged_k4geo *>(aSegmentation);
+    }
+    else if (segmentationType == "FCCSWGridPhiTheta_k4geo")
+    {
+      segmentation = dynamic_cast<dd4hep::DDSegmentation::GridTheta_k4geo *>(aSegmentation);
+      phiThetaSegmentation = dynamic_cast<dd4hep::DDSegmentation::FCCSWGridPhiTheta_k4geo *>(aSegmentation);
+    }
+    else
+    {
+      error() << "Segmentation type not handled." << endmsg;
+      return StatusCode::FAILURE;
+    }
+    
+    if (segmentation == nullptr || (phiThetaSegmentation == nullptr && moduleThetaSegmentation == nullptr))
+    {
+      error() << "Unable to cast segmentation pointer!!!!" << endmsg;
       return StatusCode::FAILURE;
     }
 
-    info() << "FCCSWGridModuleThetaMerged: size in Theta " << segmentation->gridSizeTheta() << " , bins in Module " << segmentation->nModules()
-           << endmsg;
-    info() << "FCCSWGridModuleThetaMerged: offset in Theta " << segmentation->offsetTheta() << endmsg;
+    info() << "Segmentation: size in Theta " << segmentation->gridSizeTheta() << endmsg;
+    info() << "Segmentation: offset in Theta " << segmentation->offsetTheta() << endmsg;
+    if (segmentationType == "FCCSWGridModuleThetaMerged_k4geo")
+    {
+      info() << "Segmentation: bins in Module " << moduleThetaSegmentation->nModules() << endmsg;
+    }
+    else if (segmentationType == "FCCSWGridPhiTheta_k4geo")
+    {
+      info() << "Segmentation: size in Phi " << phiThetaSegmentation->gridSizePhi() << endmsg;
+      info() << "Segmentation: offset in Phi " << phiThetaSegmentation->offsetPhi() << endmsg;
+    }
 
-    auto decoder = m_geoSvc->getDetector()->readout(m_readoutNamesSegmented[iSys]).idSpec().decoder();
     // Loop over all cells in the calorimeter and retrieve existing cellIDs
     // Loop over active layers
+    auto decoder = m_geoSvc->getDetector()->readout(m_readoutNamesSegmented[iSys]).idSpec().decoder();
     std::vector<std::pair<int, int>> extrema;
+    // extrema[0]: (0, nLayers-1)
     extrema.push_back(std::make_pair(0, m_activeVolumesNumbersSegmented[iSys] - 1));
+    // extrema[1] and extrema[2] will contain theta and phi/module ranges, will be set later
+    // as they (theta) depend on layer
     extrema.push_back(std::make_pair(0, 0));
     extrema.push_back(std::make_pair(0, 0));
-    for (unsigned int ilayer = 0; ilayer < m_activeVolumesNumbersSegmented[iSys]; ilayer++) {
-      dd4hep::DDSegmentation::CellID volumeId = 0;
-      // Get VolumeID
-      (*decoder)[m_fieldNamesSegmented[iSys]].set(volumeId, m_fieldValuesSegmented[iSys]);
-      (*decoder)[m_activeFieldNamesSegmented[iSys]].set(volumeId, ilayer);
-      (*decoder)["theta"].set(volumeId, 0);
-      (*decoder)["module"].set(volumeId, 0);
-      // Get number of segmentation cells within the active volume, for given layer      
-      auto numCells = det::utils::numberOfCells(volumeId, *segmentation);
-      // Range of module ID
-      extrema[1] = std::make_pair(0, (numCells[0] - 1)*segmentation->mergedModules(ilayer));
-      // Range and min of theta ID
-      // for HCAL use alternative calculation
-      if (m_fieldNamesSegmented[iSys] == "system" &&
-	  m_fieldValuesSegmented[iSys] == m_hcalBarrelSysId){
-	uint cellsTheta = ceil(( 2*m_activeVolumesTheta[ilayer] - segmentation->gridSizeTheta() ) / 2 / segmentation->gridSizeTheta()) * 2 + 1; //ceil( 2*m_activeVolumesRadii[ilayer] / segmentation->gridSizeTheta());
-	uint minThetaID = int(floor(( - m_activeVolumesTheta[ilayer] + 0.5 * segmentation->gridSizeTheta() - segmentation->offsetTheta()) / segmentation->gridSizeTheta()));
-	numCells[1]=cellsTheta;
-	numCells[2]=minThetaID;
+    for (unsigned int ilayer = 0; ilayer < m_activeVolumesNumbersSegmented[iSys]; ilayer++)
+    {
+      if (segmentationType == "FCCSWGridPhiTheta_k4geo")
+      {
+        // for ECAL, G4 volumes extend along the full z so
+        // they can be used - once obtained from the cellID - to
+        // determine the full theta range of the layer.
+        // For HCal the G4 volume containing the cell spans only
+        // a subrange of the full z range of the HCal layer - one
+        // would need to find the HCalLayerVol volume to determine
+        // the theta range from it. 
+        // Thus for HCAL we use the theta range passed via activeVolumesTheta
+
+        // Set system and layer of volume ID
+        dd4hep::DDSegmentation::CellID volumeId = 0;
+        (*decoder)[m_fieldNamesSegmented[iSys]].set(volumeId, m_fieldValuesSegmented[iSys]);
+        (*decoder)[m_activeFieldNamesSegmented[iSys]].set(volumeId, ilayer);
+        (*decoder)["theta"].set(volumeId, 0);
+        (*decoder)["phi"].set(volumeId, 0);
+        // Get number of segmentation cells within the active volume
+        std::array<uint, 3> numCells;
+        // for volumes (such as Allegro's HCAL) for which theta range
+        // is passed via activeVolumesTheta option then use that instead of
+        // numberOfCells helper function
+        if (m_activeVolumesTheta[iSys].size()>0)
+        {
+          int nPhiCells = TMath::TwoPi() / phiThetaSegmentation->gridSizePhi();
+          double thetaCellSize = phiThetaSegmentation->gridSizeTheta();
+          double thetaOffset = phiThetaSegmentation->offsetTheta();
+          double thetaMin = m_activeVolumesTheta[iSys][ilayer];
+          double thetaMax = TMath::Pi() - thetaMin;
+          uint minThetaID = int(floor((thetaMin + 0.5 * thetaCellSize - thetaOffset) / thetaCellSize));
+          uint maxThetaID = int(floor((thetaMax + 0.5 * thetaCellSize - thetaOffset) / thetaCellSize));
+          uint nThetaCells = 1 + maxThetaID - minThetaID;
+          numCells[0] = nPhiCells;
+          numCells[1] = nThetaCells;
+          numCells[2] = minThetaID;
+        }
+        else
+        {
+          numCells = det::utils::numberOfCells(volumeId, *phiThetaSegmentation);
+        }
+        // extrema[1]: 0, ID of last cell in phi
+        extrema[1] = std::make_pair(0, numCells[0] - 1);
+        // extrema[2]: min theta ID, ID of last cell in theta
+        extrema[2] = std::make_pair(numCells[2], numCells[1] + numCells[2] - 1);
+        debug() << "Layer: " << ilayer << endmsg;
+        debug() << "Extrema[0]: " << extrema[0].first << " , " << extrema[0].second << endmsg;
+        debug() << "Extrema[1]: " << extrema[1].first << " , " << extrema[1].second << endmsg;
+        debug() << "Extrema[2]: " << extrema[2].first << " , " << extrema[2].second << endmsg;
+        debug() << "Number of segmentation cells in phi, in theta, and min theta ID, : " << numCells << endmsg;
+        // Loop over segmentation cells
+        for (unsigned int iphi = 0; iphi < numCells[0]; iphi++)
+        {
+          for (unsigned int itheta = 0; itheta < numCells[1]; itheta++)
+          {
+            dd4hep::DDSegmentation::CellID cellId = volumeId;
+            decoder->set(cellId, "phi", iphi);
+            decoder->set(cellId, "theta", itheta + numCells[2]); // start from the minimum existing theta cell in this layer
+            uint64_t id = cellId;
+            double noise = 0.;
+            double noiseOffset = 0.;
+            if (m_fieldValuesSegmented[iSys] == m_ecalBarrelSysId)
+            {
+              noise = m_ecalBarrelNoiseTool->getNoiseConstantPerCell(id);
+              noiseOffset = m_ecalBarrelNoiseTool->getNoiseOffsetPerCell(id);
+            }
+            else if (m_fieldValuesSegmented[iSys] == m_hcalBarrelSysId)
+            {
+              noise = m_hcalBarrelNoiseTool->getNoiseConstantPerCell(id);
+              noiseOffset = m_hcalBarrelNoiseTool->getNoiseOffsetPerCell(id);
+            }
+            else
+            {
+              warning() << "Unexpected system value for phi-theta readout " << m_fieldValuesSegmented[iSys]
+                        << ", setting noise to 0.0" << endmsg;
+            }
+            map.insert(std::pair<uint64_t, std::pair<double, double>>(id, std::make_pair(noise, noiseOffset)));
+          }
+        }
       }
-      extrema[2] = std::make_pair(numCells[2], numCells[2] + (numCells[1] - 1)*segmentation->mergedThetaCells(ilayer));
-      debug() << "Layer: " << ilayer << endmsg;
-      debug() << "Number of segmentation cells in (module, theta): " << numCells << endmsg;
-      // Loop over segmentation cells
-      for (unsigned int imodule = 0; imodule < numCells[0]; imodule++) {
-        for (unsigned int itheta = 0; itheta < numCells[1]; itheta++) {
-	  dd4hep::DDSegmentation::CellID cellId = volumeId;
-	  decoder->set(cellId, "module", imodule*segmentation->mergedModules(ilayer));
-	  decoder->set(cellId, "theta", numCells[2] + itheta*segmentation->mergedThetaCells(ilayer));  // start from the minimum existing theta cell in this layer
-	  uint64_t id = cellId;
-	  double noise = 0.;
-	  double noiseOffset = 0.;
-	  if (m_fieldValuesSegmented[iSys] == m_hcalBarrelSysId){
-	    noise = m_hcalBarrelNoiseTool->getNoiseConstantPerCell(id);
-	    noiseOffset = m_hcalBarrelNoiseTool->getNoiseOffsetPerCell(id);
-	  } else if (m_fieldValuesSegmented[iSys] == m_ecalBarrelSysId){
-	    noise = m_ecalBarrelNoiseTool->getNoiseConstantPerCell(id);
-            noiseOffset = m_ecalBarrelNoiseTool->getNoiseOffsetPerCell(id);
-	  }
-          map.insert( std::pair<uint64_t, std::pair<double, double> >(id, std::make_pair(noise, noiseOffset) ) );
+      else if (segmentationType == "FCCSWGridModuleThetaMerged_k4geo")
+      {
+        // Set system and layer of volume ID
+        dd4hep::DDSegmentation::CellID volumeId = 0;
+        (*decoder)[m_fieldNamesSegmented[iSys]].set(volumeId, m_fieldValuesSegmented[iSys]);
+        (*decoder)[m_activeFieldNamesSegmented[iSys]].set(volumeId, ilayer);
+        (*decoder)["theta"].set(volumeId, 0);
+        (*decoder)["module"].set(volumeId, 0);
+        // Get number of segmentation cells within the active volume, for given layer
+        auto numCells = det::utils::numberOfCells(volumeId, *moduleThetaSegmentation);
+        // extrema[1]: Range of module ID (0, max module ID)
+        extrema[1] = std::make_pair(0, (numCells[0] - 1) * moduleThetaSegmentation->mergedModules(ilayer));
+        // extrema[2]: Range of theta ID (min theta ID, max theta ID
+        extrema[2] = std::make_pair(numCells[2], numCells[2] + (numCells[1] - 1) * moduleThetaSegmentation->mergedThetaCells(ilayer));
+        debug() << "Layer: " << ilayer << endmsg;
+        debug() << "Number of segmentation cells in (module, theta): " << numCells << endmsg;
+        // Loop over segmentation cells
+        for (unsigned int imodule = 0; imodule < numCells[0]; imodule++)
+        {
+          for (unsigned int itheta = 0; itheta < numCells[1]; itheta++)
+          {
+            dd4hep::DDSegmentation::CellID cellId = volumeId;
+            decoder->set(cellId, "module", imodule * moduleThetaSegmentation->mergedModules(ilayer));
+            decoder->set(cellId, "theta", numCells[2] + itheta * moduleThetaSegmentation->mergedThetaCells(ilayer)); // start from the minimum existing theta cell in this layer
+            uint64_t id = cellId;
+            double noise = 0.;
+            double noiseOffset = 0.;
+            if (m_fieldValuesSegmented[iSys] == m_ecalBarrelSysId)
+            {
+              noise = m_ecalBarrelNoiseTool->getNoiseConstantPerCell(id);
+              noiseOffset = m_ecalBarrelNoiseTool->getNoiseOffsetPerCell(id);
+            }
+            else
+            {
+              warning() << "Unexpected system value for module-theta readout " << m_fieldValuesSegmented[iSys]
+                        << ", setting noise to 0.0" << endmsg;
+            }
+            map.insert(std::pair<uint64_t, std::pair<double, double>>(id, std::make_pair(noise, noiseOffset)));
+          }
         }
       }
     }
@@ -127,7 +248,8 @@ StatusCode CreateFCCeeCaloNoiseLevelMap::initialize() {
   tree.Branch("cellId", &saveCellId, "cellId/l");
   tree.Branch("noiseLevel", &saveNoiseLevel);
   tree.Branch("noiseOffset", &saveNoiseOffset);
-  for (const auto& item : map) {
+  for (const auto &item : map)
+  {
     saveCellId = item.first;
     saveNoiseLevel = item.second.first;
     saveNoiseOffset = item.second.second;

--- a/RecFCCeeCalorimeter/src/components/CreateFCCeeCaloNoiseLevelMap.h
+++ b/RecFCCeeCalorimeter/src/components/CreateFCCeeCaloNoiseLevelMap.h
@@ -40,9 +40,11 @@ private:
   /// ideally could replace with vector of handles (so that we can also have ecal endcap and so on)
   /// Handle for the cells noise tool in ECal
   ToolHandle<INoiseConstTool> m_ecalBarrelNoiseTool{"ReadNoiseFromFileTool", this};
-  Gaudi::Property<uint> m_ecalBarrelSysId{this, "ecalBarrelSysId", 5};
   /// Handle for the cells noise tool in HCal
   ToolHandle<INoiseConstTool> m_hcalBarrelNoiseTool{"ReadNoiseFromFileTool", this};
+
+  // System ID of ECAL and HCAL barrels
+  Gaudi::Property<uint> m_ecalBarrelSysId{this, "ecalBarrelSysId", 4};
   Gaudi::Property<uint> m_hcalBarrelSysId{this, "hcalBarrelSysId", 8};
 
   /// Names of the detector readout for the volumes
@@ -52,11 +54,11 @@ private:
   /// Values of the fields describing the segmented volume
   Gaudi::Property<std::vector<int>> m_fieldValuesSegmented{this, "systemValues", {4, 8}};
   /// Names of the active volume in geometry along radial axis (e.g. layer), the others are "module" or "phi", "theta"
-  Gaudi::Property<std::vector<std::string>> m_activeFieldNamesSegmented{this, "activeFieldNames", {"layer"}};
-  /// Number of layers in the segmented volume
+  Gaudi::Property<std::vector<std::string>> m_activeFieldNamesSegmented{this, "activeFieldNames", {"layer", "layer"}};
+  /// Number of layers in the segmented volumes
   Gaudi::Property<std::vector<unsigned int>> m_activeVolumesNumbersSegmented{this, "activeVolumesNumbers", {12, 13}};
-  // Radii of layers in the segmented volume
-  Gaudi::Property<std::vector<double>> m_activeVolumesTheta{this, "activeVolumesTheta"};
+  // Theta ranges of layers in the segmented volumes (if needed)
+  Gaudi::Property<std::vector<std::vector<double>>> m_activeVolumesTheta{this, "activeVolumesTheta"};
 
   /// Name of output file
   std::string m_outputFileName;


### PR DESCRIPTION
This PR adds code to create noise map and cell neighbour map for ECAL + HCAL barrel including links between ECAL outermost and HCAL innermost layers.
The code is developed mainly for the inclined cell readout of the Allegro ECAL but also work for an ECAL with more standard phi-theta readout, for which a corresponding cell positioning tool is also implemented in this PR.