### PR TITLE
Replace Double_t with double to fix the nightlies

### DIFF
--- a/RecCalorimeter/src/components/CalibrateBenchmarkMethod.cpp
+++ b/RecCalorimeter/src/components/CalibrateBenchmarkMethod.cpp
@@ -191,7 +191,7 @@ StatusCode CalibrateBenchmarkMethod::execute(const EventContext&) const {
 }
 
 // minimisation function for the benchmark method
-double CalibrateBenchmarkMethod::chiSquareFitBarrel(const Double_t* parameter) const {
+double CalibrateBenchmarkMethod::chiSquareFitBarrel(const double* parameter) const {
   double fitvalue = 0.;
   // loop over all events, vector of a size of #evts is filled with the energies
   // ECal calibrated to EM scale, HCal calibrated to HAD scale
@@ -203,7 +203,7 @@ double CalibrateBenchmarkMethod::chiSquareFitBarrel(const Double_t* parameter) c
     double energyInLastLayerECal = m_vecEnergyInLastLayerECal.at(i);
     double energyInFirstLayerHCal = m_vecEnergyInFirstLayerHCal.at(i);
 
-    Double_t benchmarkEnergy =
+    double benchmarkEnergy =
         parameter[0] * totalEnergyInECal + parameter[1] * totalEnergyInHCal +
         parameter[2] *
             std::sqrt(std::fabs(energyInLastLayerECal * parameter[0] * energyInFirstLayerHCal * parameter[1])) +
@@ -277,8 +277,8 @@ void CalibrateBenchmarkMethod::runMinimization(int n_param, const std::vector<do
   minimizer->Minimize();
 
   // Access the results if needed
-  const Double_t* xs = minimizer->X();
-  const Double_t* ys = minimizer->Errors();
+  const double* xs = minimizer->X();
+  const double* ys = minimizer->Errors();
 
   std::cout << "Minimum: f(";
   for (int i = 0; i < n_param; ++i) {

--- a/RecCalorimeter/src/components/CalibrateBenchmarkMethod.h
+++ b/RecCalorimeter/src/components/CalibrateBenchmarkMethod.h
@@ -64,7 +64,7 @@ private:
   /// Pointer to the interface of histogram service
   ServiceHandle<ITHistSvc> m_histSvc;
 
-  double chiSquareFitBarrel(const Double_t* par) const;
+  double chiSquareFitBarrel(const double* par) const;
   void registerHistogram(const std::string& path, TH1F*& histogramName);
   void runMinimization(int n_param, const std::vector<double>& variable, const std::vector<double>& steps,
                        const std::vector<int>& fixedParameters) const;


### PR DESCRIPTION
BEGINRELEASENOTES
- Replace Double_t with double to fix the nightlies

ENDRELEASENOTES

For some reason building these files has stopped working:

```
  >> 213    /tmp/root/spack-stage/spack-stage-k4reccalorimeter-e60d5bbe08edc020
            8abef9d87792615e2ee6ed4c_develop-2gwso5ans7ims5bhprmwgafc2xbrc25q/s
            pack-src/RecCalorimeter/src/components/CalibrateBenchmarkMethod.h:6
            7:35: error: 'Double_t' does not name a type; did you mean 'double_
            t'?
     214       67 |   double chiSquareFitBarrel(const Double_t* par) const;
     215          |                                   ^~~~~~~~
     216          |                                   double_t
```

and the fix is to simply use `double` instead of `Double_t`. Only https://github.com/HEP-FCC/k4RecCalorimeter/pull/154 was merged yesterday but I don't see the relation to this. It's also not reproducible when building after sourcing the stack, but the failure also happens in the LCG stack.