### PR TITLE
Don't use ROOT typedef

### DIFF
--- a/RecCalorimeter/src/components/CalibrateBenchmarkMethod.cpp
+++ b/RecCalorimeter/src/components/CalibrateBenchmarkMethod.cpp
@@ -191,7 +191,7 @@ StatusCode CalibrateBenchmarkMethod::execute(const EventContext&) const {
 }
 
 // minimisation function for the benchmark method
-double CalibrateBenchmarkMethod::chiSquareFitBarrel(const Double_t* parameter) const {
+double CalibrateBenchmarkMethod::chiSquareFitBarrel(const double* parameter) const {
   double fitvalue = 0.;
   // loop over all events, vector of a size of #evts is filled with the energies
   // ECal calibrated to EM scale, HCal calibrated to HAD scale

--- a/RecCalorimeter/src/components/CalibrateBenchmarkMethod.h
+++ b/RecCalorimeter/src/components/CalibrateBenchmarkMethod.h
@@ -64,7 +64,7 @@ private:
   /// Pointer to the interface of histogram service
   ServiceHandle<ITHistSvc> m_histSvc;
 
-  double chiSquareFitBarrel(const Double_t* par) const;
+  double chiSquareFitBarrel(const double* par) const;
   void registerHistogram(const std::string& path, TH1F*& histogramName);
   void runMinimization(int n_param, const std::vector<double>& variable, const std::vector<double>& steps,
                        const std::vector<int>& fixedParameters) const;


### PR DESCRIPTION
BEGINRELEASENOTES
- Avoid the usage of `Double_t` typedef in method signature to be less dependent on included headers

ENDRELEASENOTES

The `Double_t` typedef has pointed to `double` in ROOT for >20 years at this point and it would require to forward declare it in the header to avoid brittle builds that depend on it being included by one of the included headers. Switching to `double` seems to be the easiest solution here for me.