### PR TITLE
Fix compiler warnings

### DIFF
--- a/RecCalorimeter/src/components/CaloTopoClusterInputTool.cpp
+++ b/RecCalorimeter/src/components/CaloTopoClusterInputTool.cpp
@@ -42,7 +42,7 @@ StatusCode CaloTopoClusterInputTool::initialize() {
 StatusCode CaloTopoClusterInputTool::finalize() { return AlgTool::finalize(); }
 
 StatusCode CaloTopoClusterInputTool::cellIDMap(std::unordered_map<uint64_t, double>& aCells) {
-  uint totalNumberOfCells = 0;
+  [[maybe_unused]] uint totalNumberOfCells = 0;
 
   // 1. ECAL barrel
   // Get the input collection with calorimeter cells

--- a/RecCalorimeter/src/components/CaloTowerTool.cpp
+++ b/RecCalorimeter/src/components/CaloTowerTool.cpp
@@ -443,8 +443,6 @@ std::pair<dd4hep::DDSegmentation::Segmentation*, CaloTowerTool::SegmentationType
 void CaloTowerTool::attachCells(float eta, float phi, uint halfEtaFin, uint halfPhiFin, edm4hep::MutableCluster& aEdmCluster, edm4hep::CalorimeterHitCollection* aEdmClusterCells, bool aEllipse) {
   int etaId = idEta(eta);
   int phiId = idPhi(phi);
-  int num1 = 0;
-  int num2 = 0;
   std::vector<dd4hep::DDSegmentation::CellID> seen_cellIDs;
   if (aEllipse) {
     for (int iEta = etaId - halfEtaFin; iEta <= int(etaId + halfEtaFin); iEta++) {
@@ -458,7 +456,6 @@ void CaloTowerTool::attachCells(float eta, float phi, uint halfEtaFin, uint half
             auto cellclone = cell.clone();
             aEdmClusterCells->push_back(cellclone);
             aEdmCluster.addToHits(cellclone);
-            num1++;
           }
         }
       }
@@ -474,7 +471,6 @@ void CaloTowerTool::attachCells(float eta, float phi, uint halfEtaFin, uint half
           auto cellclone = cell.clone();
           aEdmClusterCells->push_back(cellclone);
           aEdmCluster.addToHits(cellclone);
-          num2++;
         }
       }
     }

--- a/RecCalorimeter/src/components/CreateCaloCells.h
+++ b/RecCalorimeter/src/components/CreateCaloCells.h
@@ -110,15 +110,6 @@ private:
                                                   "to to change segmentation (e.g. ID of the "
                                                   "ECal)"};
 
-  /** Temporary: for use with MergeLayer tool
-   * MergeLayer is going to be replaced by RedoSegmentation once we can define
-   * segmentation with variable cell (layer) size.
-   * This property won't be needed anymore.
-   */
-  unsigned int m_activeVolumesNumber;
-  /// Use only volume ID? If false, using PhiEtaSegmentation
-  bool m_useVolumeIdOnly;
-
   /// Pointer to the geometry service
   ServiceHandle<IGeoSvc> m_geoSvc;
   dd4hep::VolumeManager m_volman;

--- a/RecCalorimeter/src/components/CreateCaloCellsNoise.h
+++ b/RecCalorimeter/src/components/CreateCaloCellsNoise.h
@@ -97,16 +97,6 @@ private:
                                                   "Value of the field that identifies the volume "
                                                   "to to change segmentation (e.g. ID of the "
                                                   "ECal)"};
-
-  /** Temporary: for use with MergeLayer tool
-   * MergeLayer is going to be replaced by RedoSegmentation once we can define
-   * segmentation with variable cell (layer) size.
-   * This property won't be needed anymore.
-   */
-  unsigned int m_activeVolumesNumber;
-  /// Use only volume ID? If false, using PhiEtaSegmentation
-  bool m_useVolumeIdOnly;
-
   /// Pointer to the geometry service
   ServiceHandle<IGeoSvc> m_geoSvc;
   dd4hep::VolumeManager m_volman;

--- a/RecCalorimeter/src/components/CreateCaloClusters.cpp
+++ b/RecCalorimeter/src/components/CreateCaloClusters.cpp
@@ -271,8 +271,6 @@ StatusCode CreateCaloClusters::execute(const EventContext&) const {
 	      posCell = m_cellPositionsHCalTool->xyzPosition(cellId);
 	    if ( !calibECal && !m_doCryoCorrection)
 	      cellEnergy = cellEnergy * (1/m_ehHCal);
-	    else if ( m_doCryoCorrection )
-	      cellEnergy = cellEnergy;
 	  }
 
 	  newCell.setEnergy(cellEnergy);

