### PR TITLE
fix metadata of topoclusters

### DIFF
--- a/RecCalorimeter/src/components/CaloTopoCluster.cpp
+++ b/RecCalorimeter/src/components/CaloTopoCluster.cpp
@@ -7,7 +7,7 @@
 // k4geo
 #include "detectorCommon/DetUtils_k4geo.h"
 
-// datamodel
+// EDM4HEP
 #include "edm4hep/Cluster.h"
 #include "edm4hep/ClusterCollection.h"
 #include "edm4hep/CalorimeterHit.h"
@@ -79,6 +79,11 @@ StatusCode CaloTopoCluster::initialize() {
       return StatusCode::FAILURE;
     }
   }
+
+  // initialise the list of metadata for the clusters
+  std::vector<std::string> shapeParameterNames = {"dR_over_E"};
+  m_shapeParametersHandle.put(shapeParameterNames);
+
   return StatusCode::SUCCESS;
 }
 

--- a/RecCalorimeter/src/components/CaloTopoCluster.h
+++ b/RecCalorimeter/src/components/CaloTopoCluster.h
@@ -5,8 +5,9 @@
 #include "Gaudi/Algorithm.h"
 #include "GaudiKernel/ToolHandle.h"
 
-// k4FWCore
+// Key4HEP
 #include "k4FWCore/DataHandle.h"
+#include "k4FWCore/MetaDataHandle.h"
 #include "k4Interface/ICaloReadCellNoiseMap.h"
 #include "k4Interface/ICaloReadNeighboursMap.h"
 #include "k4Interface/ICalorimeterTool.h"
@@ -15,13 +16,14 @@
 
 class IGeoSvc;
 
-// datamodel
+// EDM4HEP
 namespace edm4hep {
 class CalorimeterHit;
 class CalorimeterHitCollection;
 class ClusterCollection;
 }
 
+// DD4HEP
 namespace DD4hep {
 namespace DDSegmentation {
 class Segmentation;
@@ -97,6 +99,11 @@ private:
   mutable DataHandle<edm4hep::ClusterCollection> m_clusterCollection{"calo/clusters", Gaudi::DataHandle::Writer, this};
   // Cluster cells in collection
   mutable DataHandle<edm4hep::CalorimeterHitCollection> m_clusterCellsCollection{"calo/clusterCells", Gaudi::DataHandle::Writer, this};
+  /// Handle for the cluster shape metadata to write
+  MetaDataHandle<std::vector<std::string>> m_shapeParametersHandle{
+    m_clusterCollection,
+    edm4hep::labels::ShapeParameterNames,
+    Gaudi::DataHandle::Writer};
   /// Pointer to the geometry service
   SmartIF<IGeoSvc> m_geoSvc;
   /// Handle for the input tool

--- a/RecFCCeeCalorimeter/src/components/CaloTopoClusterFCCee.cpp
+++ b/RecFCCeeCalorimeter/src/components/CaloTopoClusterFCCee.cpp
@@ -86,6 +86,10 @@ StatusCode CaloTopoClusterFCCee::initialize() {
   m_decoder_ecal = m_geoSvc->getDetector()->readout(m_readoutName).idSpec().decoder();
   m_index_layer_ecal = m_decoder_ecal->index("layer");
 
+  // initialise the list of metadata for the clusters
+  std::vector<std::string> shapeParameterNames = {"dR_over_E"};
+  m_shapeParametersHandle.put(shapeParameterNames);
+
   return StatusCode::SUCCESS;
 }
 

--- a/RecFCCeeCalorimeter/src/components/CaloTopoClusterFCCee.h
+++ b/RecFCCeeCalorimeter/src/components/CaloTopoClusterFCCee.h
@@ -10,8 +10,9 @@
 #include "Gaudi/Algorithm.h"
 #include "GaudiKernel/ToolHandle.h"
 
-// k4FWCore
+// Key4HEP
 #include "k4FWCore/DataHandle.h"
+#include "k4FWCore/MetaDataHandle.h"
 #include "k4Interface/ICaloReadCellNoiseMap.h"
 #include "k4Interface/ICaloReadNeighboursMap.h"
 #include "k4Interface/ICalorimeterTool.h"
@@ -21,13 +22,14 @@
 // k4SimGeant4
 class IGeoSvc;
 
-// Datamodel
+// EDM4HEP
 namespace edm4hep {
 class CalorimeterHit;
 class CalorimeterHitCollection;
 class ClusterCollection;
 }
 
+// DD4HEP
 namespace DD4hep {
 namespace DDSegmentation {
 class Segmentation;
@@ -102,6 +104,11 @@ private:
   mutable DataHandle<edm4hep::ClusterCollection> m_clusterCollection{"calo/clusters", Gaudi::DataHandle::Writer, this};
   // Cluster cells in collection
   mutable DataHandle<edm4hep::CalorimeterHitCollection> m_clusterCellsCollection{"calo/clusterCells", Gaudi::DataHandle::Writer, this};
+  /// Handle for the cluster shape metadata to write
+  MetaDataHandle<std::vector<std::string>> m_shapeParametersHandle{
+    m_clusterCollection,
+    edm4hep::labels::ShapeParameterNames,
+    Gaudi::DataHandle::Writer};
   /// Pointer to the geometry service
   SmartIF<IGeoSvc> m_geoSvc;
   /// Handle for the input tool


### PR DESCRIPTION
The topoclustering algorithm adds a shape parameter to the output cluster collection (https://github.com/HEP-FCC/k4RecCalorimeter/blob/b571f7c49595b4b99f98857ef54014658cb51abc/RecFCCeeCalorimeter/src/components/CaloTopoClusterFCCee.cpp#L225) but it does not declare it in the metadata information of the clusters. Downstream algorithms such as AugmentClustersFCCee append metadata and shape parameters, and algorithms such as MVA calibration or photon ID look at the metadata to identify the position of the input features. The missing info in the topocluster metadata screws up the latter algorithms, as the real input features to be used are shifted by +1 with respect to what the tools extract from the metadata.
This PR fixes the problem by adding proper metadata info to the topoclusters.