### PR TITLE
Fix scripts for automatic tests

### DIFF
--- a/RecFCCeeCalorimeter/tests/options/ALLEGRO_o1_v03.sh
+++ b/RecFCCeeCalorimeter/tests/options/ALLEGRO_o1_v03.sh
@@ -1,49 +1,40 @@
 #!/bin/bash
 
-# Define the function for downloading files
+# set this to 1 to use ee->Z->qq Pythia events, or 0 to use particle guns for e and pi, barrel and endcap
+usePythia=1
+
+# Define the unction for downloading files
+# Attempt to download the file using wget, exit the script if wget failed
 download_file() {
   local url="$1"
-
-  # Attempt to download the file using wget
-  wget "$url"
-
-  # Check the exit status of wget
-  if [ $? -ne 0 ]; then
-    # if wget failed, exit the script with status code 1
-    echo "Download failed."
-    exit 1
-  fi
+  wget "$url" || { echo "Download failed"; exit 1; }
 }
 
-# set-up the Key4hep environment if not already set
+# Check that the Key4hep environment is set
 if [[ -z "${KEY4HEP_STACK}" ]]; then
   echo "Error: Key4hep environment not set"
   return 1
 fi
 
-# download the events to reconstruct
-if ! -test ./pythia_ee_z_qq_10evt.hepmc; then
-  echo "Downloading files needed for simulation"
-  download_file "https://fccsw.web.cern.ch/fccsw/filesForSimDigiReco/gen/pythia_ee_z_qq_10evt.hepmc"
-fi
-
 # run the SIM step (for debug do not run it if files already present. Comment the if and fi lines for production)
-# if ! test -f ALLEGRO_sim_ee_z_qq.root; then
-echo "Performing the Geant4 simulation with ddsim"
-ddsim --inputFiles pythia_ee_z_qq_10evt.hepmc --numberOfEvents -1 --outputFile ALLEGRO_sim_ee_z_qq.root --compactFile $K4GEO/FCCee/ALLEGRO/compact/ALLEGRO_o1_v03/ALLEGRO_o1_v03.xml
-# fi
-#if ! test -f ALLEGRO_sim_e_barrel.root; then
-#echo "Generating events and performing the Geant4 simulation with ddsim"
-#ddsim --enableGun --gun.distribution uniform --gun.energy "10*GeV" --gun.particle e- --numberOfEvents 10 --outputFile ALLEGRO_sim_e_barrel.root --random.enableEventSeed --random.seed 42 --compactFile $K4GEO/FCCee/ALLEGRO/compact/ALLEGRO_o1_v03/ALLEGRO_o1_v03.xml
-#ddsim --enableGun --gun.distribution uniform --gun.energy "10*GeV" --gun.particle e- --numberOfEvents 10 --outputFile ALLEGRO_sim_e_endcap.root --random.enableEventSeed --random.seed 42 --compactFile $K4GEO/FCCee/ALLEGRO/compact/ALLEGRO_o1_v03/ALLEGRO_o1_v03.xml
-#ddsim --enableGun --gun.distribution uniform --gun.energy "10*GeV" --gun.particle pi- --numberOfEvents 10 --outputFile ALLEGRO_sim_pi_barrel.root --random.enableEventSeed --random.seed 42 --compactFile $K4GEO/FCCee/ALLEGRO/compact/ALLEGRO_o1_v03/ALLEGRO_o1_v03.xml
-#ddsim --enableGun --gun.distribution uniform --gun.energy "10*GeV" --gun.particle pi- --numberOfEvents 10 --outputFile ALLEGRO_sim_pi_endcap.root --random.enableEventSeed --random.seed 42 --compactFile $K4GEO/FCCee/ALLEGRO/compact/ALLEGRO_o1_v03/ALLEGRO_o1_v03.xml
-#fi
-
-retcode=$?
-if [ $retcode -ne 0 ]; then
-  echo "Simulation failed"
-  exit $retcode
+if [ "$usePythia" -gt 0 ]; then
+  # download the events to reconstruct
+  if ! test -f ./pythia_ee_z_qq_10evt.hepmc; then
+    echo "Downloading files needed for simulation"
+    download_file "https://fccsw.web.cern.ch/fccsw/filesForSimDigiReco/gen/pythia_ee_z_qq_10evt.hepmc"
+  fi
+  # if ! test -f ALLEGRO_sim_ee_z_qq.root; then
+  echo "Performing the Geant4 simulation with ddsim"
+  ddsim --inputFiles pythia_ee_z_qq_10evt.hepmc --numberOfEvents -1 --outputFile ALLEGRO_sim_ee_z_qq.root --compactFile $K4GEO/FCCee/ALLEGRO/compact/ALLEGRO_o1_v03/ALLEGRO_o1_v03.xml || { retcode=$? ; echo "Simulation failed" ; exit $retcode ; }
+  # fi
+else
+  #if ! test -f ALLEGRO_sim_e_barrel.root; then
+  echo "Generating events and performing the Geant4 simulation with ddsim"
+  ddsim --enableGun --gun.distribution uniform --gun.energy "10*GeV" --gun.thetaMin "90*deg" --gun.thetaMax "90*deg" --gun.particle e- --numberOfEvents 100 --outputFile ALLEGRO_sim_e_barrel.root --random.enableEventSeed --random.seed 42 --compactFile $K4GEO/FCCee/ALLEGRO/compact/ALLEGRO_o1_v03/ALLEGRO_o1_v03.xml || exit 1
+  ddsim --enableGun --gun.distribution uniform --gun.energy "10*GeV" --gun.thetaMin "160*deg" --gun.thetaMax "160*deg" --gun.particle e- --numberOfEvents 100 --outputFile ALLEGRO_sim_e_endcap.root --random.enableEventSeed --random.seed 42 --compactFile $K4GEO/FCCee/ALLEGRO/compact/ALLEGRO_o1_v03/ALLEGRO_o1_v03.xml || exit 1
+  ddsim --enableGun --gun.distribution uniform --gun.energy "50*GeV" --gun.thetaMin "90*deg" --gun.thetaMax "90*deg" --gun.particle pi- --numberOfEvents 100 --outputFile ALLEGRO_sim_pi_barrel.root --random.enableEventSeed --random.seed 42 --compactFile $K4GEO/FCCee/ALLEGRO/compact/ALLEGRO_o1_v03/ALLEGRO_o1_v03.xml || exit 1
+  ddsim --enableGun --gun.distribution uniform --gun.energy "50*GeV" --gun.thetaMin "160*deg" --gun.thetaMax "160*deg" --gun.particle pi- --numberOfEvents 100 --outputFile ALLEGRO_sim_pi_endcap.root --random.enableEventSeed --random.seed 42 --compactFile $K4GEO/FCCee/ALLEGRO/compact/ALLEGRO_o1_v03/ALLEGRO_o1_v03.xml || exit 1
+  #fi
 fi
 
 # get the files needed for calibration, noise, neighbor finding, etc
