### PR TITLE
Update for changes in allegro ecal segmentation.

### DIFF
--- a/RecFCCeeCalorimeter/src/components/CellPositionsECalBarrelModuleThetaSegTool.h
+++ b/RecFCCeeCalorimeter/src/components/CellPositionsECalBarrelModuleThetaSegTool.h
@@ -59,8 +59,6 @@ private:
   Gaudi::Property<std::string> m_readoutName{this, "readoutName", "ECalBarrelModuleThetaMerged"};
   /// Merged module-theta segmentation
   dd4hep::DDSegmentation::FCCSWGridModuleThetaMerged_k4geo* m_segmentation;
-  /// Cellid decoder
-  dd4hep::DDSegmentation::BitFieldCoder* m_decoder;
   /// Volume manager
   dd4hep::VolumeManager m_volman;
 };


### PR DESCRIPTION
The allegro ecal segmentation class has been changed to properly return a position in the volume-local coordinate system.  Remove the workaround here that was dealing with what the segmentation used to return.



BEGINRELEASENOTES
- Update cell position calculation for Allegro ECal to go along with changes in k4geo.
ENDRELEASENOTES
