### PR TITLE
Add resolved pi0 candidate reconstruction algorithm for ALLEGRO ECAL

### DIFF
--- a/RecCalorimeter/src/components/PairCaloClustersPi0.cpp
+++ b/RecCalorimeter/src/components/PairCaloClustersPi0.cpp
@@ -229,7 +229,8 @@ PairCaloClustersPi0::ClusterPairing(const edm4hep::ClusterCollection* inClusters
     edm4hep::Vector3d position2(outCluster2.getPosition().x, outCluster2.getPosition().y, outCluster2.getPosition().z);
     edm4hep::Vector3d momentum1=PairCaloClustersPi0::projectMomentum( outCluster1.getEnergy(), position1, edm4hep::Vector3d(0,0,0));
     edm4hep::Vector3d momentum2=PairCaloClustersPi0::projectMomentum( outCluster2.getEnergy(), position2, edm4hep::Vector3d(0,0,0));
-    verbose() << "Final pairing " << i << " first cluster = " << bestcombi_pairs[i].first << ", second cluster =  " << bestcombi_pairs[i].second << ", invariant mass [GeV] = " << PairCaloClustersPi0::getInvariantMass( outCluster1.getEnergy(), momentum1, outCluster2.getEnergy(), momentum2 ) <<endmsg;
+    double this_pi0_invM=PairCaloClustersPi0::getInvariantMass( outCluster1.getEnergy(), momentum1, outCluster2.getEnergy(), momentum2 );
+    verbose() << "Final pairing " << i << " first cluster = " << bestcombi_pairs[i].first << ", second cluster =  " << bestcombi_pairs[i].second << ", invariant mass [GeV] = " <<  this_pi0_invM <<endmsg;
     
     //edm4hep::Vector3f pi0_momentum(momentum1.x+momentum2.x, momentum1.y+momentum2.y, momentum1.z+momentum2.z);
     edm4hep::MutableReconstructedParticle this_pi0(
@@ -238,7 +239,7 @@ PairCaloClustersPi0::ClusterPairing(const edm4hep::ClusterCollection* inClusters
 	edm4hep::Vector3f(momentum1.x+momentum2.x, momentum1.y+momentum2.y, momentum1.z+momentum2.z),
 	edm4hep::Vector3f(0,0,0),
 	0.,
-	0.1349770, // pi0 mass taken from https://pdg.lbl.gov/2018/listings/rpp2018-list-pi-zero.pdf
+	this_pi0_invM,
 	0.,
 	edm4hep::CovMatrix4f()
 	);

--- a/RecCalorimeter/src/components/PairCaloClustersPi0.cpp
+++ b/RecCalorimeter/src/components/PairCaloClustersPi0.cpp
@@ -10,7 +10,7 @@ PairCaloClustersPi0::PairCaloClustersPi0(const std::string& name, ISvcLocator* s
   declareProperty("inClusters", m_inClusters, "Input cluster collection");
   declareProperty("reconstructedPi0", m_reconstructedPi0, "Output1: Reconstructed pi0 collection");
   declareProperty("unpairedClusters", m_unpairedClusters, "Output2: Unpaired cluster collection");
-  declareProperty("pairedClusters", m_pairedClusters, "Outpu3: Paired cluster collection");
+  declareProperty("pairedClusters", m_pairedClusters, "Output3: Paired cluster collection");
 }
 
 StatusCode PairCaloClustersPi0::initialize() {

--- a/RecCalorimeter/src/components/PairCaloClustersPi0.cpp
+++ b/RecCalorimeter/src/components/PairCaloClustersPi0.cpp
@@ -1,0 +1,247 @@
+#include "PairCaloClustersPi0.h"
+
+// Include the <cmath> header for sqrt, pow
+#include <cmath>
+
+DECLARE_COMPONENT(PairCaloClustersPi0)
+
+PairCaloClustersPi0::PairCaloClustersPi0(const std::string& name, ISvcLocator* svcLoc)
+    : Gaudi::Algorithm(name, svcLoc) {
+  declareProperty("inClusters", m_inClusters, "Input cluster collection");
+  declareProperty("pairedClusters", m_pairedClusters, "Outpu1: Paired cluster collection");
+  declareProperty("unpairedClusters", m_unpairedClusters, "Output2: Unpaired cluster collection");
+}
+
+StatusCode PairCaloClustersPi0::initialize() {
+  {
+    StatusCode sc = Gaudi::Algorithm::initialize();
+    if (sc.isFailure()) {
+      return sc;
+    }
+    /*
+    // Initialize random service
+    m_randSvc = service("RndmGenSvc", false);
+    if (!m_randSvc) {
+      error() << "Couldn't get RndmGenSvc!!!!" << endmsg;
+      return StatusCode::FAILURE;
+    }
+    // Initialize binary random number generator
+    if (m_bit.initialize(m_randSvc, Rndm::Bit()).isFailure()) {
+      error() << "Couldn't initialize RndmGenSvc!!!!" << endmsg;
+      return StatusCode::FAILURE;
+    }
+    */
+  }
+
+  // print pi0 mass window
+  info() << "pi0 mass window for cluster pairing: [" <<m_massLow<<","<<m_massHigh<<"] GeV, peak= "<<m_massPeak<<" GeV"<< endmsg;
+
+  return StatusCode::SUCCESS;
+}
+
+StatusCode PairCaloClustersPi0::execute(const EventContext&) const {
+  verbose() << "-------------------------------------------" << endmsg;
+
+  // Get the input collection with clusters
+  const edm4hep::ClusterCollection* inClusters = m_inClusters.get();
+
+  // Initialize output clusters
+  edm4hep::ClusterCollection* outClusters = ClusterPairing(inClusters, m_massPeak, m_massLow, m_massHigh);
+
+  if (!outClusters) {
+    error() << "Something went wrong in initialization of the output cluster collection, exiting!" << endmsg;
+    return StatusCode::FAILURE;
+  }
+
+  return StatusCode::SUCCESS;
+}
+
+StatusCode PairCaloClustersPi0::finalize() { return Gaudi::Algorithm::finalize(); }
+
+// calculation of invariant mass
+double PairCaloClustersPi0::getInvariantMass(
+    double E1, edm4hep::Vector3d momentum1, double E2, edm4hep::Vector3d momentum2) const{
+  double invM = pow(E1+E2, 2) - pow(momentum1.x+momentum2.x, 2) - pow(momentum1.y+momentum2.y, 2) - pow(momentum1.z+momentum2.z, 2);
+  if (invM>0){
+    invM=sqrt(invM);
+  }
+  else{
+    invM=0;
+  }
+  return invM;
+}
+
+// projection: energy -> 3 momentum of a cluster
+edm4hep::Vector3d PairCaloClustersPi0::projectMomentum(double energy, edm4hep::Vector3d position, edm4hep::Vector3d origin) const{
+  double dirx=position.x-origin.x;
+  double diry=position.y-origin.y;
+  double dirz=position.z-origin.z;
+  double quadsum_dir=pow(dirx,2) + pow(diry,2) + pow(dirz,2);
+  if (quadsum_dir>0){
+    quadsum_dir=sqrt(quadsum_dir);
+    double px=energy * dirx / quadsum_dir;
+    double py=energy * diry / quadsum_dir;
+    double pz=energy * dirz / quadsum_dir;
+    return edm4hep::Vector3d(px, py, pz);
+  }
+  else{
+    return edm4hep::Vector3d(0,0,0);
+  }
+}
+
+// cluster pairing
+edm4hep::ClusterCollection*
+PairCaloClustersPi0::ClusterPairing(const edm4hep::ClusterCollection* inClusters, double masspeak, double masslow, double masshigh) const {
+
+  edm4hep::ClusterCollection* pairedClusters = m_pairedClusters.createAndPut();
+  edm4hep::ClusterCollection* unpairedClusters = m_unpairedClusters.createAndPut();
+
+  // ***** Step 1: Get all possible cluster pairs in the mass window, overlap of clusters allowed *****
+  verbose() << "We are in cluster pairing, step 1" <<endmsg;
+  std::vector<std::pair<size_t, size_t>> vec_AllPossiblePairs;
+  for (size_t i=0; i<inClusters->size(); ++i){
+    double energy_i=inClusters->at(i).getEnergy();
+    edm4hep::Vector3d cluster_i_position3d(inClusters->at(i).getPosition().x, inClusters->at(i).getPosition().y, inClusters->at(i).getPosition().z);
+    edm4hep::Vector3d cluster_i_origin3d(0., 0., 0.);
+    edm4hep::Vector3d cluster_i_momentum=PairCaloClustersPi0::projectMomentum(energy_i, cluster_i_position3d, cluster_i_origin3d);
+    for(size_t j=i+1; j<inClusters->size(); j++){
+      double energy_j=inClusters->at(j).getEnergy();
+      edm4hep::Vector3d cluster_j_position3d(inClusters->at(j).getPosition().x, inClusters->at(j).getPosition().y, inClusters->at(j).getPosition().z);
+      edm4hep::Vector3d cluster_j_origin3d(0., 0., 0.);
+      edm4hep::Vector3d cluster_j_momentum=PairCaloClustersPi0::projectMomentum(energy_j, cluster_j_position3d, cluster_j_origin3d);
+      double invM=PairCaloClustersPi0::getInvariantMass(energy_i, cluster_i_momentum, energy_j, cluster_j_momentum);
+      if (invM>masslow && invM<masshigh){
+	std::pair<size_t, size_t> this_possible_pair=std::make_pair(i,j);
+	vec_AllPossiblePairs.push_back(this_possible_pair);
+      }
+    }
+  }
+  // ***** Step 2: make all possible combinations of cluster pairing without overlap *****
+  verbose() << "We are in cluster pairing step 2" <<endmsg;
+  std::vector<std::vector<std::pair<size_t, size_t>>> vec_combi_pairs;
+  // initialisation
+  for (size_t i=0; i<vec_AllPossiblePairs.size(); i++){
+    std::vector<std::pair<size_t, size_t>> this_combi_pairs;
+    this_combi_pairs.push_back(vec_AllPossiblePairs[i]);
+    vec_combi_pairs.push_back(this_combi_pairs);
+  }
+  verbose() << "Initialisation with all possible pairs, size =  " << vec_combi_pairs.size() <<endmsg;
+  // iterations
+  size_t start_of_iter = 0; // starting index of pair combination in this iteration
+  size_t end_of_iter = vec_combi_pairs.size(); // end index of pair combination in this iteration
+  // run at most (Number of Pairs - 1) iterations to get all combinations
+  for (size_t i_iter=0; i_iter+1<vec_AllPossiblePairs.size(); i_iter++){
+    // in each iteration, loop over relevant pair combinations to this iteration
+    for (size_t i_combi=start_of_iter; i_combi<end_of_iter; i_combi++){
+      // try to extend the list of pair combinations by one more pair
+      for (size_t i_pair=0; i_pair<vec_AllPossiblePairs.size(); i_pair++){
+	bool IsClusterOverlap=false;
+	for (size_t j_pair=0; j_pair<vec_combi_pairs[i_combi].size(); j_pair++){
+	  if (vec_AllPossiblePairs[i_pair].first >= vec_combi_pairs[i_combi][j_pair].first || // avoid double counting combinations
+	      vec_AllPossiblePairs[i_pair].first == vec_combi_pairs[i_combi][j_pair].second ||
+	      vec_AllPossiblePairs[i_pair].second == vec_combi_pairs[i_combi][j_pair].first ||
+	      vec_AllPossiblePairs[i_pair].second == vec_combi_pairs[i_combi][j_pair].second){
+	    IsClusterOverlap=true;
+	    break;
+	  }
+	}
+	if (IsClusterOverlap==false){
+	  std::vector<std::pair<size_t, size_t>> vec_combi_copy;
+	  for (size_t k_pair=0; k_pair<vec_combi_pairs[i_combi].size(); k_pair++){
+	    vec_combi_copy.push_back(vec_combi_pairs[i_combi][k_pair]);
+	  }
+	  vec_combi_copy.push_back(vec_AllPossiblePairs[i_pair]);
+	  vec_combi_pairs.push_back(vec_combi_copy);
+	}
+      }
+    }
+    start_of_iter=end_of_iter;
+    end_of_iter=vec_combi_pairs.size();
+  }
+  // ***** Step 3: choose the combination with the most number of pairs and closest to the pi0 mass
+  verbose() << "We are in cluster pairing step 3" <<endmsg;
+  // Step 3(a): number of pairs
+  size_t max_Npairs=0;
+  std::vector<std::vector<std::pair<size_t, size_t>>> vec_Maxcombi_pairs;
+  std::vector<std::pair<size_t, size_t>> bestcombi_pairs;
+  for (size_t i_combi=0; i_combi<vec_combi_pairs.size(); i_combi++){
+    size_t this_Npairs=vec_combi_pairs[i_combi].size();
+    if (this_Npairs>max_Npairs){
+      max_Npairs=this_Npairs;
+      vec_Maxcombi_pairs.clear();
+      vec_Maxcombi_pairs.push_back(vec_combi_pairs[i_combi]);
+    }
+    else if (this_Npairs==max_Npairs){
+      vec_Maxcombi_pairs.push_back(vec_combi_pairs[i_combi]);
+    }
+  }
+  // Step 3(b): mass deviation
+  size_t index_best_combi=-1;
+  double best_devM=1000.;
+  if (vec_Maxcombi_pairs.size()>1){
+    for (size_t i_combi=0; i_combi<vec_Maxcombi_pairs.size(); i_combi++){
+      double this_devM=0.;
+      for (size_t i_pair=0; i_pair<vec_Maxcombi_pairs[i_combi].size(); i_pair++){
+	auto this_cluster1=inClusters->at(vec_Maxcombi_pairs[i_combi][i_pair].first);
+	auto this_cluster2=inClusters->at(vec_Maxcombi_pairs[i_combi][i_pair].second);
+	edm4hep::Vector3d position1(this_cluster1.getPosition().x, this_cluster1.getPosition().y, this_cluster1.getPosition().z);
+	edm4hep::Vector3d position2(this_cluster2.getPosition().x, this_cluster2.getPosition().y, this_cluster2.getPosition().z);
+	edm4hep::Vector3d momentum1=PairCaloClustersPi0::projectMomentum(this_cluster1.getEnergy(), position1, edm4hep::Vector3d(0,0,0));
+	edm4hep::Vector3d momentum2=PairCaloClustersPi0::projectMomentum(this_cluster2.getEnergy(), position2, edm4hep::Vector3d(0,0,0));
+	double this_invM=PairCaloClustersPi0::getInvariantMass(
+	    this_cluster1.getEnergy(), momentum1, this_cluster2.getEnergy(), momentum2);
+	this_devM+=pow((this_invM - masspeak),2);
+      }
+      this_devM/=vec_Maxcombi_pairs[i_combi].size();
+      if (this_devM<best_devM){
+	index_best_combi=i_combi;
+	best_devM=this_devM;
+      }
+      else if (this_devM==best_devM){
+	index_best_combi = (rand()%2) ? i_combi : index_best_combi; // randomly choose one
+      }
+    }
+    bestcombi_pairs=vec_Maxcombi_pairs[index_best_combi];
+  }
+  else if (vec_Maxcombi_pairs.size()==1){
+    bestcombi_pairs=vec_Maxcombi_pairs[0];
+  }
+  // this is purely debugging
+  for (size_t i_pair=0; i_pair<bestcombi_pairs.size(); i_pair++){
+    edm4hep::Vector3d position1(inClusters->at(bestcombi_pairs[i_pair].first).getPosition().x, inClusters->at(bestcombi_pairs[i_pair].first).getPosition().y, inClusters->at(bestcombi_pairs[i_pair].first).getPosition().z);
+    edm4hep::Vector3d position2(inClusters->at(bestcombi_pairs[i_pair].second).getPosition().x, inClusters->at(bestcombi_pairs[i_pair].second).getPosition().y, inClusters->at(bestcombi_pairs[i_pair].second).getPosition().z);
+    edm4hep::Vector3d momentum1=PairCaloClustersPi0::projectMomentum( inClusters->at(bestcombi_pairs[i_pair].first).getEnergy(), position1, edm4hep::Vector3d(0,0,0));
+    edm4hep::Vector3d momentum2=PairCaloClustersPi0::projectMomentum( inClusters->at(bestcombi_pairs[i_pair].second).getEnergy(), position2, edm4hep::Vector3d(0,0,0));
+    double print_invM=PairCaloClustersPi0::getInvariantMass( inClusters->at(bestcombi_pairs[i_pair].first).getEnergy(), momentum1, inClusters->at(bestcombi_pairs[i_pair].second).getEnergy(), momentum2 );
+    verbose() << "Final pairing " << i_pair << " first cluster = " << bestcombi_pairs[i_pair].first << ", second cluster =  " << bestcombi_pairs[i_pair].second << ", invariant mass [GeV] = " << print_invM <<endmsg;
+  }
+  // Step 4: save paired and unpaired clusters
+  verbose() << "We are in cluster pairing step 4" <<endmsg;
+  std::vector<size_t> vec_index_paired_clusters;
+  // save paired clusters
+  for (size_t i=0; i<bestcombi_pairs.size(); i++){
+    auto outCluster1 = inClusters->at(bestcombi_pairs[i].first).clone();
+    pairedClusters->push_back(outCluster1);
+    vec_index_paired_clusters.push_back(bestcombi_pairs[i].first);
+    auto outCluster2 = inClusters->at(bestcombi_pairs[i].second).clone();
+    pairedClusters->push_back(outCluster2);
+    vec_index_paired_clusters.push_back(bestcombi_pairs[i].second);
+  }
+  for (size_t i=0; i<inClusters->size(); ++i){
+    bool IsPaired=false;
+    for (size_t j=0; j<vec_index_paired_clusters.size(); j++){
+      if (i==j){
+	IsPaired=true;
+	break;
+      }
+    }
+    // save unpaired clusters
+    if (!IsPaired){
+      auto outCluster = inClusters->at(i).clone();
+      unpairedClusters->push_back(outCluster);
+      verbose() << "save unpaired cluster. cluster index = " << i <<endmsg;
+    }
+  }
+
+  return unpairedClusters;
+}

--- a/RecCalorimeter/src/components/PairCaloClustersPi0.h
+++ b/RecCalorimeter/src/components/PairCaloClustersPi0.h
@@ -33,9 +33,10 @@ class Vector3d;
 
 /** @class PairCaloClustersPi0
  *
- *  Make pi0 candidate (reconstructed particle) from cluster pairs, according tothe definition of a pi0 mass window
+ *  Make pi0 candidate (reconstructed particle) from cluster pairs, according to the definition of a pi0 mass window
  *  Output1: A list of reconstructed particles, with energy, momentum, and pointers to a pair of clusters
  *  Output2: The rest of clusters not involved in the reconstructioni of pi0 candidate through the pairing.
+ *  Output3: Clusters used in the reconstructioni of pi0 candidate.
  *  
  *  @author Zhibo Wu
  */

--- a/RecCalorimeter/src/components/PairCaloClustersPi0.h
+++ b/RecCalorimeter/src/components/PairCaloClustersPi0.h
@@ -1,0 +1,120 @@
+#ifndef RECCALORIMETER_PAIRCALOCLUSTERSPI0_H
+#define RECCALORIMETER_PAIRCALOCLUSTERSPI0_H
+
+// Key4HEP
+#include "k4FWCore/DataHandle.h"
+
+// Gaudi
+#include "Gaudi/Algorithm.h"
+#include "GaudiKernel/MsgStream.h"
+//#include "GaudiKernel/IRndmGenSvc.h"
+//#include "GaudiKernel/RndmGenerators.h"
+#include "GaudiKernel/ToolHandle.h"
+
+// our edm
+#include "edm4hep/Cluster.h"
+#include "edm4hep/ClusterCollection.h"
+#include "edm4hep/Vector3d.h"
+
+//class IRndmGenSvc;
+
+// EDM4HEP
+namespace edm4hep {
+class Cluster;
+class MutableCluster;
+class ClusterCollection;
+class Vector3d;
+} // namespace edm4hep
+
+/** @class CorrectCaloClusters
+ *
+ *  Apply corrections to the clusters reconstructed in ECAL.
+ *  * Upstream energy correction corrects for the energy lost by the particles in the material before they enter
+ *    active volume of the calorimeter. The correction is parametrized in one (cluster energy) or two variables (cluster
+ *    energy, cluster angle)
+ *  * Downstream energy correction corrects for the energy lost due to punch trough. This energy is deposited in the
+ *    instrumentation behind the active volume of the calorimeter. It is parametrized in one (cluster energy) or two
+ *    variables (cluster energy, cluster angle)
+ * * Benchmark calibration should be used for the combined simulation of ECal and HCal when using charged pions.
+ *    At the input level, the ECal should be calibrated to EM scale and HCal should be calibrated to HAD scale.
+ *    The aim of the benchmark calibration is to bring ECal to HAD scale and also to take into account
+ *    the energy loss between the ECal and HCal (e.g. in cryostat) - for this, the energy from the last ECal layer and
+ * the first HCal layer is used. While, downstream correction is part of the benchmark method (energy lost between ECal
+ * and HCal), as well as the upstream correction for ECal For standalone ECal, include upstream and downstream
+ * correction; for ECal+HCal simulation apply only benchmark correction should be applied To obtain the actual
+ * parameters run RecCalorimeter/tests/options/fcc_ee_caloBenchmarkCalibration.py which calls CalibrateBenchmarkMethod
+ *
+ *  Based on similar corrections by Jana Faltova and Anna Zaborowska.
+ *
+ *  @author Juraj Smiesko, benchmark calibration added by Michaela Mlynarikova
+ */
+
+class PairCaloClustersPi0 : public Gaudi::Algorithm {
+
+public:
+  PairCaloClustersPi0(const std::string& name, ISvcLocator* svcLoc);
+
+  StatusCode initialize();
+
+  StatusCode execute(const EventContext&) const;
+
+  StatusCode finalize();
+
+private:
+  /**
+   * Cluster pairing algorithm
+   *
+   * @param[in] inClusters  Pointer to the input cluster collection.
+   * @param[in] masspeak    pi0 mass peak.
+   * @param[in] masslow     Lower boundary of the pi0 mass window.
+   * @param[in] masshigh    Upper boundary of the pi0 mass window.
+   *
+   * @return                Pointer to the output cluster collection.
+   */
+  edm4hep::ClusterCollection* ClusterPairing(const edm4hep::ClusterCollection* inClusters, double masspeak, double masslow, double masshigh) const;
+
+  /**
+   * Project the energy of a cluster in the pointing direction of the cluster
+   *
+   * @param[in]  energy     Energy of the cluster.
+   * @param[in]  position   Barycenter of the cluster.
+   * @param[in]  origin     Origin of the cluster (inferred from cluster pointing)
+   *
+   * @return                Effective momentum of cluster.
+   */
+  edm4hep::Vector3d projectMomentum(double energy, edm4hep::Vector3d position, edm4hep::Vector3d origin) const;
+
+  /**
+   * Calculate invariant mass of two input clusters
+   *
+   * @param[in]  E1          Energy of the first cluster.
+   * @param[in]  momentum1   Momentum of the first cluster.
+   * @param[in]  E2          Energy of the second cluster.
+   * @param[in]  momentum2   Momentum of the second cluster.
+   *
+   * @return                 Invariant mass.
+   */
+  double getInvariantMass(double E1, edm4hep::Vector3d momentum1 ,double E2, edm4hep::Vector3d momentum2) const;
+
+  /// Handle for input calorimeter clusters collection
+  mutable DataHandle<edm4hep::ClusterCollection> m_inClusters{"inClusters", Gaudi::DataHandle::Reader, this};
+  /// Handle for paired (output1) calorimeter clusters collection
+  mutable DataHandle<edm4hep::ClusterCollection> m_pairedClusters{"pairedClusters", Gaudi::DataHandle::Writer, this};
+  /// Handle for unpaired (output2) calorimeter clusters collection
+  mutable DataHandle<edm4hep::ClusterCollection> m_unpairedClusters{"unpairedClusters", Gaudi::DataHandle::Writer, this};
+
+  // pi0 mass window
+  Gaudi::Property<double> m_massPeak{this, "massPeak", 0.135, "pi0 mass peak [GeV]"};
+  Gaudi::Property<double> m_massLow{this, "massLow", 0.0, "lower boundary of pi0 mass window [GeV]"};
+  Gaudi::Property<double> m_massHigh{this, "massHigh", 0.27, "upper boundary of pi0 mass window [GeV]"};
+
+  /*
+  /// Random Number Service
+  SmartIF<IRndmGenSvc> m_randSvc;
+  /// Randomly choose between 0 and 1, used in cluster pairing
+  Rndm::Numbers m_bit;
+  */
+
+};
+
+#endif /* RECCALORIMETER_PAIRCALOCLUSTERSPI0_H */

--- a/RecCalorimeter/src/components/PairCaloClustersPi0.h
+++ b/RecCalorimeter/src/components/PairCaloClustersPi0.h
@@ -14,6 +14,8 @@
 // our edm
 #include "edm4hep/Cluster.h"
 #include "edm4hep/ClusterCollection.h"
+#include "edm4hep/ReconstructedParticle.h"
+#include "edm4hep/ReconstructedParticleCollection.h"
 #include "edm4hep/Vector3d.h"
 
 //class IRndmGenSvc;
@@ -23,30 +25,19 @@ namespace edm4hep {
 class Cluster;
 class MutableCluster;
 class ClusterCollection;
+class ReconstructedParticle;
+class MutableReconstructedParticle;
+class ReconstructedParticleCollection;
 class Vector3d;
 } // namespace edm4hep
 
-/** @class CorrectCaloClusters
+/** @class PairCaloClustersPi0
  *
- *  Apply corrections to the clusters reconstructed in ECAL.
- *  * Upstream energy correction corrects for the energy lost by the particles in the material before they enter
- *    active volume of the calorimeter. The correction is parametrized in one (cluster energy) or two variables (cluster
- *    energy, cluster angle)
- *  * Downstream energy correction corrects for the energy lost due to punch trough. This energy is deposited in the
- *    instrumentation behind the active volume of the calorimeter. It is parametrized in one (cluster energy) or two
- *    variables (cluster energy, cluster angle)
- * * Benchmark calibration should be used for the combined simulation of ECal and HCal when using charged pions.
- *    At the input level, the ECal should be calibrated to EM scale and HCal should be calibrated to HAD scale.
- *    The aim of the benchmark calibration is to bring ECal to HAD scale and also to take into account
- *    the energy loss between the ECal and HCal (e.g. in cryostat) - for this, the energy from the last ECal layer and
- * the first HCal layer is used. While, downstream correction is part of the benchmark method (energy lost between ECal
- * and HCal), as well as the upstream correction for ECal For standalone ECal, include upstream and downstream
- * correction; for ECal+HCal simulation apply only benchmark correction should be applied To obtain the actual
- * parameters run RecCalorimeter/tests/options/fcc_ee_caloBenchmarkCalibration.py which calls CalibrateBenchmarkMethod
- *
- *  Based on similar corrections by Jana Faltova and Anna Zaborowska.
- *
- *  @author Juraj Smiesko, benchmark calibration added by Michaela Mlynarikova
+ *  Make pi0 candidate (reconstructed particle) from cluster pairs, according tothe definition of a pi0 mass window
+ *  Output1: A list of reconstructed particles, with energy, momentum, and pointers to a pair of clusters
+ *  Output2: The rest of clusters not involved in the reconstructioni of pi0 candidate through the pairing.
+ *  
+ *  @author Zhibo Wu
  */
 
 class PairCaloClustersPi0 : public Gaudi::Algorithm {
@@ -103,6 +94,8 @@ private:
   /// Handle for unpaired (output2) calorimeter clusters collection
   mutable DataHandle<edm4hep::ClusterCollection> m_unpairedClusters{"unpairedClusters", Gaudi::DataHandle::Writer, this};
 
+  mutable DataHandle<edm4hep::ReconstructedParticleCollection> m_reconstructedPi0{"reconstructedPi0", Gaudi::DataHandle::Writer, this};
+  
   // pi0 mass window
   Gaudi::Property<double> m_massPeak{this, "massPeak", 0.135, "pi0 mass peak [GeV]"};
   Gaudi::Property<double> m_massLow{this, "massLow", 0.0, "lower boundary of pi0 mass window [GeV]"};

--- a/RecCalorimeter/src/components/PairCaloClustersPi0.h
+++ b/RecCalorimeter/src/components/PairCaloClustersPi0.h
@@ -89,12 +89,13 @@ private:
 
   /// Handle for input calorimeter clusters collection
   mutable DataHandle<edm4hep::ClusterCollection> m_inClusters{"inClusters", Gaudi::DataHandle::Reader, this};
-  /// Handle for paired (output1) calorimeter clusters collection
-  mutable DataHandle<edm4hep::ClusterCollection> m_pairedClusters{"pairedClusters", Gaudi::DataHandle::Writer, this};
+  /// Handle for reconstructed pi0 particles (output1) collection
+  mutable DataHandle<edm4hep::ReconstructedParticleCollection> m_reconstructedPi0{"reconstructedPi0", Gaudi::DataHandle::Writer, this};
   /// Handle for unpaired (output2) calorimeter clusters collection
   mutable DataHandle<edm4hep::ClusterCollection> m_unpairedClusters{"unpairedClusters", Gaudi::DataHandle::Writer, this};
+  /// Handle for paired (output3) calorimeter clusters collection
+  mutable DataHandle<edm4hep::ClusterCollection> m_pairedClusters{"pairedClusters", Gaudi::DataHandle::Writer, this};
 
-  mutable DataHandle<edm4hep::ReconstructedParticleCollection> m_reconstructedPi0{"reconstructedPi0", Gaudi::DataHandle::Writer, this};
   
   // pi0 mass window
   Gaudi::Property<double> m_massPeak{this, "massPeak", 0.135, "pi0 mass peak [GeV]"};

--- a/RecFCCeeCalorimeter/tests/options/ALLEGRO_o1_v03_digi_reco.py
+++ b/RecFCCeeCalorimeter/tests/options/ALLEGRO_o1_v03_digi_reco.py
@@ -70,6 +70,9 @@ ecalBarrelThetaWeights = [-1, 3.0, 3.0, 3.0, 4.25, 4.0, 4.0, 4.0, 4.0, 4.0, 4.0]
 runPhotonIDTool = False
 logEWeightInPhotonID = False
 
+# resolved pi0 reconstruction by cluster pairing
+addPi0RecoTool = True
+
 #
 # ALGORITHMS AND SERVICES SETUP
 #
@@ -666,6 +669,18 @@ if doTopoClustering:
                                                              do_photon_shapeVar=runPhotonIDTool,
                                                              do_widthTheta_logE_weights=logEWeightInPhotonID,
                                                              OutputLevel=INFO)
+        if addPi0RecoTool:
+            from Configurables import PairCaloClustersPi0
+            Pi0RecoAlg = PairCaloClustersPi0(
+                "resolvedPi0FromClusterPair",
+                inClusters="Augmented" + createECalBarrelTopoClusters.clusters.Path,
+                unpairedClusters="Unpaired" + "Augmented" + createECalBarrelTopoClusters.clusters.Path,
+                reconstructedPi0="ResolvedPi0Particle",
+                massPeak=0.122201,
+                massLow=0.0754493,
+                massHigh=0.153543,
+                OutputLevel=INFO
+            )
 
     if applyMVAClusterEnergyCalibration:
         inClusters = ""
@@ -875,6 +890,10 @@ if doSWClustering or doTopoClustering:
         if addShapeParameters:
             TopAlg += [augmentECalBarrelTopoClusters]
             augmentECalBarrelTopoClusters.AuditExecute = True
+
+            if addPi0RecoTool:
+                TopAlg + =[Pi0RecoAlg]
+                Pi0RecoAlg.AuditExecute = True
 
         if applyMVAClusterEnergyCalibration:
             TopAlg += [calibrateECalBarrelTopoClusters]


### PR DESCRIPTION

BEGINRELEASENOTES
- Created new algorithm "PairCaloClustersPi0" to reconstruct all possible resolved pi0 candidates from pairs of ALLEGRO ECAL topo-clusters (following the _pi0->photon+photon_ decay process). For the moment, the pi0 mass window is studied and optimised only for topo-clusters.
- The rest of topo-clusters that are not paired into pi0 candidates will be saved in a separate cluster collection.

ENDRELEASENOTES
