### PR TITLE
Create noise map for new HCal segmentations

### DIFF
--- a/RecFCCeeCalorimeter/src/components/CreateFCCeeCaloNoiseLevelMap.h
+++ b/RecFCCeeCalorimeter/src/components/CreateFCCeeCaloNoiseLevelMap.h
@@ -45,22 +45,25 @@ private:
   ToolHandle<INoiseConstTool> m_ecalEndcapNoiseTool{"ReadNoiseFromFileTool", this};
   /// Handle for the cells noise tool in HCal
   ToolHandle<INoiseConstTool> m_hcalBarrelNoiseTool{"ReadNoiseFromFileTool", this};
+  /// Handle for the cells noise tool in HCal
+  ToolHandle<INoiseConstTool> m_hcalEndcapNoiseTool{"ReadNoiseFromFileTool", this};
 
   // System ID of ECAL and HCAL detectors
   Gaudi::Property<uint> m_ecalBarrelSysId{this, "ecalBarrelSysId", 4};
   Gaudi::Property<uint> m_ecalEndcapSysId{this, "ecalEndcapSysId", 5};
   Gaudi::Property<uint> m_hcalBarrelSysId{this, "hcalBarrelSysId", 8};
+  Gaudi::Property<uint> m_hcalEndcapSysId{this, "hcalEndcapSysId", 9};
 
   /// Names of the detector readout for the volumes
-  Gaudi::Property<std::vector<std::string>> m_readoutNamesSegmented{this, "readoutNames", {"ECalBarrelModuleThetaMerged", "ECalEndcapTurbine", "BarHCal_Readout_phitheta"}};
+  Gaudi::Property<std::vector<std::string>> m_readoutNamesSegmented{this, "readoutNames", {"ECalBarrelModuleThetaMerged", "ECalEndcapTurbine", "HCalBarrelReadout","HCalEndcapReadout"}};
   /// Name of the fields describing the segmented volume
-  Gaudi::Property<std::vector<std::string>> m_fieldNamesSegmented{this, "systemNames", {"system", "system", "system"}};
+  Gaudi::Property<std::vector<std::string>> m_fieldNamesSegmented{this, "systemNames", {"system", "system", "system", "system"}};
   /// Values of the fields describing the segmented volume
-  Gaudi::Property<std::vector<int>> m_fieldValuesSegmented{this, "systemValues", {4, 5, 8}};
+  Gaudi::Property<std::vector<int>> m_fieldValuesSegmented{this, "systemValues", {4, 5, 8, 9}};
   /// Names of the active volume in geometry along radial axis (e.g. layer), the others are "module" or "phi", "theta"
-  Gaudi::Property<std::vector<std::string>> m_activeFieldNamesSegmented{this, "activeFieldNames", {"layer", "layer", "layer"}};
+  Gaudi::Property<std::vector<std::string>> m_activeFieldNamesSegmented{this, "activeFieldNames", {"layer", "layer", "layer", "layer"}};
   /// Number of layers in the segmented volumes
-  Gaudi::Property<std::vector<unsigned int>> m_activeVolumesNumbersSegmented{this, "activeVolumesNumbers", {11, 98, 13}};
+  Gaudi::Property<std::vector<unsigned int>> m_activeVolumesNumbersSegmented{this, "activeVolumesNumbers", {11, 98, 13, 37}};
   // Theta ranges of layers in the segmented volumes (if needed)
   Gaudi::Property<std::vector<std::vector<double>>> m_activeVolumesTheta{this, "activeVolumesTheta"};
 


### PR DESCRIPTION

BEGINRELEASENOTES
- The CreateFCCeeCaloNoiseLevelMap tool is updated to create noise map for phi-theta and phi-row HCal segmentations

ENDRELEASENOTES
