### PR TITLE
fix noise filtering bug in calo digitisation, and restore defaults

### DIFF
--- a/RecCalorimeter/src/components/CreateCaloCells.cpp
+++ b/RecCalorimeter/src/components/CreateCaloCells.cpp
@@ -70,6 +70,12 @@ StatusCode CreateCaloCells::initialize() {
       error() << "Unable to create empty cells!" << endmsg;
       return StatusCode::FAILURE;
     }
+    verbose() << "Initialised empty cell map with size " << m_cellsMap.size() << endmsg;
+    // noise filtering erases cells from the cell map after each event, so we need
+    // to backup the empty cell map for later reuse
+    if (m_addCellNoise && m_filterCellNoise) {
+      m_emptyCellsMap = m_cellsMap;
+    }
   }
   if (m_addPosition){
     m_volman = m_geoSvc->getDetector()->volumeManager();

--- a/RecCalorimeter/src/components/CreateCaloCells.h
+++ b/RecCalorimeter/src/components/CreateCaloCells.h
@@ -28,7 +28,7 @@ class IGeoSvc;
 /** @class CreateCaloCells
  *
  *  Algorithm for creating calorimeter cells from Geant4 hits.
- *  Tube geometry with ModuleThetaMerged segmentation expected.
+ *  Tube geometry with PhiEta segmentation expected.
  *
  *  Flow of the program:
  *  1/ Merge Geant4 energy deposits with same cellID
@@ -70,7 +70,7 @@ private:
   /// Handle for the calorimeter cells noise tool
   mutable ToolHandle<INoiseCaloCellsTool> m_noiseTool{"NoiseCaloCellsFlatTool", this};
   /// Handle for the geometry tool
-  ToolHandle<ICalorimeterTool> m_geoTool{"TubeLayerModuleThetaMergedCaloTool", this};
+  ToolHandle<ICalorimeterTool> m_geoTool{"TubeLayerPhiEtaCaloTool", this};
 
   /// Add crosstalk to cells?
   Gaudi::Property<bool> m_addCrosstalk{this, "addCrosstalk", false, "Add crosstalk effect?"};
@@ -92,7 +92,7 @@ private:
   mutable DataHandle<edm4hep::CalorimeterHitCollection> m_cells{"cells", Gaudi::DataHandle::Writer, this};
   MetaDataHandle<std::string> m_cellsCellIDEncoding{m_cells, edm4hep::labels::CellIDEncoding, Gaudi::DataHandle::Writer};
   /// Name of the detector readout
-  Gaudi::Property<std::string> m_readoutName{this, "readoutName", "ECalBarrelModuleThetaMerged", "Name of the detector readout"};
+  Gaudi::Property<std::string> m_readoutName{this, "readoutName", "ECalBarrelPhiEta", "Name of the detector readout"};
   /// Name of active volumes
   Gaudi::Property<std::string> m_activeVolumeName{this, "activeVolumeName", "_sensitive", "Name of the active volumes"};
   /// Name of active layers for sampling calorimeter
@@ -116,7 +116,7 @@ private:
    * This property won't be needed anymore.
    */
   unsigned int m_activeVolumesNumber;
-  /// Use only volume ID? If false, using ModuleThetaMergedSegmentation
+  /// Use only volume ID? If false, using PhiEtaSegmentation
   bool m_useVolumeIdOnly;
 
   /// Pointer to the geometry service
@@ -126,6 +126,8 @@ private:
   mutable std::unordered_map<uint64_t, double> m_cellsMap;
   /// Maps of cell IDs (corresponding to DD4hep IDs) on transfer of signals due to crosstalk
   mutable std::unordered_map<uint64_t, double> m_CrosstalkCellsMap;
+  /// Maps of cell IDs with zero energy, for all cells in calo (needed if addCellNoise and filterCellNoise are both set)
+  mutable std::unordered_map<uint64_t, double> m_emptyCellsMap;
 };
 
 #endif /* RECCALORIMETER_CREATECALOCELLS_H */

--- a/RecCalorimeter/src/components/CreatePositionedCaloCells.cpp
+++ b/RecCalorimeter/src/components/CreatePositionedCaloCells.cpp
@@ -68,6 +68,12 @@ StatusCode CreatePositionedCaloCells::initialize() {
       error() << "Unable to create empty cells!" << endmsg;
       return StatusCode::FAILURE;
     }
+    verbose() << "Initialised empty cell map with size " << m_cellsMap.size() << endmsg;
+    // noise filtering erases cells from the cell map after each event, so we need
+    // to backup the empty cell map for later reuse
+    if (m_addCellNoise && m_filterCellNoise) {
+      m_emptyCellsMap = m_cellsMap;
+    }
   }
 
   // Copy over the CellIDEncoding string from the input collection to the output collection
@@ -88,7 +94,14 @@ StatusCode CreatePositionedCaloCells::execute(const EventContext&) const {
 
   // 0. Clear all cells
   if (m_addCellNoise) {
-    std::for_each(m_cellsMap.begin(), m_cellsMap.end(), [](std::pair<const uint64_t, double>& p) { p.second = 0; });
+    // if cells are not filtered, the map has same size in each event, equal to the total number
+    // of cells in the calorimeter, so we can just reset the values to 0
+    // if cells are filtered, during each event they are removed from the cellsMap, so one has to
+    // restore the initial map of all empty cells
+    if (!m_filterCellNoise)
+      std::for_each(m_cellsMap.begin(), m_cellsMap.end(), [](std::pair<const uint64_t, double>& p) { p.second = 0; });
+    else
+      m_cellsMap = m_emptyCellsMap;
   } else {
     m_cellsMap.clear();
   }

--- a/RecCalorimeter/src/components/CreatePositionedCaloCells.h
+++ b/RecCalorimeter/src/components/CreatePositionedCaloCells.h
@@ -89,7 +89,8 @@ private:
   mutable std::unordered_map<uint64_t, double> m_cellsMap;
   /// Maps of cell IDs (corresponding to DD4hep IDs) on transfer of signals due to crosstalk
   mutable std::unordered_map<uint64_t, double> m_crosstalkCellsMap;
-
+  /// Maps of cell IDs with zero energy, for all cells in calo (needed if addNoise and filterNoise are both set)
+  mutable std::unordered_map<uint64_t, double> m_emptyCellsMap;
   /// Cache position vs cellID
   mutable std::unordered_map<dd4hep::DDSegmentation::CellID, edm4hep::Vector3f> m_positions_cache{};
 };


### PR DESCRIPTION
In the calo digitisation classes, when noise filtering is on, the cells which actually get populated with noise becomes smaller and smaller event after event due to the fact that the filtered cells are removed from the cell map (from e.g. this: https://github.com/HEP-FCC/k4RecCalorimeter/blob/af83315a749bf118e9b499b75cbb3904f6d07ef6/RecCalorimeter/src/components/NoiseCaloCellsFromFileTool.cpp#L110) and never re-added at the beginning of the next event. 

This PR fixes the problem. 

Also, a PR recently merged (#107) changed some default values of the properties of CreateCaloCells. Even though those are configurables and can be modified at python level, for backward compatibility I'd rather restore the original values as mentioned here https://github.com/HEP-FCC/k4RecCalorimeter/pull/107#issuecomment-2348741613

@kjvbrt I think @BrieucF is still on vacation so could you please have a look? Since it's a bug fix this is quite urgent. When merged I can then open a follow-up PR to fix the things mentioned in https://github.com/HEP-FCC/k4RecCalorimeter/pull/107#issuecomment-2348741613

Thanks, Giovanni