### PR TITLE
Removing CentOs7 from the test matrix

### DIFF
--- a/.github/workflows/key4hep-build.yaml
+++ b/.github/workflows/key4hep-build.yaml
@@ -12,10 +12,7 @@ jobs:
     strategy:
       matrix:
         build_type: ["release", "nightly"]
-        image: ["alma9", "ubuntu22", "centos7"]
-        exclude:
-          - build_type: "nightly"
-            image: "centos7"
+        image: ["alma9", "ubuntu22"]
       fail-fast: false
     runs-on: ubuntu-latest
     steps:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # k4RecCalorimeter - Key4hep Framework Components for Calorimeter Reconstruction
 
+![key4hep-build](https://github.com/HEP-FCC/FCCAnalyses/actions/workflows/key4hep-build.yaml/badge.svg)
+
 The components are available from the Key4hep stack on machines with CVMFS.
 
 ```


### PR DESCRIPTION
Adds also build status badge.