### PR TITLE
Allow topoclustering algorithm to use overrided Segmentation::neighbour function

### DIFF
--- a/RecCalorimeter/src/components/ConstNoiseTool.cpp
+++ b/RecCalorimeter/src/components/ConstNoiseTool.cpp
@@ -17,6 +17,8 @@ ConstNoiseTool::ConstNoiseTool(const std::string& type, const std::string& name,
 }
 
 StatusCode ConstNoiseTool::initialize() {
+  // initialize decoder for retrieving system ID
+  m_decoder = std::make_unique<dd4hep::DDSegmentation::BitFieldCoder>(m_systemEncoding);
 
   // check that sizes of m_detectors and m_detectorNoiseRMS and m_detectorNoiseOffset are the same
   if (m_detectorsNoiseRMS.size() != m_detectors.size()) {

--- a/RecCalorimeter/src/components/ConstNoiseTool.h
+++ b/RecCalorimeter/src/components/ConstNoiseTool.h
@@ -74,7 +74,7 @@ private:
   SmartIF<IGeoSvc> m_geoSvc;
 
   /// Decoder
-  dd4hep::DDSegmentation::BitFieldCoder* m_decoder = new dd4hep::DDSegmentation::BitFieldCoder(m_systemEncoding.get());
+  dd4hep::DDSegmentation::BitFieldCoder* m_decoder = new dd4hep::DDSegmentation::BitFieldCoder(m_systemEncoding);
 };
 
 #endif /* RECCALORIMETER_CONSTNOISETOOL_H */

--- a/RecCalorimeter/src/components/ConstNoiseTool.h
+++ b/RecCalorimeter/src/components/ConstNoiseTool.h
@@ -67,11 +67,14 @@ private:
   Gaudi::Property<std::vector<double>> m_detectorsNoiseOffset{
       this, "detectorsNoiseOffset", {0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0}, "Cell noise offset in GeV"};
 
+  /// System encoding string
+  Gaudi::Property<std::string> m_systemEncoding{this, "systemEncoding", "system:4", "System encoding string"};
+
   /// Pointer to the geometry service
   SmartIF<IGeoSvc> m_geoSvc;
 
   /// Decoder
-  dd4hep::DDSegmentation::BitFieldCoder* m_decoder = new dd4hep::DDSegmentation::BitFieldCoder("system:5");
+  dd4hep::DDSegmentation::BitFieldCoder* m_decoder = new dd4hep::DDSegmentation::BitFieldCoder(m_systemEncoding.get());
 };
 
 #endif /* RECCALORIMETER_CONSTNOISETOOL_H */

--- a/RecCalorimeter/src/components/ConstNoiseTool.h
+++ b/RecCalorimeter/src/components/ConstNoiseTool.h
@@ -71,7 +71,7 @@ private:
   SmartIF<IGeoSvc> m_geoSvc;
 
   /// Decoder
-  dd4hep::DDSegmentation::BitFieldCoder* m_decoder = new dd4hep::DDSegmentation::BitFieldCoder("system:4");
+  dd4hep::DDSegmentation::BitFieldCoder* m_decoder = new dd4hep::DDSegmentation::BitFieldCoder("system:5");
 };
 
 #endif /* RECCALORIMETER_CONSTNOISETOOL_H */

--- a/RecCalorimeter/src/components/ConstNoiseTool.h
+++ b/RecCalorimeter/src/components/ConstNoiseTool.h
@@ -74,7 +74,7 @@ private:
   SmartIF<IGeoSvc> m_geoSvc;
 
   /// Decoder
-  dd4hep::DDSegmentation::BitFieldCoder* m_decoder = new dd4hep::DDSegmentation::BitFieldCoder(m_systemEncoding);
+  std::unique_ptr<dd4hep::DDSegmentation::BitFieldCoder> m_decoder;
 };
 
 #endif /* RECCALORIMETER_CONSTNOISETOOL_H */

--- a/RecFCCeeCalorimeter/CMakeLists.txt
+++ b/RecFCCeeCalorimeter/CMakeLists.txt
@@ -50,3 +50,10 @@ add_test(NAME FCCeeLAr_benchmarkCorrection
          WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
 )
 set_test_env(FCCeeLAr_benchmarkCorrection)
