### PR TITLE
Make sure to properly support newer versions of onnxruntime

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,11 +28,20 @@ find_package(k4FWCore) # implicit: Gaudi
 find_package(EDM4HEP) # implicit: Podio
 find_package(DD4hep)
 find_package(k4geo)
-find_package(ONNXRuntime)
 find_package(FastJet)
 # New versions of ONNRuntime package provide onnxruntime-Config.cmake
 # and use the name onnxruntime
 find_package(onnxruntime)
+if (NOT onnxruntime_FOUND)
+  message(STATUS "Could not find onnxruntime (> 1.17.1). Looking for an older version")
+  find_package(ONNXRuntime)
+endif()
+
+if(onnxruntime_FOUND OR ONNXRuntime_FOUND)
+else()
+  message(FATAL_ERROR "Failed to locate ONNXRuntime!")
+endif()
+
 #---------------------------------------------------------------
 
 

--- a/RecFCCeeCalorimeter/CMakeLists.txt
+++ b/RecFCCeeCalorimeter/CMakeLists.txt
@@ -2,17 +2,6 @@
 # Package: RecFCCeeCalorimeter
 ################################################################################
 
-# ONNX DEPENDENCIES
-# includes
-include_directories("${ONNXRUNTIME_INCLUDE_DIRS}")
-# libs
-link_directories("${ONNXRUNTIME_LIBRARY_DIRS}")
-# New versions of ONNXRuntime add directories to include
-# through the target onnxruntime::onnxruntime
-if(onnxruntime_FOUND)
-  set(ONNXRUNTIME_LIBRARY onnxruntime::onnxruntime)
-endif()
-
 file(GLOB _module_sources src/components/*.cpp)
 gaudi_add_module(k4RecFCCeeCalorimeterPlugins
                  SOURCES ${_module_sources}
@@ -26,7 +15,7 @@ gaudi_add_module(k4RecFCCeeCalorimeterPlugins
                       DD4hep::DDG4
                       ROOT::Core
                       ROOT::Hist
-                      ${ONNXRUNTIME_LIBRARY}
+                      onnxruntime::onnxruntime
                       nlohmann_json::nlohmann_json
                       )
 install(TARGETS k4RecFCCeeCalorimeterPlugins

--- a/RecFCCeeCalorimeter/src/components/CalibrateCaloClusters.h
+++ b/RecFCCeeCalorimeter/src/components/CalibrateCaloClusters.h
@@ -26,7 +26,7 @@ namespace dd4hep {
 }
 
 // ONNX
-#include "onnxruntime/core/session/experimental_onnxruntime_cxx_api.h"
+#include "onnxruntime_cxx_api.h"
 
 /** @class CalibrateCaloClusters
  *
@@ -149,12 +149,13 @@ private:
 
   // the ONNX runtime session for applying the calibration,
   // the environment, and the input and output shapes and names
-  Ort::Experimental::Session* m_ortSession = nullptr;
+  Ort::Session* m_ortSession = nullptr;
   Ort::Env* m_ortEnv = nullptr;
+  Ort::MemoryInfo m_ortMemInfo;
   std::vector<std::int64_t> m_input_shapes;
   std::vector<std::int64_t> m_output_shapes;
-  std::vector<std::string> m_input_names;
-  std::vector<std::string> m_output_names;
+  std::vector<const char*> m_input_names;
+  std::vector<const char*> m_output_names;
 
   // the indices of the shapeParameters containing the inputs to the model (if they exist)
   std::vector<unsigned short int> m_inputPositionsInShapeParameters;

--- a/RecFCCeeCalorimeter/src/components/OnnxruntimeUtilities.h
+++ b/RecFCCeeCalorimeter/src/components/OnnxruntimeUtilities.h
@@ -1,0 +1,18 @@
+#ifndef RECFCCEECALORIMETER_ONNXRUNTIMEUTILITIES_H
+#define RECFCCEECALORIMETER_ONNXRUNTIMEUTILITIES_H
+
+#include "onnxruntime_cxx_api.h"
+
+#include <vector>
+
+// convert vector data with given shape into ONNX runtime tensor
+template <typename T>
+Ort::Value vec_to_tensor(std::vector<T> &data,
+                         const std::vector<std::int64_t> &shape,
+                         const Ort::MemoryInfo &mem_info) {
+  auto tensor = Ort::Value::CreateTensor<T>(mem_info, data.data(), data.size(),
+                                            shape.data(), shape.size());
+  return tensor;
+}
+
+#endif

--- a/RecFCCeeCalorimeter/src/components/PhotonIDTool.h
+++ b/RecFCCeeCalorimeter/src/components/PhotonIDTool.h
@@ -18,7 +18,7 @@ namespace edm4hep {
 }
 
 // ONNX
-#include "onnxruntime/core/session/experimental_onnxruntime_cxx_api.h"
+#include "onnxruntime_cxx_api.h"
 
 /** @class PhotonIDTool
  *
@@ -100,12 +100,13 @@ private:
 
   // the ONNX runtime session for running the inference,
   // the environment, and the input and output shapes and names
-  Ort::Experimental::Session* m_ortSession = nullptr;
+  Ort::Session* m_ortSession = nullptr;
   Ort::Env* m_ortEnv = nullptr;
+  Ort::MemoryInfo m_ortMemInfo;
   std::vector<std::int64_t> m_input_shapes;
   std::vector<std::int64_t> m_output_shapes;
-  std::vector<std::string> m_input_names;
-  std::vector<std::string> m_output_names;
+  std::vector<const char*> m_input_names;
+  std::vector<const char*> m_output_names;
   std::vector<std::string> m_internal_input_names;
   
   // the indices of the shapeParameters containing the inputs to the model (-1 if not found)

--- a/cmake/FindONNXRuntime.cmake
+++ b/cmake/FindONNXRuntime.cmake
@@ -1,4 +1,6 @@
-find_path(ONNXRUNTIME_INCLUDE_DIR onnxruntime/core/session/onnxruntime_cxx_inline.h
+find_path(ONNXRUNTIME_INCLUDE_DIR
+          NAMES onnxruntime_cxx_api.h
+          PATH_SUFFIXES onnxruntime/core/session
           HINTS $ENV{ONNXRUNTIME_ROOT_DIR}/include ${ONNXRUNTIME_ROOT_DIR}/include)
 
 find_library(ONNXRUNTIME_LIBRARY NAMES onnxruntime
@@ -11,4 +13,13 @@ mark_as_advanced(ONNXRUNTIME_FOUND ONNXRUNTIME_INCLUDE_DIR ONNXRUNTIME_LIBRARY)
 
 set(ONNXRUNTIME_INCLUDE_DIRS ${ONNXRUNTIME_INCLUDE_DIR})
 set(ONNXRUNTIME_LIBRARIES ${ONNXRUNTIME_LIBRARY})
-get_filename_component(ONNXRUNTIME_LIBRARY_DIRS ${ONNXRUNTIME_LIBRARY} PATH)
+
+# Rig an onnxruntime::onnxruntime target that works similar (enough) to the one
+# that can be directly found via find_package(onnxruntime) for newer versions of
+# onnxruntime
+add_library(onnxruntime::onnxruntime INTERFACE IMPORTED GLOBAL)
+set_target_properties(onnxruntime::onnxruntime
+  PROPERTIES
+  INTERFACE_INCLUDE_DIRECTORIES "${ONNXRUNTIME_INCLUDE_DIRS}"
+  INTERFACE_LINK_LIBRARIES "${ONNXRUNTIME_LIBRARIES}"
+)


### PR DESCRIPTION
This PR ensures that newer versions of onnxruntime are preferred by CMake and also that newer versions of onnxruntime actually compile (see also https://github.com/HEP-FCC/FCCAnalyses/pull/381 for some more details than here). In short this PR 

- Makes `FindONNXRuntime.cmake` create the an `onnxruntime::onnxruntime` target that works similar (enough) to the one from `onnxruntime`, such that we can simplify the cmake configuration to only use that.
- Makes the c++ code work with older versions (< 1.13) and newer versions using some pre-processor checks.

The CI has been working because it found an ONNXRuntime version 1.10, but I could not build this with a newer version of onnxruntime locally.

- [x] Also includes the changes from #103 so that has to be merged first. 