### PR TITLE
Update CMakeLists.txt to use Key4hepConfig

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,17 +12,6 @@ if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
     "Install path prefix, prepended onto install directories." FORCE )
 endif()
 
-# Set up C++ Standard
-# ``-DCMAKE_CXX_STANDARD=<standard>`` when invoking CMake
-set(CMAKE_CXX_STANDARD 17 CACHE STRING "")
-if(NOT CMAKE_CXX_STANDARD MATCHES "17|20")
-  message(FATAL_ERROR "Unsupported C++ standard: ${CMAKE_CXX_STANDARD}")
-endif()
-
-if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fdiagnostics-color=always -Wno-dangling-reference")
-endif()
-
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake ${CMAKE_MODULE_PATH})
 
 
@@ -49,13 +38,7 @@ endif()
 
 #---------------------------------------------------------------
 
-
-#--- The genConf directory has been renamed to genConfDir in Gaudi 35r1
-#--- See https://gitlab.cern.ch/gaudi/Gaudi/-/merge_requests/1158
 set(GAUDI_GENCONF_DIR "genConfDir")
-if (${Gaudi_VERSION} VERSION_LESS 35.1)
-  set(GAUDI_GENCONF_DIR "genConf")
-endif()
 
 function(set_test_env _testname)
   set_property(TEST ${_testname} APPEND PROPERTY ENVIRONMENT


### PR DESCRIPTION
BEGINRELEASENOTES
- Update CMakeLists.txt to use Key4hepConfig. It had already been added to solve a problem with rpaths but some settings related to the standard from before it was added were still there.

ENDRELEASENOTES