### PR TITLE
Remove the need for an explicit typename

### DIFF
--- a/RecCalorimeter/src/components/CreateTruthJet.cpp
+++ b/RecCalorimeter/src/components/CreateTruthJet.cpp
@@ -92,10 +92,9 @@ struct CreateTruthJet final
       for (auto constit : constits) {
         int index = constit.user_info<k4::recCalo::ClusterInfo>().index();
 
-        edm4hep::MutableMCRecoParticleAssociation association;
+        auto association = assoc.create();
         association.setRec(jet);
         association.setSim((input)[index]);
-        assoc.push_back(association);
       }
 
       edmJets.push_back(jet);


### PR DESCRIPTION
Use `auto` and `Collection::create` to remove the need for an explicit typename to make key4hep/EDM4hep#341 transparent.

@BrieucF another one that is required to make the EDM4hep PR work transparently.