@@ -63,4 +54,11 @@ fi
 
 # run the RECO step
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd ) # workaround to have ctests working
-k4run $SCRIPT_DIR/ALLEGRO_o1_v03_digi_reco.py
+if [ "$usePythia" -gt 0 ]; then
+  k4run $SCRIPT_DIR/ALLEGRO_o1_v03_digi_reco.py
+else
+  k4run $SCRIPT_DIR/ALLEGRO_o1_v03_digi_reco.py --EventDataSvc.input=ALLEGRO_sim_e_barrel.root --out.filename=ALLEGRO_sim_digi_reco_e_barrel.root || exit 1
+  k4run $SCRIPT_DIR/ALLEGRO_o1_v03_digi_reco.py --EventDataSvc.input=ALLEGRO_sim_e_endcap.root --out.filename=ALLEGRO_sim_digi_reco_e_endcap.root || exit 1
+  k4run $SCRIPT_DIR/ALLEGRO_o1_v03_digi_reco.py --EventDataSvc.input=ALLEGRO_sim_pi_barrel.root --out.filename=ALLEGRO_sim_digi_reco_pi_barrel.root || exit 1
+  k4run $SCRIPT_DIR/ALLEGRO_o1_v03_digi_reco.py --EventDataSvc.input=ALLEGRO_sim_pi_endcap.root --out.filename=ALLEGRO_sim_digi_reco_pi_endcap.root || exit 1
+fi

--- a/RecFCCeeCalorimeter/tests/options/ALLEGRO_o1_v03_digi_reco.py
+++ b/RecFCCeeCalorimeter/tests/options/ALLEGRO_o1_v03_digi_reco.py
@@ -150,6 +150,8 @@ if addCrosstalk:
     readCrosstalkMap = ReadCaloCrosstalkMap("ReadCrosstalkMap",
                                             fileName="https://fccsw.web.cern.ch/fccsw/filesForSimDigiReco/ALLEGRO/ALLEGRO_o1_v03/xtalk_neighbours_map_ecalB_thetamodulemerged.root",
                                             OutputLevel=INFO)
+else:
+    readCrosstalkMap = None
 
 # Create cells in ECal barrel (needed if one wants to apply cell calibration,
 # which is not performed by ddsim)


### PR DESCRIPTION
Implements some style suggestion from the previous PR moving scripts to ddsim+k4run (https://github.com/HEP-FCC/k4RecCalorimeter/pull/109) and fixes a couple of small bugs in those scripts
Also implements an option to run over particle gun samples instead of Pythia Z->qq (the latter is the default, but the former can be useful for some local tests)