+
+add_test(NAME IDEA_o1_v03_reco
+         COMMAND k4run RecFCCeeCalorimeter/tests/options/IDEA_o1_v03_reco.py
+         WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+)
+set_test_env(IDEA_o1_v03_reco)
+set_tests_properties(IDEA_o1_v03_reco PROPERTIES DEPENDS simulateSiPM)

--- a/RecFCCeeCalorimeter/src/components/CaloTopoClusterFCCee.h
+++ b/RecFCCeeCalorimeter/src/components/CaloTopoClusterFCCee.h
@@ -18,6 +18,7 @@
 #include "k4FWCore/MetaDataHandle.h"
 #include "k4Interface/INoiseConstTool.h"
 #include "k4Interface/ICaloReadNeighboursMap.h"
+#include "k4Interface/IGeoSvc.h"
 
 // EDM4HEP
 namespace edm4hep {
@@ -119,6 +120,14 @@ private:
   mutable ToolHandle<INoiseConstTool> m_noiseTool{"TopoCaloNoisyCells", this};
   /// Handle for neighbours tool
   mutable ToolHandle<ICaloReadNeighboursMap> m_neighboursTool{"TopoCaloNeighbours", this};
+  // flag to use a pre-calculated neighbor map
+  Gaudi::Property<bool> m_useNeighborMap{this, "useNeighborMap", true, "use pre-calculated neighbor map"};
+  // use GeoSvc when the neighbor map is not present
+  SmartIF<IGeoSvc> m_geoSvc;
+  // name of the readout (or segmentation)
+  Gaudi::Property<std::string> m_readoutName{this, "readoutName", "", "name of the readout/segmentation"};
+  // pointer to the segmentation object
+  dd4hep::DDSegmentation::Segmentation* m_segmentation = nullptr;
 
   /// Seed threshold in sigma
   Gaudi::Property<int> m_seedSigma{this, "seedSigma", 4, "number of sigma in noise threshold"};

--- a/RecFCCeeCalorimeter/src/components/CaloTopoClusterFCCee.h
+++ b/RecFCCeeCalorimeter/src/components/CaloTopoClusterFCCee.h
@@ -124,8 +124,8 @@ private:
   Gaudi::Property<bool> m_useNeighborMap{this, "useNeighborMap", true, "use pre-calculated neighbor map"};
   // use GeoSvc when the neighbor map is not present
   SmartIF<IGeoSvc> m_geoSvc;
-  // name of the readout (or segmentation)
-  Gaudi::Property<std::string> m_readoutName{this, "readoutName", "", "name of the readout/segmentation"};
+  // name of the readout: only needed if useNeighborMap is set to false
+  Gaudi::Property<std::string> m_readoutName{this, "readoutName", "", "name of the readout (needed if useNeighborMap=false)"};
   // pointer to the segmentation object
   dd4hep::DDSegmentation::Segmentation* m_segmentation = nullptr;
 

--- a/RecFCCeeCalorimeter/tests/options/IDEA_o1_v03_reco.py
+++ b/RecFCCeeCalorimeter/tests/options/IDEA_o1_v03_reco.py
@@ -1,0 +1,87 @@
+from Gaudi.Configuration import *
+from Configurables import ApplicationMgr
+
+from Configurables import k4DataSvc
+dataservice = k4DataSvc("EventDataSvc", input="testIDEA_o1_v03_digi.root")
+
+# detector geometry
+# if K4GEO is empty, this should use relative path to working directory
+from Configurables import GeoSvc
+import os
+geoservice = GeoSvc("GeoSvc")
+path_to_detector = "/afs/cern.ch/work/s/sako/private/kfc-dream/k4geo/" # os.environ.get("K4GEO", "")
+detectors_to_use = [
+    'FCCee/IDEA/compact/IDEA_o1_v03/IDEA_o1_v03.xml'
+]
+
+geoservice.detectors = [
+    os.path.join(path_to_detector, _det) for _det in detectors_to_use
+]
+
+geoservice.OutputLevel = INFO
+
+from Configurables import PodioInput
+podioinput = PodioInput("PodioInput",
+    collections = [
+        "DRcaloSiPMreadout_scint",
+        "DRcaloSiPMreadout_scintContributions",
+        "DRcaloSiPMreadoutSimHit",
+        "DRcaloSiPMreadoutDigiHit_scint",
+        "DRcaloSiPMreadoutDigiHit"
+    ],
+    OutputLevel = DEBUG
+)
+
+# use const noise tool for the moment
+from Configurables import ConstNoiseTool
+constNoiseTool = ConstNoiseTool("ConstNoiseTool",
+    detectors = ["FiberDRCalo"],
+    detectorsNoiseRMS = [0.001], # ad-hoc small value
+    detectorsNoiseOffset = [0.],
+    OutputLevel = INFO
+)
+
+from Configurables import CaloTopoClusterFCCee
+topoClusterCheren = CaloTopoClusterFCCee("topoClusterCheren",
+    cells = ["DRcaloSiPMreadoutDigiHit"],
+    clusters = "TopoClusterCheren",
+    clusterCells = "TopoClusterCherenCells",
+    useNeighborMap = False,
+    readoutName = "DRcaloSiPMreadout",
+    neigboursTool = None,
+    noiseTool = constNoiseTool,
+    seedSigma = 4,
+    neighbourSigma = 2,
+    lastNeighbourSigma = 0,
+    OutputLevel = INFO
+)
+
+topoClusterScint = CaloTopoClusterFCCee("topoClusterScint",
+    cells = ["DRcaloSiPMreadoutDigiHit_scint"],
+    clusters = "TopoClusterScint",
+    clusterCells = "TopoClusterScintCells",
+    useNeighborMap = False,
+    readoutName = "DRcaloSiPMreadout",
+    neigboursTool = None,
+    noiseTool = constNoiseTool,
+    seedSigma = 4,
+    neighbourSigma = 2,
+    lastNeighbourSigma = 0,
+    OutputLevel = INFO
+)
+
+from Configurables import PodioOutput
+podiooutput = PodioOutput("PodioOutput", filename = "testIDEA_o1_v03_reco.root", OutputLevel = DEBUG)
+podiooutput.outputCommands = ["keep *"]
+
+ApplicationMgr(
+    TopAlg = [
+        podioinput,
+        topoClusterCheren,
+        topoClusterScint,
+        podiooutput
+    ],
+    EvtSel = 'NONE',
+    EvtMax = 10,
+    ExtSvc = [dataservice,geoservice]
+)

--- a/RecFCCeeCalorimeter/tests/options/IDEA_o1_v03_reco.py
+++ b/RecFCCeeCalorimeter/tests/options/IDEA_o1_v03_reco.py
@@ -9,7 +9,7 @@ dataservice = k4DataSvc("EventDataSvc", input="testIDEA_o1_v03_digi.root")
 from Configurables import GeoSvc
 import os
 geoservice = GeoSvc("GeoSvc")
-path_to_detector = "/afs/cern.ch/work/s/sako/private/kfc-dream/k4geo/" # os.environ.get("K4GEO", "")
+path_to_detector = os.environ.get("K4GEO", "")
 detectors_to_use = [
     'FCCee/IDEA/compact/IDEA_o1_v03/IDEA_o1_v03.xml'
 ]
@@ -36,6 +36,7 @@ podioinput = PodioInput("PodioInput",
 from Configurables import ConstNoiseTool
 constNoiseTool = ConstNoiseTool("ConstNoiseTool",
     detectors = ["FiberDRCalo"],
+    systemEncoding = "system:5",
     detectorsNoiseRMS = [0.001], # ad-hoc small value
     detectorsNoiseOffset = [0.],
     OutputLevel = INFO
@@ -50,6 +51,7 @@ topoClusterCheren = CaloTopoClusterFCCee("topoClusterCheren",
     readoutName = "DRcaloSiPMreadout",
     neigboursTool = None,
     noiseTool = constNoiseTool,
+    systemEncoding = "system:5",
     seedSigma = 4,
     neighbourSigma = 2,
     lastNeighbourSigma = 0,
@@ -64,6 +66,7 @@ topoClusterScint = CaloTopoClusterFCCee("topoClusterScint",
     readoutName = "DRcaloSiPMreadout",
     neigboursTool = None,
     noiseTool = constNoiseTool,
+    systemEncoding = "system:5",
     seedSigma = 4,
     neighbourSigma = 2,
     lastNeighbourSigma = 0,


### PR DESCRIPTION

BEGINRELEASENOTES
- Allow topoclustering algorithm to use overrided Segmentation::neighbour function

ENDRELEASENOTES

This PR allows to use of overrided `Segmentation::neighbour` function to avoid using `TTree` based neighbor map (and instead retrieves the neighboring `CellID` on-the-fly). A switch `useNeighborMap` is added to support backward compatibility.