--- a/RecCalorimeter/src/components/CreateCaloClusters.h
+++ b/RecCalorimeter/src/components/CreateCaloClusters.h
@@ -79,8 +79,6 @@ private:
   /// Handle for tool to get positions in HCal Barrel and Ext Barrel, no Segmentation
   ToolHandle<ICellPositionsTool> m_cellPositionsHCalNoSegTool{"CellPositionsHCalBarrelNoSegTool", this};
   
-  const char *types[2] = {"EM", "HAD"};
-
   mutable TH1F* m_energyScale;
   mutable TH1F* m_benchmark;
   mutable TH1F* m_fractionEMcluster;

--- a/RecCalorimeter/src/components/LayeredCaloTowerTool.cpp
+++ b/RecCalorimeter/src/components/LayeredCaloTowerTool.cpp
@@ -215,7 +215,7 @@ void LayeredCaloTowerTool::attachCells(float eta, float phi, uint halfEtaFin, ui
   for (const auto& cell : *cells) {
     float etaCell = m_segmentation->eta(cell.getCellID());
     float phiCell = m_segmentation->phi(cell.getCellID());
-    if ((abs(static_cast<long int>(idEta(etaCell)) - static_cast<long int>(idEta(eta))) <= halfEtaFin) && (abs(static_cast<long int>(idPhi(phiCell)) - static_cast<long int>(idPhi(phi))) <= halfPhiFin)) {
+    if ((std::abs(static_cast<long int>(idEta(etaCell)) - static_cast<long int>(idEta(eta))) <= halfEtaFin) && (std::abs(static_cast<long int>(idPhi(phiCell)) - static_cast<long int>(idPhi(phi))) <= halfPhiFin)) {
       aEdmClusterCells->push_back(cell);
       aEdmCluster.addToHits(aEdmClusterCells->at(aEdmClusterCells->size() - 1));
     }

--- a/RecCalorimeter/src/components/PreparePileup.cpp
+++ b/RecCalorimeter/src/components/PreparePileup.cpp
@@ -131,7 +131,7 @@ StatusCode PreparePileup::initialize() {
   debug() << "Number of calorimeter towers (eta x phi) : " << m_nEtaTower << " x " << m_nPhiTower << endmsg;
   // OPTIMISATION OF CLUSTER SIZE
   // sanity check
-  if (!(m_nEtaFinal.size() == 0 && m_nPhiFinal.size() == 0) & !(m_nEtaFinal.size() == m_numLayers && m_nPhiFinal.size() == m_numLayers)) {
+  if (!(m_nEtaFinal.size() == 0 && m_nPhiFinal.size() == 0) && !(m_nEtaFinal.size() == m_numLayers && m_nPhiFinal.size() == m_numLayers)) {
     error() << "Size of optimised window should be equal to number of layers or empty" << endmsg;
     return StatusCode::FAILURE;
   }

--- a/RecFCCeeCalorimeter/src/components/CaloTowerToolFCCee.cpp
+++ b/RecFCCeeCalorimeter/src/components/CaloTowerToolFCCee.cpp
@@ -379,8 +379,6 @@ std::pair<dd4hep::DDSegmentation::Segmentation*, CaloTowerToolFCCee::Segmentatio
 void CaloTowerToolFCCee::attachCells(float theta, float phi, uint halfThetaFin, uint halfPhiFin, edm4hep::MutableCluster& aEdmCluster, edm4hep::CalorimeterHitCollection* aEdmClusterCells, bool aEllipse) {
   int thetaId = idTheta(theta);
   int phiId = idPhi(phi);
-  int num1 = 0;
-  int num2 = 0;
   std::vector<dd4hep::DDSegmentation::CellID> seen_cellIDs;
   if (aEllipse) {
     for (int iTheta = thetaId - halfThetaFin; iTheta <= int(thetaId + halfThetaFin); iTheta++) {
@@ -394,7 +392,6 @@ void CaloTowerToolFCCee::attachCells(float theta, float phi, uint halfThetaFin, 
             auto cellclone = cell.clone();
             aEdmClusterCells->push_back(cellclone);
             aEdmCluster.addToHits(cellclone);
-            num1++;
           }
         }
       }
@@ -410,7 +407,6 @@ void CaloTowerToolFCCee::attachCells(float theta, float phi, uint halfThetaFin, 
           auto cellclone = cell.clone();
           aEdmClusterCells->push_back(cellclone);
           aEdmCluster.addToHits(cellclone);
-          num2++;
         }
       }
     }


### PR DESCRIPTION
We should enable the same warnings as in Key4hep probably, but that's left for another time. Maybe it's good if some people have a look at the warnings in case the expectations were different from what the code was doing. In particular here: https://github.com/HEP-FCC/k4RecCalorimeter/pull/125/files#diff-0341e38011283eda958d6139213699c31fe2f8e76825d208ea0691a0d3529216L274-L275, where a variable was being set to itself.