### PR TITLE
use INoiseConstTool instead of ICaloReadCellNoiseMap

### DIFF
--- a/RecCalorimeter/src/components/CaloTopoCluster.cpp
+++ b/RecCalorimeter/src/components/CaloTopoCluster.cpp
@@ -227,10 +227,10 @@ void CaloTopoCluster::findingSeeds(const std::unordered_map<uint64_t, double>& a
                                    std::vector<std::pair<uint64_t, double>>& aSeeds) const {
   for (const auto& cell : aCells) {
     // retrieve the noise const and offset assigned to cell
-    double threshold = m_noiseTool->noiseOffset(cell.first) + (m_noiseTool->noiseRMS(cell.first) * aNumSigma);
+    double threshold = m_noiseTool->getNoiseOffsetPerCell(cell.first) + (m_noiseTool->getNoiseRMSPerCell(cell.first) * aNumSigma);
     if (msgLevel() <= MSG::VERBOSE) {
-      verbose() << "noise offset    = " << m_noiseTool->noiseOffset(cell.first) << "GeV " << endmsg;
-      verbose() << "noise rms       = " << m_noiseTool->noiseRMS(cell.first) << "GeV " << endmsg;
+      verbose() << "noise offset    = " << m_noiseTool->getNoiseOffsetPerCell(cell.first) << "GeV " << endmsg;
+      verbose() << "noise rms       = " << m_noiseTool->getNoiseRMSPerCell(cell.first) << "GeV " << endmsg;
       verbose() << "seed threshold  = " << threshold << "GeV " << endmsg;
     }
     if (abs(cell.second) > threshold) {
@@ -333,7 +333,7 @@ std::vector<std::pair<uint64_t, uint>> CaloTopoCluster::searchForNeighbours(
         bool addNeighbour = false;
         int cellType = 2;
         // retrieve the cell noise level [GeV]
-        double thr = m_noiseTool->noiseOffset(neighbourID) + (aNumSigma * m_noiseTool->noiseRMS(neighbourID));
+        double thr = m_noiseTool->getNoiseOffsetPerCell(neighbourID) + (aNumSigma * m_noiseTool->getNoiseRMSPerCell(neighbourID));
         if (abs(neighbouringCellEnergy) > thr)
           addNeighbour = true;
         else

--- a/RecCalorimeter/src/components/CaloTopoCluster.h
+++ b/RecCalorimeter/src/components/CaloTopoCluster.h
@@ -10,7 +10,7 @@
 // Key4HEP
 #include "k4FWCore/DataHandle.h"
 #include "k4FWCore/MetaDataHandle.h"
-#include "k4Interface/ICaloReadCellNoiseMap.h"
+#include "k4Interface/INoiseConstTool.h"
 #include "k4Interface/ICaloReadNeighboursMap.h"
 #include "k4Interface/ICalorimeterTool.h"
 #include "k4Interface/ICellPositionsTool.h"
@@ -115,7 +115,7 @@ private:
   /// Handle for the input tool
   mutable ToolHandle<ITopoClusterInputTool> m_inputTool{"TopoClusterInput", this};
   /// Handle for the cells noise tool
-  mutable ToolHandle<ICaloReadCellNoiseMap> m_noiseTool{"TopoCaloNoisyCells", this};
+  mutable ToolHandle<INoiseConstTool> m_noiseTool{"TopoCaloNoisyCells", this};
   /// Handle for neighbours tool
   mutable ToolHandle<ICaloReadNeighboursMap> m_neighboursTool{"TopoCaloNeighbours", this};
   /// Handle for tool to get positions in ECal Barrel

--- a/RecCalorimeter/src/components/TopoCaloNoisyCells.cpp
+++ b/RecCalorimeter/src/components/TopoCaloNoisyCells.cpp
@@ -9,7 +9,7 @@ DECLARE_COMPONENT(TopoCaloNoisyCells)
 
 TopoCaloNoisyCells::TopoCaloNoisyCells(const std::string& type, const std::string& name, const IInterface* parent)
     : AlgTool(type, name, parent) {
-  declareInterface<ICaloReadCellNoiseMap>(this);
+  declareInterface<INoiseConstTool>(this);
 }
 
 StatusCode TopoCaloNoisyCells::initialize() {
@@ -60,5 +60,5 @@ StatusCode TopoCaloNoisyCells::initialize() {
 
 StatusCode TopoCaloNoisyCells::finalize() { return AlgTool::finalize(); }
 
-double TopoCaloNoisyCells::noiseRMS(uint64_t aCellId) { return m_map[aCellId].first; }
-double TopoCaloNoisyCells::noiseOffset(uint64_t aCellId) { return m_map[aCellId].second; }
+double TopoCaloNoisyCells::getNoiseRMSPerCell(uint64_t aCellId) { return m_map[aCellId].first; }
+double TopoCaloNoisyCells::getNoiseOffsetPerCell(uint64_t aCellId) { return m_map[aCellId].second; }

--- a/RecCalorimeter/src/components/TopoCaloNoisyCells.h
+++ b/RecCalorimeter/src/components/TopoCaloNoisyCells.h
@@ -5,7 +5,7 @@
 #include "GaudiKernel/AlgTool.h"
 
 // k4FWCore
-#include "k4Interface/ICaloReadCellNoiseMap.h"
+#include "k4Interface/INoiseConstTool.h"
 
 class IGeoSvc;
 
@@ -18,7 +18,7 @@ class IGeoSvc;
  *  @author Coralie Neubueser
  */
 
-class TopoCaloNoisyCells : public AlgTool, virtual public ICaloReadCellNoiseMap {
+class TopoCaloNoisyCells : public AlgTool, virtual public INoiseConstTool {
 public:
   TopoCaloNoisyCells(const std::string& type, const std::string& name, const IInterface* parent);
   virtual ~TopoCaloNoisyCells() = default;
@@ -32,13 +32,13 @@ public:
    *   @param[in] aCellId of the cell of interest.
    *   return double.
    */
-  virtual double noiseRMS(uint64_t aCellId) final;
+  virtual double getNoiseRMSPerCell(uint64_t aCellId) final;
 
   /** Expected noise per cell in terms of mean of distibution.
    *   @param[in] aCellId of the cell of interest.
    *   return double.
    */
-  virtual double noiseOffset(uint64_t aCellId) final;
+  virtual double getNoiseOffsetPerCell(uint64_t aCellId) final;
 
 private:
   /// Name

--- a/RecFCCeeCalorimeter/src/components/CaloTopoClusterFCCee.cpp
+++ b/RecFCCeeCalorimeter/src/components/CaloTopoClusterFCCee.cpp
@@ -210,11 +210,13 @@ CaloTopoClusterFCCee::findSeeds(const edm4hep::CalorimeterHitCollection* allCell
     verbose() << "cellID   = " << cell.getCellID() << endmsg;
 
     // retrieve the noise const and offset assigned to cell
-    double threshold =
-        m_noiseTool->noiseOffset(cell.getCellID()) + (m_noiseTool->noiseRMS(cell.getCellID()) * m_seedSigma);
+    double offset = m_noiseTool->getNoiseOffsetPerCell(cell.getCellID());
+    double rms = m_noiseTool->getNoiseRMSPerCell(cell.getCellID());
+    double threshold = offset + rms * m_seedSigma;
+
     debug() << "======================================" << endmsg;
-    debug() << "noise offset    = " << m_noiseTool->noiseOffset(cell.getCellID()) << " GeV " << endmsg;
-    debug() << "noise rms       = " << m_noiseTool->noiseRMS(cell.getCellID()) << " GeV " << endmsg;
+    debug() << "noise offset    = " << offset << " GeV " << endmsg;
+    debug() << "noise rms       = " << rms << " GeV " << endmsg;
     debug() << "seed threshold  = " << threshold << " GeV " << endmsg;
     debug() << "======================================" << endmsg;
     if (std::fabs(cell.getEnergy()) > threshold) {
@@ -345,7 +347,9 @@ std::vector<std::pair<uint64_t, uint32_t>> CaloTopoClusterFCCee::searchForNeighb
       bool addNeighbour = false;
       int cellType = 2;
       // retrieve the cell noise level [GeV]
-      double thr = m_noiseTool->noiseOffset(neighbourID) + (aNumSigma * m_noiseTool->noiseRMS(neighbourID));
+      double offset = m_noiseTool->getNoiseOffsetPerCell(neighbourID);
+      double rms = m_noiseTool->getNoiseRMSPerCell(neighbourID);
+      double thr = offset + rms * aNumSigma;
       if (std::fabs(neighbouringCellEnergy) > thr)
         addNeighbour = true;
       else

--- a/RecFCCeeCalorimeter/src/components/CaloTopoClusterFCCee.h
+++ b/RecFCCeeCalorimeter/src/components/CaloTopoClusterFCCee.h
@@ -16,7 +16,7 @@
 // Key4HEP
 #include "k4FWCore/DataHandle.h"
 #include "k4FWCore/MetaDataHandle.h"
-#include "k4Interface/ICaloReadCellNoiseMap.h"
+#include "k4Interface/INoiseConstTool.h"
 #include "k4Interface/ICaloReadNeighboursMap.h"
 
 // EDM4HEP
@@ -116,7 +116,7 @@ private:
   MetaDataHandle<std::vector<std::string>> m_shapeParametersHandle{
       m_clusterCollection, edm4hep::labels::ShapeParameterNames, Gaudi::DataHandle::Writer};
   /// Handle for the cells noise tool
-  mutable ToolHandle<ICaloReadCellNoiseMap> m_noiseTool{"TopoCaloNoisyCells", this};
+  mutable ToolHandle<INoiseConstTool> m_noiseTool{"TopoCaloNoisyCells", this};
   /// Handle for neighbours tool
   mutable ToolHandle<ICaloReadNeighboursMap> m_neighboursTool{"TopoCaloNeighbours", this};
 


### PR DESCRIPTION
INoiseConstTool and ICaloReadCellNoiseMap interfaces in k4FWCore provide identical functionality.
After this PR is merged we can remove the latter.
I have checked the ICaloReadCellNoiseMap is used only in those few places: https://github.com/search?q=ICaloReadCellNoiseMap&type=code
I have run the reconstruction before and after these changes and the topocluster distributions are identical

Needed by https://github.com/key4hep/k4FWCore/pull/299

BEGINRELEASENOTES
- use INoiseConstTool instead of ICaloReadCellNoiseMap so that we can remove ICaloReadCellNoiseMap interface from k4FWCore (they were both providing the same functionality)

ENDRELEASENOTES
