### PR TITLE
fix crash due to wrong treatment of pointers in ONNX-related code, and remove one photon-ID variable from decorations when not needed

### DIFF
--- a/RecFCCeeCalorimeter/src/components/AugmentClustersFCCee.cpp
+++ b/RecFCCeeCalorimeter/src/components/AugmentClustersFCCee.cpp
@@ -129,9 +129,9 @@ StatusCode AugmentClustersFCCee::initialize()
       showerShapeDecorations.push_back(Form("energy_fraction_%s_layer_%d", detector, layer));
       showerShapeDecorations.push_back(Form("theta_%s_layer_%d", detector, layer));
       showerShapeDecorations.push_back(Form("phi_%s_layer_%d", detector, layer));
-      showerShapeDecorations.push_back(Form("maxcell_E_%s_layer_%d", detector, layer));
       // pi0/photon shape var only calculated in EMB
       if (m_do_photon_shapeVar && m_systemIDs[k] == systemID_EMB) {
+        showerShapeDecorations.push_back(Form("maxcell_E_%s_layer_%d", detector, layer));
         showerShapeDecorations.push_back(Form("width_theta_%s_layer_%d", detector, layer));
         showerShapeDecorations.push_back(Form("width_module_%s_layer_%d", detector, layer));
         showerShapeDecorations.push_back(Form("Ratio_E_max_2ndmax_%s_layer_%d", detector, layer));
@@ -651,7 +651,7 @@ StatusCode AugmentClustersFCCee::execute([[maybe_unused]] const EventContext &ev
               return StatusCode::FAILURE;
             }
             width_theta[layer+startPositionToFill] = (sumEnLayer[layer+startPositionToFill] > 0.) ? std::sqrt(std::fabs(w_theta2)) : 0. ;
-	  }
+	        }
           double w_module2 = module2_E_layer[layer+startPositionToFill] / sumEnLayer[layer+startPositionToFill] - std::pow(module_E_layer[layer+startPositionToFill] / sumEnLayer[layer+startPositionToFill], 2);
           // Very small but negative values caused by computational precision are allowed,
           // otherwise crash.

--- a/RecFCCeeCalorimeter/src/components/CalibrateCaloClusters.cpp
+++ b/RecFCCeeCalorimeter/src/components/CalibrateCaloClusters.cpp
@@ -169,8 +169,23 @@ StatusCode CalibrateCaloClusters::finalize()
 {
   if (m_ortSession)
     delete m_ortSession;
+
   if (m_ortEnv)
     delete m_ortEnv;
+
+  for (std::size_t i = 0; i < m_input_names.size(); i++) {
+    if (m_input_names.at(i)) {
+      delete m_input_names.at(i);
+    }
+  }
+  m_input_names.resize(0);
+
+  for (std::size_t i = 0; i < m_output_names.size(); i++) {
+    if (m_output_names.at(i)) {
+      delete m_output_names.at(i);
+    }
+  }
+  m_output_names.resize(0);
 
   return Gaudi::Algorithm::finalize();
 }
@@ -271,7 +286,7 @@ StatusCode CalibrateCaloClusters::readCalibrationFile(const std::string &calibra
 #if ORT_API_VERSION < 13
     m_output_names.emplace_back(AllocatedStringPtr(m_ortSession->GetOutputName(i, allocator), allocDeleter).release());
 #else
-    m_output_names.emplace_back(m_ortSession->GetOutputNameAllocated(i, allocator).get());
+    m_output_names.emplace_back(m_ortSession->GetOutputNameAllocated(i, allocator).release());
 #endif
     m_output_shapes = m_ortSession->GetOutputTypeInfo(i).GetTensorTypeAndShapeInfo().GetShape();
     debug() << "\t" << m_output_names.at(i) << " : ";

--- a/RecFCCeeCalorimeter/src/components/CalibrateCaloClusters.cpp
+++ b/RecFCCeeCalorimeter/src/components/CalibrateCaloClusters.cpp
@@ -173,22 +173,17 @@ StatusCode CalibrateCaloClusters::finalize()
   if (m_ortEnv)
     delete m_ortEnv;
 
-  for (std::size_t i = 0; i < m_input_names.size(); i++) {
-    if (m_input_names.at(i)) {
-      delete m_input_names.at(i);
-    }
+  for (auto& name : m_input_names) {
+    delete name;
   }
-  m_input_names.resize(0);
 
-  for (std::size_t i = 0; i < m_output_names.size(); i++) {
-    if (m_output_names.at(i)) {
-      delete m_output_names.at(i);
-    }
+  for (auto& name : m_output_names) {
+    delete name;
   }
-  m_output_names.resize(0);
 
   return Gaudi::Algorithm::finalize();
 }
+
 
 edm4hep::ClusterCollection *CalibrateCaloClusters::initializeOutputClusters(
     const edm4hep::ClusterCollection *inClusters) const

--- a/RecFCCeeCalorimeter/src/components/PhotonIDTool.cpp
+++ b/RecFCCeeCalorimeter/src/components/PhotonIDTool.cpp
@@ -138,19 +138,13 @@ StatusCode PhotonIDTool::finalize()
   if (m_ortEnv)
     delete m_ortEnv;
 
-  for (std::size_t i = 0; i < m_input_names.size(); i++) {
-    if (m_input_names.at(i)) {
-      delete m_input_names.at(i);
-    }
+  for (auto& name : m_input_names) {
+    delete name;
   }
-  m_input_names.resize(0);
 
-  for (std::size_t i = 0; i < m_output_names.size(); i++) {
-    if (m_output_names.at(i)) {
-      delete m_output_names.at(i);
-    }
+  for (auto& name : m_output_names) {
+    delete name;
   }
-  m_output_names.resize(0);
 
   return Gaudi::Algorithm::finalize();
 }

--- a/RecFCCeeCalorimeter/src/components/PhotonIDTool.cpp
+++ b/RecFCCeeCalorimeter/src/components/PhotonIDTool.cpp
@@ -134,8 +134,23 @@ StatusCode PhotonIDTool::finalize()
 {
   if (m_ortSession)
     delete m_ortSession;
+
   if (m_ortEnv)
     delete m_ortEnv;
+
+  for (std::size_t i = 0; i < m_input_names.size(); i++) {
+    if (m_input_names.at(i)) {
+      delete m_input_names.at(i);
+    }
+  }
+  m_input_names.resize(0);
+
+  for (std::size_t i = 0; i < m_output_names.size(); i++) {
+    if (m_output_names.at(i)) {
+      delete m_output_names.at(i);
+    }
+  }
+  m_output_names.resize(0);
 
   return Gaudi::Algorithm::finalize();
 }
@@ -341,7 +356,7 @@ StatusCode PhotonIDTool::readMVAFiles(const std::string& mvaInputsFileName,
 #if ORT_API_VERSION < 13
     m_output_names.emplace_back(AllocatedStringPtr(m_ortSession->GetOutputName(i, allocator), allocDeleter).release());
 #else
-    m_output_names.emplace_back(m_ortSession->GetOutputNameAllocated(i, allocator).get());
+    m_output_names.emplace_back(m_ortSession->GetOutputNameAllocated(i, allocator).release());
 #endif
 
     m_output_shapes = m_ortSession->GetOutputTypeInfo(i).GetTensorTypeAndShapeInfo().GetShape();


### PR DESCRIPTION
Pointers were not treated correctly in some cases and led to a crash, see discussion in https://github.com/……HEP-FCC/k4RecCalorimeter/pull/104#discussion_r1735675543

Also, one shape parameter for photon ID was being added to clusters even when the flag for adding photon-id related variables was false.

This PR fixes both things