### PR TITLE
fix bug in calculation of theta of layer  barycentre 

### DIFF
--- a/RecFCCeeCalorimeter/src/components/AugmentClustersFCCee.cpp
+++ b/RecFCCeeCalorimeter/src/components/AugmentClustersFCCee.cpp
@@ -74,7 +74,7 @@ StatusCode AugmentClustersFCCee::initialize()
     const char *detector = m_detectorNames[k].c_str();
     for (unsigned layer = 0; layer < m_numLayers[k]; layer++)
     {
-      showerShapeDecorations.push_back(Form("energy_%s_layer_%d", detector, layer));
+      showerShapeDecorations.push_back(Form("energy_fraction_%s_layer_%d", detector, layer));
       showerShapeDecorations.push_back(Form("theta_%s_layer_%d", detector, layer));
       showerShapeDecorations.push_back(Form("phi_%s_layer_%d", detector, layer));
     }
@@ -221,11 +221,12 @@ StatusCode AugmentClustersFCCee::execute([[maybe_unused]] const EventContext &ev
       }
       for (unsigned layer = 0; layer < m_numLayers[k]; layer++)
       {
+        // theta
         if (m_thetaRecalcLayerWeights[k][layer]<0)
         {
           if (sumEnLayer[layer+startPositionToFill] != 0.0)
           {
-            sumEnLayer[layer+startPositionToFill] /= sumWeightLayer[layer+startPositionToFill];
+            sumThetaLayer[layer+startPositionToFill] /= sumEnLayer[layer+startPositionToFill];
           }
         }
         else
@@ -235,6 +236,8 @@ StatusCode AugmentClustersFCCee::execute([[maybe_unused]] const EventContext &ev
             sumThetaLayer[layer+startPositionToFill] /= sumWeightLayer[layer+startPositionToFill];
           }
         }
+
+        // phi
         if (sumEnLayer[layer+startPositionToFill] != 0.0)
         {
           sumPhiLayer[layer+startPositionToFill] /= sumEnLayer[layer+startPositionToFill];


### PR DESCRIPTION
There was a typo in the cluster decorator  in the final normalisation of the layer theta when linear (E) weights are used.

Also, since the shapeParameters related to the energy are not the raw energies but rather energy fractions (energy in layer / cluster energy), I have renamed the metadata energy_ .. to energy_fraction_ ..
