### PR TITLE
Include "edm4hep/Constants.h" where it's needed

### DIFF
--- a/RecCalorimeter/src/components/CaloTopoCluster.h
+++ b/RecCalorimeter/src/components/CaloTopoCluster.h
@@ -5,6 +5,8 @@
 #include "Gaudi/Algorithm.h"
 #include "GaudiKernel/ToolHandle.h"
 
+#include "edm4hep/Constants.h"
+
 // Key4HEP
 #include "k4FWCore/DataHandle.h"
 #include "k4FWCore/MetaDataHandle.h"

--- a/RecCalorimeter/src/components/CreatePositionedCaloCells.h
+++ b/RecCalorimeter/src/components/CreatePositionedCaloCells.h
@@ -1,6 +1,9 @@
 #ifndef RECCALORIMETER_CREATEPOSITIONEDCALOCELLS_H
 #define RECCALORIMETER_CREATEPOSITIONEDCALOCELLS_H
 
+
+#include "edm4hep/Constants.h"
+
 // k4FWCore
 #include "k4FWCore/DataHandle.h"
 #include "k4FWCore/MetaDataHandle.h"

--- a/RecFCCeeCalorimeter/src/components/AugmentClustersFCCee.h
+++ b/RecFCCeeCalorimeter/src/components/AugmentClustersFCCee.h
@@ -1,6 +1,8 @@
 #ifndef RECFCCEECALORIMETER_AUGMENTCLUSTERSFCCEE_H
 #define RECFCCEECALORIMETER_AUGMENTCLUSTERSFCCEE_H
 
+#include "edm4hep/Constants.h"
+
 // Key4HEP
 #include "k4FWCore/DataHandle.h"
 #include "k4FWCore/MetaDataHandle.h"

--- a/RecFCCeeCalorimeter/src/components/CalibrateCaloClusters.h
+++ b/RecFCCeeCalorimeter/src/components/CalibrateCaloClusters.h
@@ -1,6 +1,8 @@
 #ifndef RECFCCEECALORIMETER_CALIBRATECALOCLUSTERS_H
 #define RECFCCEECALORIMETER_CALIBRATECALOCLUSTERS_H
 
+#include "edm4hep/Constants.h"
+
 // Key4HEP
 #include "k4FWCore/DataHandle.h"
 #include "k4FWCore/MetaDataHandle.h"

--- a/RecFCCeeCalorimeter/src/components/CaloTopoClusterFCCee.h
+++ b/RecFCCeeCalorimeter/src/components/CaloTopoClusterFCCee.h
@@ -10,6 +10,8 @@
 #include "Gaudi/Algorithm.h"
 #include "GaudiKernel/ToolHandle.h"
 
+#include "edm4hep/Constants.h"
+
 // Key4HEP
 #include "k4FWCore/DataHandle.h"
 #include "k4FWCore/MetaDataHandle.h"

--- a/RecFCCeeCalorimeter/src/components/PhotonIDTool.h
+++ b/RecFCCeeCalorimeter/src/components/PhotonIDTool.h
@@ -1,6 +1,9 @@
 #ifndef RECFCCEECALORIMETER_PHOTONIDTOOL_H
 #define RECFCCEECALORIMETER_PHOTONIDTOOL_H
 
+
+#include "edm4hep/Constants.h"
+
 // Key4HEP
 #include "k4FWCore/DataHandle.h"
 #include "k4FWCore/MetaDataHandle.h"


### PR DESCRIPTION
After https://github.com/key4hep/k4FWCore/pull/253, `DataHandle.h` will not include `edm4hep/Constants.h` (it should never have because it wasn't being used at least for the last versions) so now this include will need to happen wherever some label from `edm4hep::labels` is used.