### PR TITLE
Avoid crashing when cross-talk not wanted

### DIFF
--- a/RecCalorimeter/src/components/ReadCaloCrosstalkMap.cpp
+++ b/RecCalorimeter/src/components/ReadCaloCrosstalkMap.cpp
@@ -13,6 +13,11 @@ ReadCaloCrosstalkMap::ReadCaloCrosstalkMap(const std::string& type, const std::s
 }
 
 StatusCode ReadCaloCrosstalkMap::initialize() {
+  // prevent to initialize the tool if not intended (input file path empty)
+  // otherwise things will crash if m_fileName is not available
+  // not a perfect solution but tools seems to not be meant to be optional
+  if (m_fileName == "") return StatusCode::SUCCESS;
+
   StatusCode sc = GaudiTool::initialize();
   info() <<"Loading crosstalk map..." << endmsg;
   if (sc.isFailure()) return sc;

--- a/RecCalorimeter/src/components/ReadCaloCrosstalkMap.cpp
+++ b/RecCalorimeter/src/components/ReadCaloCrosstalkMap.cpp
@@ -16,7 +16,10 @@ StatusCode ReadCaloCrosstalkMap::initialize() {
   // prevent to initialize the tool if not intended (input file path empty)
   // otherwise things will crash if m_fileName is not available
   // not a perfect solution but tools seems to not be meant to be optional
-  if (m_fileName == "") return StatusCode::SUCCESS;
+  if (m_fileName == "") {
+    debug() << "Empty 'fileName' provided, it means cross-talk map is not needed, exitting ReadCaloCrosstalkMap initilization" << endmsg;
+    return StatusCode::SUCCESS;
+  }
 
   StatusCode sc = GaudiTool::initialize();
   info() <<"Loading crosstalk map..." << endmsg;

--- a/RecCalorimeter/src/components/ReadCaloCrosstalkMap.h
+++ b/RecCalorimeter/src/components/ReadCaloCrosstalkMap.h
@@ -40,7 +40,7 @@ public:
 
 private:
   /// Name of input root file that contains the TTree with cellID->vec<list_crosstalk_neighboursCellID> and cellId->vec<list_crosstalksCellID>
-  Gaudi::Property<std::string> m_fileName{this, "fileName", "xtalk_neighbours_map_ecalB_thetamodulemerged.root", "Name of the file that contains the crosstalk map"};
+  Gaudi::Property<std::string> m_fileName{this, "fileName", "", "Name of the file that contains the crosstalk map. Leave the default empty to avoid crashes when cross-talk is not needed."};
   /// Output maps to be used for the fast lookup in the creating calo-cells algorithm
   std::unordered_map<uint64_t, std::vector<uint64_t>> m_mapNeighbours;
   std::unordered_map<uint64_t, std::vector<double>> m_mapCrosstalks;


### PR DESCRIPTION
Tools being always initialized, this PR avoids crashing when cross-talk is not needed. Before, `ReadCaloCrosstalkMap` would always be looking for a `xtalk_neighbours_map_ecalB_thetamodulemerged.root` rootfile.