### PR TITLE
Move DataHandle and MetaDataHandle to the k4FWCore namespace

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake ${CMAKE_MODULE_PATH})
 #---------------------------------------------------------------
 find_package(ROOT COMPONENTS RIO Tree REQUIRED)
 find_package(Gaudi REQUIRED)
-find_package(k4FWCore REQUIRED) # implicit: Gaudi
+find_package(k4FWCore 1.3.0 REQUIRED)
 find_package(EDM4HEP REQUIRED) # implicit: Podio
 find_package(DD4hep REQUIRED)
 find_package(k4geo REQUIRED)

--- a/RecCalorimeter/src/components/CalibrateBenchmarkMethod.h
+++ b/RecCalorimeter/src/components/CalibrateBenchmarkMethod.h
@@ -70,11 +70,11 @@ private:
                        const std::vector<int>& fixedParameters) const;
 
   /// Handle for electromagnetic barrel cells (input collection)
-  mutable DataHandle<edm4hep::CalorimeterHitCollection> m_ecalBarrelCells{"ecalBarrelCells", Gaudi::DataHandle::Reader,
-                                                                          this};
+  mutable k4FWCore::DataHandle<edm4hep::CalorimeterHitCollection> m_ecalBarrelCells{"ecalBarrelCells",
+                                                                                    Gaudi::DataHandle::Reader, this};
   /// Handle for hadronic barrel cells (input collection)
-  mutable DataHandle<edm4hep::CalorimeterHitCollection> m_hcalBarrelCells{"hcalBarrelCells", Gaudi::DataHandle::Reader,
-                                                                          this};
+  mutable k4FWCore::DataHandle<edm4hep::CalorimeterHitCollection> m_hcalBarrelCells{"hcalBarrelCells",
+                                                                                    Gaudi::DataHandle::Reader, this};
 
   /// Histogram of total deposited energy in the calorimeters
   TH1F* m_totalEnergyECal;

--- a/RecCalorimeter/src/components/CaloTopoCluster.cpp
+++ b/RecCalorimeter/src/components/CaloTopoCluster.cpp
@@ -227,7 +227,8 @@ void CaloTopoCluster::findingSeeds(const std::unordered_map<uint64_t, double>& a
                                    std::vector<std::pair<uint64_t, double>>& aSeeds) const {
   for (const auto& cell : aCells) {
     // retrieve the noise const and offset assigned to cell
-    double threshold = m_noiseTool->getNoiseOffsetPerCell(cell.first) + (m_noiseTool->getNoiseRMSPerCell(cell.first) * aNumSigma);
+    double threshold =
+        m_noiseTool->getNoiseOffsetPerCell(cell.first) + (m_noiseTool->getNoiseRMSPerCell(cell.first) * aNumSigma);
     if (msgLevel() <= MSG::VERBOSE) {
       verbose() << "noise offset    = " << m_noiseTool->getNoiseOffsetPerCell(cell.first) << "GeV " << endmsg;
       verbose() << "noise rms       = " << m_noiseTool->getNoiseRMSPerCell(cell.first) << "GeV " << endmsg;
@@ -333,7 +334,8 @@ std::vector<std::pair<uint64_t, uint>> CaloTopoCluster::searchForNeighbours(
         bool addNeighbour = false;
         int cellType = 2;
         // retrieve the cell noise level [GeV]
-        double thr = m_noiseTool->getNoiseOffsetPerCell(neighbourID) + (aNumSigma * m_noiseTool->getNoiseRMSPerCell(neighbourID));
+        double thr = m_noiseTool->getNoiseOffsetPerCell(neighbourID) +
+                     (aNumSigma * m_noiseTool->getNoiseRMSPerCell(neighbourID));
         if (abs(neighbouringCellEnergy) > thr)
           addNeighbour = true;
         else

--- a/RecCalorimeter/src/components/CaloTopoCluster.h
+++ b/RecCalorimeter/src/components/CaloTopoCluster.h
@@ -10,10 +10,10 @@
 // Key4HEP
 #include "k4FWCore/DataHandle.h"
 #include "k4FWCore/MetaDataHandle.h"
-#include "k4Interface/INoiseConstTool.h"
 #include "k4Interface/ICaloReadNeighboursMap.h"
 #include "k4Interface/ICalorimeterTool.h"
 #include "k4Interface/ICellPositionsTool.h"
+#include "k4Interface/INoiseConstTool.h"
 #include "k4Interface/ITopoClusterInputTool.h"
 
 class IGeoSvc;
@@ -103,12 +103,13 @@ public:
 
 private:
   // Cluster collection
-  mutable DataHandle<edm4hep::ClusterCollection> m_clusterCollection{"calo/clusters", Gaudi::DataHandle::Writer, this};
+  mutable k4FWCore::DataHandle<edm4hep::ClusterCollection> m_clusterCollection{"calo/clusters",
+                                                                               Gaudi::DataHandle::Writer, this};
   // Cluster cells in collection
-  mutable DataHandle<edm4hep::CalorimeterHitCollection> m_clusterCellsCollection{"calo/clusterCells",
-                                                                                 Gaudi::DataHandle::Writer, this};
+  mutable k4FWCore::DataHandle<edm4hep::CalorimeterHitCollection> m_clusterCellsCollection{
+      "calo/clusterCells", Gaudi::DataHandle::Writer, this};
   /// Handle for the cluster shape metadata to write
-  MetaDataHandle<std::vector<std::string>> m_shapeParametersHandle{
+  k4FWCore::MetaDataHandle<std::vector<std::string>> m_shapeParametersHandle{
       m_clusterCollection, edm4hep::labels::ShapeParameterNames, Gaudi::DataHandle::Writer};
   /// Pointer to the geometry service
   SmartIF<IGeoSvc> m_geoSvc;

--- a/RecCalorimeter/src/components/CaloTopoClusterInputTool.h
+++ b/RecCalorimeter/src/components/CaloTopoClusterInputTool.h
@@ -55,24 +55,26 @@ public:
 
 private:
   /// Handle for electromagnetic barrel cells (input collection)
-  mutable DataHandle<edm4hep::CalorimeterHitCollection> m_ecalBarrelCells{"ecalBarrelCells", Gaudi::DataHandle::Reader,
-                                                                          this};
+  mutable k4FWCore::DataHandle<edm4hep::CalorimeterHitCollection> m_ecalBarrelCells{"ecalBarrelCells",
+                                                                                    Gaudi::DataHandle::Reader, this};
   /// Handle for ecal endcap calorimeter cells (input collection)
-  mutable DataHandle<edm4hep::CalorimeterHitCollection> m_ecalEndcapCells{"ecalEndcapCells", Gaudi::DataHandle::Reader,
-                                                                          this};
+  mutable k4FWCore::DataHandle<edm4hep::CalorimeterHitCollection> m_ecalEndcapCells{"ecalEndcapCells",
+                                                                                    Gaudi::DataHandle::Reader, this};
   /// Handle for ecal forward calorimeter cells (input collection)
-  mutable DataHandle<edm4hep::CalorimeterHitCollection> m_ecalFwdCells{"ecalFwdCells", Gaudi::DataHandle::Reader, this};
+  mutable k4FWCore::DataHandle<edm4hep::CalorimeterHitCollection> m_ecalFwdCells{"ecalFwdCells",
+                                                                                 Gaudi::DataHandle::Reader, this};
   /// Handle for hadronic barrel cells (input collection)
-  mutable DataHandle<edm4hep::CalorimeterHitCollection> m_hcalBarrelCells{"hcalBarrelCells", Gaudi::DataHandle::Reader,
-                                                                          this};
+  mutable k4FWCore::DataHandle<edm4hep::CalorimeterHitCollection> m_hcalBarrelCells{"hcalBarrelCells",
+                                                                                    Gaudi::DataHandle::Reader, this};
   /// Handle for hadronic extended barrel cells (input collection)
-  mutable DataHandle<edm4hep::CalorimeterHitCollection> m_hcalExtBarrelCells{"hcalExtBarrelCells",
-                                                                             Gaudi::DataHandle::Reader, this};
+  mutable k4FWCore::DataHandle<edm4hep::CalorimeterHitCollection> m_hcalExtBarrelCells{"hcalExtBarrelCells",
+                                                                                       Gaudi::DataHandle::Reader, this};
   /// Handle for hcal endcap calorimeter cells (input collection)
-  mutable DataHandle<edm4hep::CalorimeterHitCollection> m_hcalEndcapCells{"hcalEndcapCells", Gaudi::DataHandle::Reader,
-                                                                          this};
+  mutable k4FWCore::DataHandle<edm4hep::CalorimeterHitCollection> m_hcalEndcapCells{"hcalEndcapCells",
+                                                                                    Gaudi::DataHandle::Reader, this};
   /// Handle for hcal forward calorimeter cells (input collection)
-  mutable DataHandle<edm4hep::CalorimeterHitCollection> m_hcalFwdCells{"hcalFwdCells", Gaudi::DataHandle::Reader, this};
+  mutable k4FWCore::DataHandle<edm4hep::CalorimeterHitCollection> m_hcalFwdCells{"hcalFwdCells",
+                                                                                 Gaudi::DataHandle::Reader, this};
   /// Pointer to the geometry service
   SmartIF<IGeoSvc> m_geoSvc;
   /// Name of the electromagnetic barrel readout

--- a/RecCalorimeter/src/components/CaloTowerTool.h
+++ b/RecCalorimeter/src/components/CaloTowerTool.h
@@ -139,24 +139,26 @@ private:
                                                   SegmentationType aType);
   std::pair<dd4hep::DDSegmentation::Segmentation*, SegmentationType> retrieveSegmentation(std::string aReadoutName);
   /// Handle for electromagnetic barrel cells (input collection)
-  mutable DataHandle<edm4hep::CalorimeterHitCollection> m_ecalBarrelCells{"ecalBarrelCells", Gaudi::DataHandle::Reader,
-                                                                          this};
+  mutable k4FWCore::DataHandle<edm4hep::CalorimeterHitCollection> m_ecalBarrelCells{"ecalBarrelCells",
+                                                                                    Gaudi::DataHandle::Reader, this};
   /// Handle for ecal endcap calorimeter cells (input collection)
-  mutable DataHandle<edm4hep::CalorimeterHitCollection> m_ecalEndcapCells{"ecalEndcapCells", Gaudi::DataHandle::Reader,
-                                                                          this};
+  mutable k4FWCore::DataHandle<edm4hep::CalorimeterHitCollection> m_ecalEndcapCells{"ecalEndcapCells",
+                                                                                    Gaudi::DataHandle::Reader, this};
   /// Handle for ecal forward calorimeter cells (input collection)
-  mutable DataHandle<edm4hep::CalorimeterHitCollection> m_ecalFwdCells{"ecalFwdCells", Gaudi::DataHandle::Reader, this};
+  mutable k4FWCore::DataHandle<edm4hep::CalorimeterHitCollection> m_ecalFwdCells{"ecalFwdCells",
+                                                                                 Gaudi::DataHandle::Reader, this};
   /// Handle for hadronic barrel cells (input collection)
-  mutable DataHandle<edm4hep::CalorimeterHitCollection> m_hcalBarrelCells{"hcalBarrelCells", Gaudi::DataHandle::Reader,
-                                                                          this};
+  mutable k4FWCore::DataHandle<edm4hep::CalorimeterHitCollection> m_hcalBarrelCells{"hcalBarrelCells",
+                                                                                    Gaudi::DataHandle::Reader, this};
   /// Handle for hadronic extended barrel cells (input collection)
-  mutable DataHandle<edm4hep::CalorimeterHitCollection> m_hcalExtBarrelCells{"hcalExtBarrelCells",
-                                                                             Gaudi::DataHandle::Reader, this};
+  mutable k4FWCore::DataHandle<edm4hep::CalorimeterHitCollection> m_hcalExtBarrelCells{"hcalExtBarrelCells",
+                                                                                       Gaudi::DataHandle::Reader, this};
   /// Handle for hcal endcap calorimeter cells (input collection)
-  mutable DataHandle<edm4hep::CalorimeterHitCollection> m_hcalEndcapCells{"hcalEndcapCells", Gaudi::DataHandle::Reader,
-                                                                          this};
+  mutable k4FWCore::DataHandle<edm4hep::CalorimeterHitCollection> m_hcalEndcapCells{"hcalEndcapCells",
+                                                                                    Gaudi::DataHandle::Reader, this};
   /// Handle for hcal forward calorimeter cells (input collection)
-  mutable DataHandle<edm4hep::CalorimeterHitCollection> m_hcalFwdCells{"hcalFwdCells", Gaudi::DataHandle::Reader, this};
+  mutable k4FWCore::DataHandle<edm4hep::CalorimeterHitCollection> m_hcalFwdCells{"hcalFwdCells",
+                                                                                 Gaudi::DataHandle::Reader, this};
   /// Pointer to the geometry service
   ServiceHandle<IGeoSvc> m_geoSvc;
   /// Name of the electromagnetic barrel readout

--- a/RecCalorimeter/src/components/ConeSelection.h
+++ b/RecCalorimeter/src/components/ConeSelection.h
@@ -40,11 +40,12 @@ private:
   ToolHandle<ICellPositionsTool> m_cellPositionsTool{"CellPositionsTool", this};
 
   /// Handle for calo hits (input collection)
-  mutable DataHandle<edm4hep::CalorimeterHitCollection> m_cells{"cells", Gaudi::DataHandle::Reader, this};
+  mutable k4FWCore::DataHandle<edm4hep::CalorimeterHitCollection> m_cells{"cells", Gaudi::DataHandle::Reader, this};
   /// Handle for calo hits (input collection)
-  mutable DataHandle<edm4hep::MCParticleCollection> m_particles{"particles", Gaudi::DataHandle::Reader, this};
+  mutable k4FWCore::DataHandle<edm4hep::MCParticleCollection> m_particles{"particles", Gaudi::DataHandle::Reader, this};
   /// Handle for calo cells (output collection)
-  mutable DataHandle<edm4hep::CalorimeterHitCollection> m_selCells{"selCells", Gaudi::DataHandle::Writer, this};
+  mutable k4FWCore::DataHandle<edm4hep::CalorimeterHitCollection> m_selCells{"selCells", Gaudi::DataHandle::Writer,
+                                                                             this};
   /// Map of cell IDs (corresponding to DD4hep IDs) and energy
   mutable std::unordered_map<uint64_t, double> m_cellsMap;
 

--- a/RecCalorimeter/src/components/CorrectCaloClusters.h
+++ b/RecCalorimeter/src/components/CorrectCaloClusters.h
@@ -159,9 +159,10 @@ private:
   double getClusterTheta(edm4hep::Cluster cluster) const;
 
   /// Handle for input calorimeter clusters collection
-  mutable DataHandle<edm4hep::ClusterCollection> m_inClusters{"inClusters", Gaudi::DataHandle::Reader, this};
+  mutable k4FWCore::DataHandle<edm4hep::ClusterCollection> m_inClusters{"inClusters", Gaudi::DataHandle::Reader, this};
   /// Handle for corrected (output) calorimeter clusters collection
-  mutable DataHandle<edm4hep::ClusterCollection> m_outClusters{"outClusters", Gaudi::DataHandle::Writer, this};
+  mutable k4FWCore::DataHandle<edm4hep::ClusterCollection> m_outClusters{"outClusters", Gaudi::DataHandle::Writer,
+                                                                         this};
 
   /// Pointer to the geometry service
   ServiceHandle<IGeoSvc> m_geoSvc;

--- a/RecCalorimeter/src/components/CorrectECalBarrelSliWinCluster.h
+++ b/RecCalorimeter/src/components/CorrectECalBarrelSliWinCluster.h
@@ -88,14 +88,14 @@ private:
    */
   double getNoiseRMSPerCluster(double aEta, uint numCells) const;
   /// Handle for clusters (input collection)
-  mutable DataHandle<edm4hep::ClusterCollection> m_inClusters{"clusters", Gaudi::DataHandle::Reader, this};
+  mutable k4FWCore::DataHandle<edm4hep::ClusterCollection> m_inClusters{"clusters", Gaudi::DataHandle::Reader, this};
   /// Handle for corrected clusters (output collection)
-  mutable DataHandle<edm4hep::ClusterCollection> m_correctedClusters{"correctedClusters", Gaudi::DataHandle::Writer,
-                                                                     this};
+  mutable k4FWCore::DataHandle<edm4hep::ClusterCollection> m_correctedClusters{"correctedClusters",
+                                                                               Gaudi::DataHandle::Writer, this};
   /// Handle for particles with truth position and energy information: for SINGLE PARTICLE EVENTS (input collection)
-  mutable DataHandle<edm4hep::MCParticleCollection> m_particle{"particles", Gaudi::DataHandle::Reader, this};
+  mutable k4FWCore::DataHandle<edm4hep::MCParticleCollection> m_particle{"particles", Gaudi::DataHandle::Reader, this};
   /// Handle for the genvertices to read vertex position information
-  mutable DataHandle<edm4hep::VertexCollection> m_vertex{"vertices", Gaudi::DataHandle::Reader, this};
+  mutable k4FWCore::DataHandle<edm4hep::VertexCollection> m_vertex{"vertices", Gaudi::DataHandle::Reader, this};
   /// Pointer to the interface of histogram service
   ServiceHandle<ITHistSvc> m_histSvc;
   /// Pointer to the geometry service

--- a/RecCalorimeter/src/components/CreateCaloCells.h
+++ b/RecCalorimeter/src/components/CreateCaloCells.h
@@ -84,13 +84,14 @@ private:
   Gaudi::Property<bool> m_addPosition{this, "addPosition", false, "Add position information to the cells?"};
 
   /// Handle for calo hits (input collection)
-  mutable DataHandle<edm4hep::SimCalorimeterHitCollection> m_hits{"hits", Gaudi::DataHandle::Reader, this};
+  mutable k4FWCore::DataHandle<edm4hep::SimCalorimeterHitCollection> m_hits{"hits", Gaudi::DataHandle::Reader, this};
   /// Handle for the cellID encoding string of the input collection
-  MetaDataHandle<std::string> m_hitsCellIDEncoding{m_hits, edm4hep::labels::CellIDEncoding, Gaudi::DataHandle::Reader};
+  k4FWCore::MetaDataHandle<std::string> m_hitsCellIDEncoding{m_hits, edm4hep::labels::CellIDEncoding,
+                                                             Gaudi::DataHandle::Reader};
   /// Handle for calo cells (output collection)
-  mutable DataHandle<edm4hep::CalorimeterHitCollection> m_cells{"cells", Gaudi::DataHandle::Writer, this};
-  MetaDataHandle<std::string> m_cellsCellIDEncoding{m_cells, edm4hep::labels::CellIDEncoding,
-                                                    Gaudi::DataHandle::Writer};
+  mutable k4FWCore::DataHandle<edm4hep::CalorimeterHitCollection> m_cells{"cells", Gaudi::DataHandle::Writer, this};
+  k4FWCore::MetaDataHandle<std::string> m_cellsCellIDEncoding{m_cells, edm4hep::labels::CellIDEncoding,
+                                                              Gaudi::DataHandle::Writer};
   /// Name of the detector readout
   Gaudi::Property<std::string> m_readoutName{this, "readoutName", "ECalBarrelPhiEta", "Name of the detector readout"};
   /// Name of active volumes

--- a/RecCalorimeter/src/components/CreateCaloCellsNoise.h
+++ b/RecCalorimeter/src/components/CreateCaloCellsNoise.h
@@ -76,9 +76,9 @@ private:
   Gaudi::Property<bool> m_addPosition{this, "addPosition", false, "Add position information to the cells?"};
 
   /// Handle for calo hits (input collection)
-  mutable DataHandle<edm4hep::CalorimeterHitCollection> m_hits{"hits", Gaudi::DataHandle::Reader, this};
+  mutable k4FWCore::DataHandle<edm4hep::CalorimeterHitCollection> m_hits{"hits", Gaudi::DataHandle::Reader, this};
   /// Handle for calo cells (output collection)
-  mutable DataHandle<edm4hep::CalorimeterHitCollection> m_cells{"cells", Gaudi::DataHandle::Writer, this};
+  mutable k4FWCore::DataHandle<edm4hep::CalorimeterHitCollection> m_cells{"cells", Gaudi::DataHandle::Writer, this};
   /// Name of the detector readout
   Gaudi::Property<std::string> m_readoutName{this, "readoutName", "ECalBarrelPhiEta", "Name of the detector readout"};
   /// Name of active volumes

--- a/RecCalorimeter/src/components/CreateCaloClusters.h
+++ b/RecCalorimeter/src/components/CreateCaloClusters.h
@@ -65,15 +65,16 @@ private:
   SmartIF<IGeoSvc> m_geoSvc;
 
   /// Handle for calo clusters (input collection)
-  mutable DataHandle<edm4hep::ClusterCollection> m_clusters{"calo/clusters", Gaudi::DataHandle::Reader, this};
+  mutable k4FWCore::DataHandle<edm4hep::ClusterCollection> m_clusters{"calo/clusters", Gaudi::DataHandle::Reader, this};
   /// Handle for calo clusters (input collection)
-  mutable DataHandle<edm4hep::MCParticleCollection> m_genParticles{"calo/genParticles", Gaudi::DataHandle::Reader,
-                                                                   this};
+  mutable k4FWCore::DataHandle<edm4hep::MCParticleCollection> m_genParticles{"calo/genParticles",
+                                                                             Gaudi::DataHandle::Reader, this};
   /// Handle for calo clusters (output collection)
-  mutable DataHandle<edm4hep::ClusterCollection> m_newClusters{"calo/calibClusters", Gaudi::DataHandle::Writer, this};
+  mutable k4FWCore::DataHandle<edm4hep::ClusterCollection> m_newClusters{"calo/calibClusters",
+                                                                         Gaudi::DataHandle::Writer, this};
   // Handle for calo cells (output collection)
-  mutable DataHandle<edm4hep::CalorimeterHitCollection> m_newCells{"calo/calibClusterCells", Gaudi::DataHandle::Writer,
-                                                                   this};
+  mutable k4FWCore::DataHandle<edm4hep::CalorimeterHitCollection> m_newCells{"calo/calibClusterCells",
+                                                                             Gaudi::DataHandle::Writer, this};
 
   /// Handle for tool to get positions in ECal Barrel
   ToolHandle<ICellPositionsTool> m_cellPositionsECalTool{"CellPositionsECalBarrelTool", this};

--- a/RecCalorimeter/src/components/CreateCaloClustersSlidingWindow.h
+++ b/RecCalorimeter/src/components/CreateCaloClustersSlidingWindow.h
@@ -89,10 +89,10 @@ private:
    */
   unsigned int phiNeighbour(int aIPhi) const;
   /// Handle for calo clusters (output collection)
-  mutable DataHandle<edm4hep::ClusterCollection> m_clusters{"calo/clusters", Gaudi::DataHandle::Writer, this};
+  mutable k4FWCore::DataHandle<edm4hep::ClusterCollection> m_clusters{"calo/clusters", Gaudi::DataHandle::Writer, this};
   /// Handle for calo cluster cells (output collection)
-  mutable DataHandle<edm4hep::CalorimeterHitCollection> m_clusterCells{"calo/clusterCells", Gaudi::DataHandle::Writer,
-                                                                       this};
+  mutable k4FWCore::DataHandle<edm4hep::CalorimeterHitCollection> m_clusterCells{"calo/clusterCells",
+                                                                                 Gaudi::DataHandle::Writer, this};
   /// Handle for the tower building tool
   mutable ToolHandle<ITowerTool> m_towerTool;
   // calorimeter towers

--- a/RecCalorimeter/src/components/CreateEmptyCaloCellsCollection.h
+++ b/RecCalorimeter/src/components/CreateEmptyCaloCellsCollection.h
@@ -40,7 +40,7 @@ public:
 
 private:
   /// Handle for the calo cells (output collection)
-  mutable DataHandle<edm4hep::CalorimeterHitCollection> m_caloCells{"cells", Gaudi::DataHandle::Writer, this};
+  mutable k4FWCore::DataHandle<edm4hep::CalorimeterHitCollection> m_caloCells{"cells", Gaudi::DataHandle::Writer, this};
 };
 
 #endif /* RECCALORIMETER_CREATEEMPTYCALOCELLSCOLLECTION_H */

--- a/RecCalorimeter/src/components/CreatePositionedCaloCells.h
+++ b/RecCalorimeter/src/components/CreatePositionedCaloCells.h
@@ -84,16 +84,18 @@ private:
                                           "Save only cells with energy above threshold?"};
 
   /// Handle for calo hits (input collection)
-  mutable DataHandle<edm4hep::SimCalorimeterHitCollection> m_hits{"hits", Gaudi::DataHandle::Reader, this};
+  mutable k4FWCore::DataHandle<edm4hep::SimCalorimeterHitCollection> m_hits{"hits", Gaudi::DataHandle::Reader, this};
   /// Handle for the cellID encoding string of the input hit collection
-  MetaDataHandle<std::string> m_hitsCellIDEncoding{m_hits, edm4hep::labels::CellIDEncoding, Gaudi::DataHandle::Reader};
+  k4FWCore::MetaDataHandle<std::string> m_hitsCellIDEncoding{m_hits, edm4hep::labels::CellIDEncoding,
+                                                             Gaudi::DataHandle::Reader};
   /// Handle for calo cells (output collection)
-  mutable DataHandle<edm4hep::CalorimeterHitCollection> m_cells{"cells", Gaudi::DataHandle::Writer, this};
+  mutable k4FWCore::DataHandle<edm4hep::CalorimeterHitCollection> m_cells{"cells", Gaudi::DataHandle::Writer, this};
   /// Handle for hit<->cell link (output collection)
-  mutable DataHandle<edm4hep::CaloHitSimCaloHitLinkCollection> m_links{"links", Gaudi::DataHandle::Writer, this};
+  mutable k4FWCore::DataHandle<edm4hep::CaloHitSimCaloHitLinkCollection> m_links{"links", Gaudi::DataHandle::Writer,
+                                                                                 this};
   /// Handle for the cellID encoding of the output cell collection
-  MetaDataHandle<std::string> m_cellsCellIDEncoding{m_cells, edm4hep::labels::CellIDEncoding,
-                                                    Gaudi::DataHandle::Writer};
+  k4FWCore::MetaDataHandle<std::string> m_cellsCellIDEncoding{m_cells, edm4hep::labels::CellIDEncoding,
+                                                              Gaudi::DataHandle::Writer};
   /// Maps of cell IDs (corresponding to DD4hep IDs) vs digitised cell energies
   mutable std::unordered_map<uint64_t, double> m_cellsMap;
   /// Maps of cell IDs (corresponding to DD4hep IDs) on transfer of signals due to crosstalk

--- a/RecCalorimeter/src/components/LayeredCaloTowerTool.h
+++ b/RecCalorimeter/src/components/LayeredCaloTowerTool.h
@@ -136,7 +136,8 @@ public:
 
 private:
   /// Handle for calo cells (input collection)
-  mutable DataHandle<edm4hep::CalorimeterHitCollection> m_cells{"calo/cells", Gaudi::DataHandle::Reader, this};
+  mutable k4FWCore::DataHandle<edm4hep::CalorimeterHitCollection> m_cells{"calo/cells", Gaudi::DataHandle::Reader,
+                                                                          this};
   /// Pointer to the geometry service
   ServiceHandle<IGeoSvc> m_geoSvc;
   /// Name of the detector readout

--- a/RecCalorimeter/src/components/MassInv.h
+++ b/RecCalorimeter/src/components/MassInv.h
@@ -89,12 +89,12 @@ private:
    */
   double getNoiseRMSPerCluster(double aEta, uint numCells) const;
   /// Handle for clusters (input collection)
-  mutable DataHandle<edm4hep::ClusterCollection> m_inClusters{"clusters", Gaudi::DataHandle::Reader, this};
+  mutable k4FWCore::DataHandle<edm4hep::ClusterCollection> m_inClusters{"clusters", Gaudi::DataHandle::Reader, this};
   /// Handle for corrected clusters (output collection)
-  mutable DataHandle<edm4hep::ClusterCollection> m_correctedClusters{"correctedClusters", Gaudi::DataHandle::Writer,
-                                                                     this};
+  mutable k4FWCore::DataHandle<edm4hep::ClusterCollection> m_correctedClusters{"correctedClusters",
+                                                                               Gaudi::DataHandle::Writer, this};
   /// Handle for particles with truth position and energy information: for SINGLE PARTICLE EVENTS (input collection)
-  mutable DataHandle<edm4hep::MCParticleCollection> m_particle{"particles", Gaudi::DataHandle::Reader, this};
+  mutable k4FWCore::DataHandle<edm4hep::MCParticleCollection> m_particle{"particles", Gaudi::DataHandle::Reader, this};
   /// Pointer to the interface of histogram service
   ServiceHandle<ITHistSvc> m_histSvc;
   /// Pointer to the geometry service

--- a/RecCalorimeter/src/components/PreparePileup.h
+++ b/RecCalorimeter/src/components/PreparePileup.h
@@ -74,7 +74,7 @@ private:
   int m_nPhiTower;
 
   /// Handle for calo hits (input collection)
-  mutable DataHandle<edm4hep::CalorimeterHitCollection> m_hits{"hits", Gaudi::DataHandle::Reader, this};
+  mutable k4FWCore::DataHandle<edm4hep::CalorimeterHitCollection> m_hits{"hits", Gaudi::DataHandle::Reader, this};
 
   /// Map of cell IDs (corresponding to DD4hep IDs) and energy
   mutable std::unordered_map<uint64_t, double> m_cellsMap;

--- a/RecCalorimeter/src/components/SimulateSiPMwithEdep.cpp
+++ b/RecCalorimeter/src/components/SimulateSiPMwithEdep.cpp
@@ -4,7 +4,8 @@
 
 DECLARE_COMPONENT(SimulateSiPMwithEdep)
 
-SimulateSiPMwithEdep::SimulateSiPMwithEdep(const std::string& aName, ISvcLocator* aSvcLoc) : Gaudi::Algorithm(aName, aSvcLoc) {}
+SimulateSiPMwithEdep::SimulateSiPMwithEdep(const std::string& aName, ISvcLocator* aSvcLoc)
+    : Gaudi::Algorithm(aName, aSvcLoc) {}
 
 StatusCode SimulateSiPMwithEdep::initialize() {
   StatusCode sc = Gaudi::Algorithm::initialize();
@@ -20,7 +21,7 @@ StatusCode SimulateSiPMwithEdep::initialize() {
     return StatusCode::FAILURE;
   }
 
-  if (m_rndmUniform.initialize(m_randSvc, Rndm::Flat(0.,1.)).isFailure()) {
+  if (m_rndmUniform.initialize(m_randSvc, Rndm::Flat(0., 1.)).isFailure()) {
     error() << "Couldn't initialize RndmGenSvc!" << endmsg;
     return StatusCode::FAILURE;
   }
@@ -36,21 +37,23 @@ StatusCode SimulateSiPMwithEdep::initialize() {
     return StatusCode::FAILURE;
   }
 
-  if (m_wavelen.size()!=m_sipmEff.size()) {
+  if (m_wavelen.size() != m_sipmEff.size()) {
     error() << "SimulateSiPMwithEdep: "
             << "The SiPM efficiency vector size should be equal to the wavelength vector size" << endmsg;
     return StatusCode::FAILURE;
   }
 
-  if (m_wavelen.size()!=m_scintSpectrum.size()) {
+  if (m_wavelen.size() != m_scintSpectrum.size()) {
     error() << "SimulateSiPMwithEdep: "
-               "The scintillation spectrum vector size should be equal to the wavelength vector size" << endmsg;
+               "The scintillation spectrum vector size should be equal to the wavelength vector size"
+            << endmsg;
     return StatusCode::FAILURE;
   }
 
-  if (m_wavelen.size()!=m_filterEff.size()) {
+  if (m_wavelen.size() != m_filterEff.size()) {
     error() << "SimulateSiPMwithEdep: "
-               "The filter efficiency vector size should be equal to the wavelength vector size" << endmsg;
+               "The filter efficiency vector size should be equal to the wavelength vector size"
+            << endmsg;
     return StatusCode::FAILURE;
   }
 
@@ -68,7 +71,7 @@ StatusCode SimulateSiPMwithEdep::initialize() {
   properties.setRiseTime(m_risetime);
   properties.setSnr(m_snr);
   properties.setPdeType(sipm::SiPMProperties::PdeType::kSpectrumPde);
-  properties.setPdeSpectrum(m_wavelen,m_sipmEff);
+  properties.setPdeSpectrum(m_wavelen, m_sipmEff);
 
   m_sensor = std::make_unique<sipm::SiPMSensor>(properties); // must be constructed from SiPMProperties
 
@@ -83,14 +86,15 @@ StatusCode SimulateSiPMwithEdep::initialize() {
 
   // integral scintillation spectrum times efficiency
   // and retrieve average efficiency
-  auto integralSpectrum = integral(m_wavelen.value(),m_scintSpectrum.value());
-  m_integral = integral(m_wavelen.value(),specTimesEff);
-  m_efficiency = m_integral.back()/integralSpectrum.back();
+  auto integralSpectrum = integral(m_wavelen.value(), m_scintSpectrum.value());
+  m_integral = integral(m_wavelen.value(), specTimesEff);
+  m_efficiency = m_integral.back() / integralSpectrum.back();
 
   return StatusCode::SUCCESS;
 }
 
-std::vector<double> SimulateSiPMwithEdep::integral(const std::vector<double>& wavelen, const std::vector<double>& yval) const {
+std::vector<double> SimulateSiPMwithEdep::integral(const std::vector<double>& wavelen,
+                                                   const std::vector<double>& yval) const {
   double val = 0.;
   double prevXval = wavelen.front();
   std::vector<double> result = {0.};
@@ -98,8 +102,8 @@ std::vector<double> SimulateSiPMwithEdep::integral(const std::vector<double>& wa
 
   for (unsigned idx = 1; idx < wavelen.size(); idx++) {
     double intervalX = std::abs(prevXval - wavelen.at(idx));
-    double avgY = (yval.at(idx) + yval.at(idx-1))/2.;
-    val += intervalX*avgY;
+    double avgY = (yval.at(idx) + yval.at(idx - 1)) / 2.;
+    val += intervalX * avgY;
     result.push_back(val);
   }
 
@@ -111,7 +115,7 @@ StatusCode SimulateSiPMwithEdep::execute(const EventContext&) const {
   edm4hep::CalorimeterHitCollection* digiHits = m_digiHits.createAndPut();
   edm4hep::TimeSeriesCollection* waveforms = m_waveforms.createAndPut();
 
-  const double yield = m_scintYield.value()/dd4hep::keV;
+  const double yield = m_scintYield.value() / dd4hep::keV;
 
   for (unsigned int idx = 0; idx < scintHits->size(); idx++) {
     const auto& scintHit = scintHits->at(idx);
@@ -120,9 +124,9 @@ StatusCode SimulateSiPMwithEdep::execute(const EventContext&) const {
     std::vector<double> vecTimes;
     std::vector<double> vecWavelens;
 
-    for (auto contrib = scintHit.contributions_begin(); contrib!=scintHit.contributions_end(); ++contrib) {
-      const double edep = contrib->getEnergy()*dd4hep::GeV;
-      double avgNphoton = edep*yield*m_efficiency;
+    for (auto contrib = scintHit.contributions_begin(); contrib != scintHit.contributions_end(); ++contrib) {
+      const double edep = contrib->getEnergy() * dd4hep::GeV;
+      double avgNphoton = edep * yield * m_efficiency;
 
       // generate the number of p.e. (npe)
       unsigned npe = 0;
@@ -131,14 +135,14 @@ StatusCode SimulateSiPMwithEdep::execute(const EventContext&) const {
         Rndm::Numbers rnd(m_randSvc, Rndm::Poisson(avgNphoton));
         npe = static_cast<unsigned>(std::floor(rnd.shoot() + 0.5));
       } else {
-        Rndm::Numbers rnd(m_randSvc, Rndm::Gauss(avgNphoton,std::sqrt(avgNphoton)));
+        Rndm::Numbers rnd(m_randSvc, Rndm::Gauss(avgNphoton, std::sqrt(avgNphoton)));
         // prevent underflow since Gaussian can shoot negative in rare case
         double val = std::floor(rnd.shoot() + 0.5);
         npe = static_cast<unsigned>(std::max(val, 0.));
       }
 
-      vecTimes.reserve(vecTimes.size()+npe);
-      vecWavelens.reserve(vecTimes.size()+npe);
+      vecTimes.reserve(vecTimes.size() + npe);
+      vecWavelens.reserve(vecTimes.size() + npe);
 
       // calculate photon arrival time at SiPM
       // using the distance from the step to the SiPM
@@ -148,19 +152,21 @@ StatusCode SimulateSiPMwithEdep::execute(const EventContext&) const {
       const float relX = sipmPos.x - stepPos.x;
       const float relY = sipmPos.y - stepPos.y;
       const float relZ = sipmPos.z - stepPos.z;
-      const float dist = std::sqrt(relX*relX + relY*relY + relZ*relZ)*dd4hep::mm; // in mm (edm4hep unit)
+      const float dist = std::sqrt(relX * relX + relY * relY + relZ * relZ) * dd4hep::mm; // in mm (edm4hep unit)
 
-      const double effSpeedOfLight = dd4hep::c_light/m_refractiveIndex.value();
-      const double distTime = dist/effSpeedOfLight;
-      const double arrivalTime = m_switchTime.value() ? initialTime : initialTime + distTime/dd4hep::nanosecond; // in ns
+      const double effSpeedOfLight = dd4hep::c_light / m_refractiveIndex.value();
+      const double distTime = dist / effSpeedOfLight;
+      const double arrivalTime =
+          m_switchTime.value() ? initialTime : initialTime + distTime / dd4hep::nanosecond; // in ns
 
       for (unsigned ipho = 0; ipho < npe; ipho++) {
         // get photon wavelength
-        // similar to https://gitlab.cern.ch/geant4/geant4/-/blob/master/source/processes/electromagnetic/xrays/src/G4Scintillation.cc
-        const double randval = m_integral.back()*m_rndmUniform.shoot();
+        // similar to
+        // https://gitlab.cern.ch/geant4/geant4/-/blob/master/source/processes/electromagnetic/xrays/src/G4Scintillation.cc
+        const double randval = m_integral.back() * m_rndmUniform.shoot();
         unsigned xhigh = 1;
 
-        for (xhigh = 1; xhigh < m_integral.size()-1; xhigh++) {
+        for (xhigh = 1; xhigh < m_integral.size() - 1; xhigh++) {
           if (randval < m_integral.at(xhigh))
             break;
         }
@@ -169,13 +175,13 @@ StatusCode SimulateSiPMwithEdep::execute(const EventContext&) const {
         const unsigned xlow = xhigh - 1;
         const double xdiff = m_wavelen.value().at(xhigh) - m_wavelen.value().at(xlow);
         const double ydiff = m_integral.at(xhigh) - m_integral.at(xlow);
-        const double ydiffInv = (ydiff==0.) ? 0. : 1./ydiff;
-        double valWav = m_wavelen.value().at(xlow) + xdiff*(randval-m_integral.at(xlow))*ydiffInv;
+        const double ydiffInv = (ydiff == 0.) ? 0. : 1. / ydiff;
+        double valWav = m_wavelen.value().at(xlow) + xdiff * (randval - m_integral.at(xlow)) * ydiffInv;
 
         // get absorption length
         unsigned iwave = 1;
 
-        for (iwave = 1; iwave < m_wavelen.value().size()-1; iwave++) { // decreasing order
+        for (iwave = 1; iwave < m_wavelen.value().size() - 1; iwave++) { // decreasing order
           if (valWav > m_wavelen.value().at(iwave))
             break;
         }
@@ -183,19 +189,20 @@ StatusCode SimulateSiPMwithEdep::execute(const EventContext&) const {
         // absorption length is ill-defined if scintHit.getPosition() is not the sensor position
         if (!m_switchTime.value()) {
           // linear interpolation
-          const unsigned waveLow = iwave -1;
+          const unsigned waveLow = iwave - 1;
           const double waveDiff = m_wavelen.value().at(iwave) - m_wavelen.value().at(waveLow);
-          const double waveDiffInv = (waveDiff==0.) ? 0. : 1./waveDiff;
+          const double waveDiffInv = (waveDiff == 0.) ? 0. : 1. / waveDiff;
           const double abslenDiff = m_absLen.value().at(iwave) - m_absLen.value().at(waveLow);
-          double absLen = m_absLen.value().at(waveLow) + abslenDiff*waveDiffInv*(valWav - m_wavelen.value().at(waveLow));
+          double absLen =
+              m_absLen.value().at(waveLow) + abslenDiff * waveDiffInv * (valWav - m_wavelen.value().at(waveLow));
 
           // check absorption
           // similar to https://gitlab.cern.ch/geant4/geant4/-/blob/master/source/processes/management/src/G4VProcess.cc
-          const double nInteractionLengthLeft = -std::log( m_rndmUniform.shoot() );
-          const double nInteractionLength = dist/(absLen*dd4hep::meter);
+          const double nInteractionLengthLeft = -std::log(m_rndmUniform.shoot());
+          const double nInteractionLength = dist / (absLen * dd4hep::meter);
 
           // absorb photons
-          if ( nInteractionLength > nInteractionLengthLeft )
+          if (nInteractionLength > nInteractionLengthLeft)
             continue;
         }
 
@@ -208,8 +215,8 @@ StatusCode SimulateSiPMwithEdep::execute(const EventContext&) const {
     } // contrib
 
     m_sensor->resetState();
-    m_sensor->addPhotons(vecTimes,vecWavelens); // Sets photon times & wavelengths
-    m_sensor->runEvent(); // Runs the simulation
+    m_sensor->addPhotons(vecTimes, vecWavelens); // Sets photon times & wavelengths
+    m_sensor->runEvent();                        // Runs the simulation
 
     auto digiHit = digiHits->create();
     auto waveform = waveforms->create();
@@ -218,20 +225,21 @@ StatusCode SimulateSiPMwithEdep::execute(const EventContext&) const {
     const sipm::SiPMAnalogSignal anaSignal = m_sensor->signal();
 
     // if the signal never exceeds the threshold, it will return -1.
-    const double integral = std::max(0., anaSignal.integral(m_gateStart,m_gateL,m_thres)); // (intStart, intGate, threshold)
-    const double toa = std::max(0., anaSignal.toa(m_gateStart,m_gateL,m_thres));           // (intStart, intGate, threshold)
+    const double integral =
+        std::max(0., anaSignal.integral(m_gateStart, m_gateL, m_thres));           // (intStart, intGate, threshold)
+    const double toa = std::max(0., anaSignal.toa(m_gateStart, m_gateL, m_thres)); // (intStart, intGate, threshold)
     const double gateEnd = m_gateStart.value() + m_gateL.value();
 
-    digiHit.setEnergy( integral*m_scaleADC.value() );
-    digiHit.setEnergyError( m_scaleADC.value()*std::sqrt(integral) );
-    digiHit.setPosition( scintHit.getPosition() );
-    digiHit.setCellID( scintHit.getCellID() );
+    digiHit.setEnergy(integral * m_scaleADC.value());
+    digiHit.setEnergyError(m_scaleADC.value() * std::sqrt(integral));
+    digiHit.setPosition(scintHit.getPosition());
+    digiHit.setCellID(scintHit.getCellID());
     // Toa and m_gateStart are in ns
-    digiHit.setTime( toa+m_gateStart );
+    digiHit.setTime(toa + m_gateStart);
 
     // Set waveform properties
     waveform.setInterval(m_sampling);
-    waveform.setTime(toa+m_gateStart);
+    waveform.setTime(toa + m_gateStart);
     waveform.setCellID(scintHit.getCellID());
 
     // Fill the waveform with amplitude values
@@ -245,7 +253,7 @@ StatusCode SimulateSiPMwithEdep::execute(const EventContext&) const {
         double center = (tStart + tEnd) / 2.;
 
         // Only include samples within our time window of interest
-        if (center < toa+m_gateStart)
+        if (center < toa + m_gateStart)
           continue;
 
         if (center > gateEnd)
@@ -261,6 +269,4 @@ StatusCode SimulateSiPMwithEdep::execute(const EventContext&) const {
   return StatusCode::SUCCESS;
 }
 
-StatusCode SimulateSiPMwithEdep::finalize() {
-  return Gaudi::Algorithm::finalize();
-}
+StatusCode SimulateSiPMwithEdep::finalize() { return Gaudi::Algorithm::finalize(); }

--- a/RecCalorimeter/src/components/SimulateSiPMwithEdep.h
+++ b/RecCalorimeter/src/components/SimulateSiPMwithEdep.h
@@ -1,10 +1,10 @@
 #ifndef SimulateSiPMwithEdep_h
 #define SimulateSiPMwithEdep_h 1
 
-#include "edm4hep/SimCalorimeterHitCollection.h"
 #include "edm4hep/CalorimeterHitCollection.h"
-#include "edm4hep/TimeSeriesCollection.h"
 #include "edm4hep/EventHeaderCollection.h"
+#include "edm4hep/SimCalorimeterHitCollection.h"
+#include "edm4hep/TimeSeriesCollection.h"
 
 #include "k4FWCore/DataHandle.h"
 
@@ -55,13 +55,19 @@ private:
   Rndm::Numbers m_rndmExp;
 
   // input collection names
-  Gaudi::Property<std::string> m_hitColl{this, "inputHitCollection", "DRcaloSiPMreadout_scint", "input calo collection name"};
-  Gaudi::Property<std::string> m_outColl{this, "outputHitCollection", "DRcaloSiPMreadoutDigiHit_scint", "output calo collection name"};
-  Gaudi::Property<std::string> m_outTimeColl{this, "outputTimeStructCollection", "DRcaloSiPMreadoutDigiWaveform_scint", "output waveform collection name"};
+  Gaudi::Property<std::string> m_hitColl{this, "inputHitCollection", "DRcaloSiPMreadout_scint",
+                                         "input calo collection name"};
+  Gaudi::Property<std::string> m_outColl{this, "outputHitCollection", "DRcaloSiPMreadoutDigiHit_scint",
+                                         "output calo collection name"};
+  Gaudi::Property<std::string> m_outTimeColl{this, "outputTimeStructCollection", "DRcaloSiPMreadoutDigiWaveform_scint",
+                                             "output waveform collection name"};
 
-  mutable DataHandle<edm4hep::SimCalorimeterHitCollection> m_scintHits{m_hitColl, Gaudi::DataHandle::Reader, this};
-  mutable DataHandle<edm4hep::CalorimeterHitCollection> m_digiHits{m_outColl, Gaudi::DataHandle::Writer, this};
-  mutable DataHandle<edm4hep::TimeSeriesCollection> m_waveforms{m_outTimeColl, Gaudi::DataHandle::Writer, this};
+  mutable k4FWCore::DataHandle<edm4hep::SimCalorimeterHitCollection> m_scintHits{m_hitColl, Gaudi::DataHandle::Reader,
+                                                                                 this};
+  mutable k4FWCore::DataHandle<edm4hep::CalorimeterHitCollection> m_digiHits{m_outColl, Gaudi::DataHandle::Writer,
+                                                                             this};
+  mutable k4FWCore::DataHandle<edm4hep::TimeSeriesCollection> m_waveforms{m_outTimeColl, Gaudi::DataHandle::Writer,
+                                                                          this};
 
   std::unique_ptr<sipm::SiPMSensor> m_sensor;
 
@@ -75,7 +81,8 @@ private:
   // SiPM physical properties
   Gaudi::Property<double> m_sipmSize{this, "SiPMsize", 1.3, "width of photosensitive area in mm"};
   Gaudi::Property<double> m_cellPitch{this, "cellpitch", 10., "SiPM cell size in um"};
-  Gaudi::Property<double> m_recovery{this, "recovery", 10., "SiPM cell recovery time in ns"}; // https://arxiv.org/abs/2001.10322
+  Gaudi::Property<double> m_recovery{this, "recovery", 10.,
+                                     "SiPM cell recovery time in ns"}; // https://arxiv.org/abs/2001.10322
 
   // Noise parameters
   Gaudi::Property<double> m_Dcr{this, "DCR", 120e3, "SiPM DCR"}; // dark count rate
@@ -85,20 +92,26 @@ private:
 
   // integration parameters
   Gaudi::Property<double> m_gateStart{this, "gateStart", 5., "Integration gate starting time in ns"};
-  Gaudi::Property<double> m_gateL{this, "gateLength", 95., "Integration gate length in ns"};  // Should be approx 5 times fallTimeFast (see above)
-  Gaudi::Property<double> m_thres{this, "threshold", 1.5, "Integration threshold"};  // Threshold in p.e. (1.5 to suppress DCR)
+  Gaudi::Property<double> m_gateL{this, "gateLength", 95.,
+                                  "Integration gate length in ns"}; // Should be approx 5 times fallTimeFast (see above)
+  Gaudi::Property<double> m_thres{this, "threshold", 1.5,
+                                  "Integration threshold"}; // Threshold in p.e. (1.5 to suppress DCR)
 
   // SiPM efficiency, filter efficiency
-  Gaudi::Property<std::vector<double>> m_wavelen{this, "wavelength", {1000., 100.}, "wavelength vector in nm (decreasing order)"};
+  Gaudi::Property<std::vector<double>> m_wavelen{
+      this, "wavelength", {1000., 100.}, "wavelength vector in nm (decreasing order)"};
   Gaudi::Property<std::vector<double>> m_sipmEff{this, "sipmEfficiency", {0.1, 0.1}, "SiPM efficiency vs wavelength"};
-  Gaudi::Property<std::vector<double>> m_filterEff{this, "filterEfficiency", {0.1, 0.1}, "optical filter efficiency vs wavelength"};
+  Gaudi::Property<std::vector<double>> m_filterEff{
+      this, "filterEfficiency", {0.1, 0.1}, "optical filter efficiency vs wavelength"};
 
   // scintillator optical properties
   Gaudi::Property<double> m_refractiveIndex{this, "refractiveIndex", 1.6, "scintillator refractive index"};
-  Gaudi::Property<std::vector<double>> m_absLen{this, "absorptionLength", {9999., 9999.}, "scintillator absorption length in meter"};
+  Gaudi::Property<std::vector<double>> m_absLen{
+      this, "absorptionLength", {9999., 9999.}, "scintillator absorption length in meter"};
 
   // Scintillation spectrum and decay time
-  Gaudi::Property<std::vector<double>> m_scintSpectrum{this, "scintSpectrum", {1., 1.}, "scintillation spectrum vs wavelength"};
+  Gaudi::Property<std::vector<double>> m_scintSpectrum{
+      this, "scintSpectrum", {1., 1.}, "scintillation spectrum vs wavelength"};
   Gaudi::Property<double> m_scintDecaytime{this, "scintDecaytime", 2.8, "scintillation decay time in ns"};
 
   // TB-based empirical values after considering attenuation, NIM time window, etc.
@@ -109,7 +122,8 @@ private:
   Gaudi::Property<double> m_scaleADC{this, "scaleADC", 1., "calibration factor for scaling ADC to energy"};
 
   // switch to use the stored edm4hep::CaloHitContribution::getTime() as it is
-  Gaudi::Property<bool> m_switchTime{this, "switchTime", false, "switch to use the stored edm4hep::CaloHitContribution::getTime() as it is"};
+  Gaudi::Property<bool> m_switchTime{this, "switchTime", false,
+                                     "switch to use the stored edm4hep::CaloHitContribution::getTime() as it is"};
 
   // integral table - initialized at SimulateSiPMwithEdep::initialize()
   std::vector<double> m_integral;

--- a/RecCalorimeter/src/components/SimulateSiPMwithOpticalPhoton.cpp
+++ b/RecCalorimeter/src/components/SimulateSiPMwithOpticalPhoton.cpp
@@ -4,7 +4,7 @@
 DECLARE_COMPONENT(SimulateSiPMwithOpticalPhoton)
 
 SimulateSiPMwithOpticalPhoton::SimulateSiPMwithOpticalPhoton(const std::string& aName, ISvcLocator* aSvcLoc)
-  : Gaudi::Algorithm(aName, aSvcLoc) {
+    : Gaudi::Algorithm(aName, aSvcLoc) {
   // Constructor doesn't need to do anything special
 }
 
@@ -23,7 +23,7 @@ StatusCode SimulateSiPMwithOpticalPhoton::initialize() {
     return StatusCode::FAILURE;
   }
 
-  if (m_rndmUniform.initialize(m_randSvc, Rndm::Flat(0.,1.)).isFailure()) {
+  if (m_rndmUniform.initialize(m_randSvc, Rndm::Flat(0., 1.)).isFailure()) {
     error() << "Couldn't initialize RndmGenSvc!" << endmsg;
     return StatusCode::FAILURE;
   }
@@ -34,7 +34,7 @@ StatusCode SimulateSiPMwithOpticalPhoton::initialize() {
     return StatusCode::FAILURE;
   }
 
-  if (m_wavelen.size()!=m_sipmEff.size()) {
+  if (m_wavelen.size() != m_sipmEff.size()) {
     error() << "SimulateSiPMwithOpticalPhoton: "
             << "The SiPM efficiency vector size should be equal to the wavelength vector size" << endmsg;
     return StatusCode::FAILURE;
@@ -56,7 +56,7 @@ StatusCode SimulateSiPMwithOpticalPhoton::initialize() {
   // Set the PDE type to spectrum PDE
   properties.setPdeType(sipm::SiPMProperties::PdeType::kSpectrumPde);
   // Set the PDE spectrum
-  properties.setPdeSpectrum(m_wavelen.value(),m_sipmEff.value());
+  properties.setPdeSpectrum(m_wavelen.value(), m_sipmEff.value());
 
   // Create the SiPM sensor model
   m_sensor = std::make_unique<sipm::SiPMSensor>(properties);
@@ -67,7 +67,8 @@ StatusCode SimulateSiPMwithOpticalPhoton::initialize() {
   return StatusCode::SUCCESS;
 }
 
-std::vector<double> SimulateSiPMwithOpticalPhoton::integral(const std::vector<double>& wavelen, const std::vector<double>& yval) const {
+std::vector<double> SimulateSiPMwithOpticalPhoton::integral(const std::vector<double>& wavelen,
+                                                            const std::vector<double>& yval) const {
   double val = 0.;
   double prevXval = wavelen.front();
   std::vector<double> result = {0.};
@@ -75,8 +76,8 @@ std::vector<double> SimulateSiPMwithOpticalPhoton::integral(const std::vector<do
 
   for (unsigned idx = 1; idx < wavelen.size(); idx++) {
     double intervalX = std::abs(prevXval - wavelen.at(idx));
-    double avgY = (yval.at(idx) + yval.at(idx-1))/2.;
-    val += intervalX*avgY;
+    double avgY = (yval.at(idx) + yval.at(idx - 1)) / 2.;
+    val += intervalX * avgY;
     result.push_back(val);
   }
 
@@ -121,14 +122,14 @@ StatusCode SimulateSiPMwithOpticalPhoton::execute(const EventContext&) const {
     vecSpectrum.reserve(waveLength.adcCounts_size());
     // be aware that we loop in the decreasing order!
     for (unsigned bin = waveLength.adcCounts_size(); bin != 1; bin--) {
-      double wavlenBinCenter = waveLength.getTime() + waveLength.getInterval() * (static_cast<float>(bin-1) + 0.5);
-      double spectrum = static_cast<double>(waveLength.getAdcCounts(bin-1));
+      double wavlenBinCenter = waveLength.getTime() + waveLength.getInterval() * (static_cast<float>(bin - 1) + 0.5);
+      double spectrum = static_cast<double>(waveLength.getAdcCounts(bin - 1));
 
       vecWavelenEdm.push_back(wavlenBinCenter);
       vecSpectrum.push_back(spectrum);
     }
 
-    std::vector<double> integralSpectrum = integral(vecWavelenEdm,vecSpectrum);
+    std::vector<double> integralSpectrum = integral(vecWavelenEdm, vecSpectrum);
 
     // extract photon arrival times from the time structure
     // and generate wavelength according to the pdf
@@ -146,10 +147,10 @@ StatusCode SimulateSiPMwithOpticalPhoton::execute(const EventContext&) const {
         vecTimes.emplace_back(timeBin);
 
         // generate wavelength
-        const double randval = integralSpectrum.back()*m_rndmUniform.shoot();
+        const double randval = integralSpectrum.back() * m_rndmUniform.shoot();
         unsigned xhigh = 1;
 
-        for (; xhigh < integralSpectrum.size()-1; xhigh++) {
+        for (; xhigh < integralSpectrum.size() - 1; xhigh++) {
           if (randval < integralSpectrum.at(xhigh))
             break;
         }
@@ -157,8 +158,8 @@ StatusCode SimulateSiPMwithOpticalPhoton::execute(const EventContext&) const {
         const unsigned xlow = xhigh - 1;
         const double xdiff = vecWavelenEdm.at(xhigh) - vecWavelenEdm.at(xlow);
         const double ydiff = integralSpectrum.at(xhigh) - integralSpectrum.at(xlow);
-        const double ydiffInv = (ydiff==0.) ? 0. : 1./ydiff;
-        double valWav = vecWavelenEdm.at(xlow) + xdiff*(randval-integralSpectrum.at(xlow))*ydiffInv;
+        const double ydiffInv = (ydiff == 0.) ? 0. : 1. / ydiff;
+        double valWav = vecWavelenEdm.at(xlow) + xdiff * (randval - integralSpectrum.at(xlow)) * ydiffInv;
 
         vecWavelengths.emplace_back(valWav);
       }
@@ -167,7 +168,7 @@ StatusCode SimulateSiPMwithOpticalPhoton::execute(const EventContext&) const {
     // Reset the SiPM state and run the simulation
     m_sensor->resetState();
     m_sensor->addPhotons(vecTimes, vecWavelengths); // Sets photon arrival times (in ns) & wavelengths (in nm)
-    m_sensor->runEvent();        // Runs the SiPM simulation
+    m_sensor->runEvent();                           // Runs the SiPM simulation
 
     auto digiHit = digiHits->create();
     auto waveform = waveforms->create();
@@ -177,13 +178,14 @@ StatusCode SimulateSiPMwithOpticalPhoton::execute(const EventContext&) const {
 
     // Compute integral (energy) and time of arrival
     // if the signal never exceeds the threshold, it will return -1.
-    const double integral = std::max(0., anaSignal.integral(m_gateStart, m_gateL, m_thres)); // (intStart, intGate, threshold)
-    const double toa = std::max(0., anaSignal.toa(m_gateStart, m_gateL, m_thres));           // (intStart, intGate, threshold)
+    const double integral =
+        std::max(0., anaSignal.integral(m_gateStart, m_gateL, m_thres));           // (intStart, intGate, threshold)
+    const double toa = std::max(0., anaSignal.toa(m_gateStart, m_gateL, m_thres)); // (intStart, intGate, threshold)
     const double gateEnd = m_gateStart.value() + m_gateL.value();
 
     // Set digitized hit properties
-    digiHit.setEnergy(integral*m_scaleADC.value());
-    digiHit.setEnergyError(m_scaleADC.value()*std::sqrt(integral));
+    digiHit.setEnergy(integral * m_scaleADC.value());
+    digiHit.setEnergyError(m_scaleADC.value() * std::sqrt(integral));
     digiHit.setPosition(simHit.getPosition());
     digiHit.setCellID(simHit.getCellID());
     digiHit.setTime(toa + m_gateStart); // Toa and m_gateStart are in ns

--- a/RecCalorimeter/src/components/SimulateSiPMwithOpticalPhoton.h
+++ b/RecCalorimeter/src/components/SimulateSiPMwithOpticalPhoton.h
@@ -2,9 +2,9 @@
 #define RECCALORIMETER_SimulateSiPMwithOpticalPhoton_H
 
 // EDM4HEP includes
-#include "edm4hep/SimCalorimeterHitCollection.h"
 #include "edm4hep/CalorimeterHitCollection.h"
 #include "edm4hep/RawTimeSeriesCollection.h"
+#include "edm4hep/SimCalorimeterHitCollection.h"
 #include "edm4hep/TimeSeriesCollection.h"
 
 // k4FWCore includes
@@ -12,9 +12,9 @@
 
 // Gaudi includes
 #include "Gaudi/Algorithm.h"
-#include "GaudiKernel/ToolHandle.h"
 #include "GaudiKernel/IRndmGenSvc.h"
 #include "GaudiKernel/RndmGenerators.h"
+#include "GaudiKernel/ToolHandle.h"
 
 // Check for SiPMSensor header location (similar to how DigiSiPM handles this)
 #if __has_include("SiPMSensor.h")
@@ -59,21 +59,31 @@ private:
   Rndm::Numbers m_rndmUniform;
 
   // input collection names
-  Gaudi::Property<std::string> m_hitColl{this, "inputHitCollection", "DRcaloSiPMreadoutSimHit", "input calo collection name"};
-  Gaudi::Property<std::string> m_outColl{this, "outputHitCollection", "DRcaloSiPMreadoutDigiHit", "output calo collection name"};
+  Gaudi::Property<std::string> m_hitColl{this, "inputHitCollection", "DRcaloSiPMreadoutSimHit",
+                                         "input calo collection name"};
+  Gaudi::Property<std::string> m_outColl{this, "outputHitCollection", "DRcaloSiPMreadoutDigiHit",
+                                         "output calo collection name"};
 
-  Gaudi::Property<std::string> m_inTimeColl{this, "inputTimeStructCollection", "DRcaloSiPMreadoutTimeStruct", "input time structure collection name"};
-  Gaudi::Property<std::string> m_inWavlenColl{this, "inputWavlenCollection", "DRcaloSiPMreadoutWaveLen", "input wavelength collection name"};
-  Gaudi::Property<std::string> m_outTimeColl{this, "outputTimeStructCollection", "DRcaloSiPMreadoutDigiWaveform", "output waveform collection name"};
+  Gaudi::Property<std::string> m_inTimeColl{this, "inputTimeStructCollection", "DRcaloSiPMreadoutTimeStruct",
+                                            "input time structure collection name"};
+  Gaudi::Property<std::string> m_inWavlenColl{this, "inputWavlenCollection", "DRcaloSiPMreadoutWaveLen",
+                                              "input wavelength collection name"};
+  Gaudi::Property<std::string> m_outTimeColl{this, "outputTimeStructCollection", "DRcaloSiPMreadoutDigiWaveform",
+                                             "output waveform collection name"};
 
   // Input collections
-  mutable DataHandle<edm4hep::SimCalorimeterHitCollection> m_simHits{m_hitColl, Gaudi::DataHandle::Reader, this};
-  mutable DataHandle<edm4hep::RawTimeSeriesCollection> m_timeStruct{m_inTimeColl, Gaudi::DataHandle::Reader, this};
-  mutable DataHandle<edm4hep::RawTimeSeriesCollection> m_wavelenStruct{m_inWavlenColl, Gaudi::DataHandle::Reader, this};
+  mutable k4FWCore::DataHandle<edm4hep::SimCalorimeterHitCollection> m_simHits{m_hitColl, Gaudi::DataHandle::Reader,
+                                                                               this};
+  mutable k4FWCore::DataHandle<edm4hep::RawTimeSeriesCollection> m_timeStruct{m_inTimeColl, Gaudi::DataHandle::Reader,
+                                                                              this};
+  mutable k4FWCore::DataHandle<edm4hep::RawTimeSeriesCollection> m_wavelenStruct{m_inWavlenColl,
+                                                                                 Gaudi::DataHandle::Reader, this};
 
   // Output collections
-  mutable DataHandle<edm4hep::CalorimeterHitCollection> m_digiHits{m_outColl, Gaudi::DataHandle::Writer, this};
-  mutable DataHandle<edm4hep::TimeSeriesCollection> m_waveforms{m_outTimeColl, Gaudi::DataHandle::Writer, this};
+  mutable k4FWCore::DataHandle<edm4hep::CalorimeterHitCollection> m_digiHits{m_outColl, Gaudi::DataHandle::Writer,
+                                                                             this};
+  mutable k4FWCore::DataHandle<edm4hep::TimeSeriesCollection> m_waveforms{m_outTimeColl, Gaudi::DataHandle::Writer,
+                                                                          this};
 
   // SiPM sensor model
   std::unique_ptr<sipm::SiPMSensor> m_sensor;
@@ -102,7 +112,8 @@ private:
   Gaudi::Property<double> m_thres{this, "threshold", 1.5, "Integration threshold in photoelectrons"};
 
   // SiPM efficiency
-  Gaudi::Property<std::vector<double>> m_wavelen{this, "wavelength", {1000., 100.}, "wavelength vector in nm (decreasing order)"};
+  Gaudi::Property<std::vector<double>> m_wavelen{
+      this, "wavelength", {1000., 100.}, "wavelength vector in nm (decreasing order)"};
   Gaudi::Property<std::vector<double>> m_sipmEff{this, "sipmEfficiency", {0.1, 0.1}, "SiPM efficiency vs wavelength"};
 
   // scale ADC to energy

--- a/RecCalorimeter/src/components/SplitClusters.h
+++ b/RecCalorimeter/src/components/SplitClusters.h
@@ -91,12 +91,13 @@ private:
   SmartIF<IGeoSvc> m_geoSvc;
 
   /// Handle for calo clusters (input collection)
-  mutable DataHandle<edm4hep::ClusterCollection> m_clusters{"calo/clusters", Gaudi::DataHandle::Reader, this};
+  mutable k4FWCore::DataHandle<edm4hep::ClusterCollection> m_clusters{"calo/clusters", Gaudi::DataHandle::Reader, this};
   /// Handle for calo clusters (output collection)
-  mutable DataHandle<edm4hep::ClusterCollection> m_newClusters{"calo/calibClusters", Gaudi::DataHandle::Writer, this};
+  mutable k4FWCore::DataHandle<edm4hep::ClusterCollection> m_newClusters{"calo/calibClusters",
+                                                                         Gaudi::DataHandle::Writer, this};
   // Handle for calo cells (output collection)
-  mutable DataHandle<edm4hep::CalorimeterHitCollection> m_newCells{"calo/calibClusterCells", Gaudi::DataHandle::Writer,
-                                                                   this};
+  mutable k4FWCore::DataHandle<edm4hep::CalorimeterHitCollection> m_newCells{"calo/calibClusterCells",
+                                                                             Gaudi::DataHandle::Writer, this};
   /// Handle for neighbours tool
   mutable ToolHandle<ICaloReadNeighboursMap> m_neighboursTool{"TopoCaloNeighbours", this};
 

--- a/RecFCCeeCalorimeter/src/components/AugmentClustersFCCee.h
+++ b/RecFCCeeCalorimeter/src/components/AugmentClustersFCCee.h
@@ -48,14 +48,15 @@ public:
 
 private:
   /// Handle for input clusters
-  mutable DataHandle<edm4hep::ClusterCollection> m_inClusters{"inClusters", Gaudi::DataHandle::Reader, this};
+  mutable k4FWCore::DataHandle<edm4hep::ClusterCollection> m_inClusters{"inClusters", Gaudi::DataHandle::Reader, this};
   /// Handle for output clusters
-  mutable DataHandle<edm4hep::ClusterCollection> m_outClusters{"outClusters", Gaudi::DataHandle::Writer, this};
+  mutable k4FWCore::DataHandle<edm4hep::ClusterCollection> m_outClusters{"outClusters", Gaudi::DataHandle::Writer,
+                                                                         this};
   /// Handle for the cluster shape metadata to read and to write
-  MetaDataHandle<std::vector<std::string>> m_inShapeParameterHandle{m_inClusters, edm4hep::labels::ShapeParameterNames,
-                                                                    Gaudi::DataHandle::Reader};
-  MetaDataHandle<std::vector<std::string>> m_showerShapeHandle{m_outClusters, edm4hep::labels::ShapeParameterNames,
-                                                               Gaudi::DataHandle::Writer};
+  k4FWCore::MetaDataHandle<std::vector<std::string>> m_inShapeParameterHandle{
+      m_inClusters, edm4hep::labels::ShapeParameterNames, Gaudi::DataHandle::Reader};
+  k4FWCore::MetaDataHandle<std::vector<std::string>> m_showerShapeHandle{
+      m_outClusters, edm4hep::labels::ShapeParameterNames, Gaudi::DataHandle::Writer};
 
   /// Pointer to the geometry service
   ServiceHandle<IGeoSvc> m_geoSvc;

--- a/RecFCCeeCalorimeter/src/components/CalibrateCaloClusters.h
+++ b/RecFCCeeCalorimeter/src/components/CalibrateCaloClusters.h
@@ -86,15 +86,16 @@ private:
   void calcEnergiesInLayers(edm4hep::Cluster cluster, std::vector<float>& energiesInLayer) const;
 
   /// Handle for input calorimeter clusters collection
-  mutable DataHandle<edm4hep::ClusterCollection> m_inClusters{"inClusters", Gaudi::DataHandle::Reader, this};
+  mutable k4FWCore::DataHandle<edm4hep::ClusterCollection> m_inClusters{"inClusters", Gaudi::DataHandle::Reader, this};
 
   /// Handle for corrected (output) calorimeter clusters collection
-  mutable DataHandle<edm4hep::ClusterCollection> m_outClusters{"outClusters", Gaudi::DataHandle::Writer, this};
+  mutable k4FWCore::DataHandle<edm4hep::ClusterCollection> m_outClusters{"outClusters", Gaudi::DataHandle::Writer,
+                                                                         this};
 
   /// Handles for the cluster shower shape metadata to read and to write
-  MetaDataHandle<std::vector<std::string>> m_inShapeParameterHandle{m_inClusters, edm4hep::labels::ShapeParameterNames,
-                                                                    Gaudi::DataHandle::Reader};
-  MetaDataHandle<std::vector<std::string>> m_outShapeParameterHandle{
+  k4FWCore::MetaDataHandle<std::vector<std::string>> m_inShapeParameterHandle{
+      m_inClusters, edm4hep::labels::ShapeParameterNames, Gaudi::DataHandle::Reader};
+  k4FWCore::MetaDataHandle<std::vector<std::string>> m_outShapeParameterHandle{
       m_outClusters, edm4hep::labels::ShapeParameterNames, Gaudi::DataHandle::Writer};
 
   /// Pointer to the geometry service

--- a/RecFCCeeCalorimeter/src/components/CaloTopoClusterFCCee.cpp
+++ b/RecFCCeeCalorimeter/src/components/CaloTopoClusterFCCee.cpp
@@ -39,7 +39,7 @@ StatusCode CaloTopoClusterFCCee::initialize() {
     debug() << "Creating handle for input cell (CalorimeterHit) collection : " << col << endmsg;
     try {
       m_cellCollectionHandles.push_back(
-          new DataHandle<edm4hep::CalorimeterHitCollection>(col, Gaudi::DataHandle::Reader, this));
+          new k4FWCore::DataHandle<edm4hep::CalorimeterHitCollection>(col, Gaudi::DataHandle::Reader, this));
     } catch (...) {
       error() << "Error creating handle for input collection: " << col << endmsg;
       return StatusCode::FAILURE;
@@ -66,8 +66,7 @@ StatusCode CaloTopoClusterFCCee::initialize() {
       return StatusCode::FAILURE;
     }
 
-    if (m_geoSvc->getDetector()->readouts().find(m_readoutName) ==
-        m_geoSvc->getDetector()->readouts().end()) {
+    if (m_geoSvc->getDetector()->readouts().find(m_readoutName) == m_geoSvc->getDetector()->readouts().end()) {
       error() << "Readout <<" << m_readoutName << ">> does not exist." << endmsg;
 
       return StatusCode::FAILURE;
@@ -366,7 +365,7 @@ std::vector<std::pair<uint64_t, uint32_t>> CaloTopoClusterFCCee::searchForNeighb
   if (!m_useNeighborMap) {
     // DDSegmentation returns std::set
     std::set<dd4hep::DDSegmentation::CellID> outputNeighbors;
-    m_segmentation->neighbours(aCellId,outputNeighbors);
+    m_segmentation->neighbours(aCellId, outputNeighbors);
     neighboursVec = std::vector<uint64_t>(outputNeighbors.begin(), outputNeighbors.end());
   }
 

--- a/RecFCCeeCalorimeter/src/components/CaloTopoClusterFCCee.h
+++ b/RecFCCeeCalorimeter/src/components/CaloTopoClusterFCCee.h
@@ -107,7 +107,7 @@ private:
   Gaudi::Property<std::vector<std::string>> m_cellCollections{
       this, "cells", {}, "Names of CalorimeterHit collections to read"};
   /// the vector of input k4FWCore::DataHandles for the input cell collections
-  std::vector<DataHandle<edm4hep::CalorimeterHitCollection>*> m_cellCollectionHandles;
+  std::vector<k4FWCore::DataHandle<edm4hep::CalorimeterHitCollection>*> m_cellCollectionHandles;
   // Cluster collection (output)
   mutable k4FWCore::DataHandle<edm4hep::ClusterCollection> m_clusterCollection{"clusters", Gaudi::DataHandle::Writer,
                                                                                this};

--- a/RecFCCeeCalorimeter/src/components/CaloTopoClusterFCCee.h
+++ b/RecFCCeeCalorimeter/src/components/CaloTopoClusterFCCee.h
@@ -16,9 +16,9 @@
 // Key4HEP
 #include "k4FWCore/DataHandle.h"
 #include "k4FWCore/MetaDataHandle.h"
-#include "k4Interface/INoiseConstTool.h"
 #include "k4Interface/ICaloReadNeighboursMap.h"
 #include "k4Interface/IGeoSvc.h"
+#include "k4Interface/INoiseConstTool.h"
 
 // EDM4HEP
 namespace edm4hep {
@@ -106,15 +106,16 @@ private:
   /// List of input cell collections
   Gaudi::Property<std::vector<std::string>> m_cellCollections{
       this, "cells", {}, "Names of CalorimeterHit collections to read"};
-  /// the vector of input DataHandles for the input cell collections
+  /// the vector of input k4FWCore::DataHandles for the input cell collections
   std::vector<DataHandle<edm4hep::CalorimeterHitCollection>*> m_cellCollectionHandles;
   // Cluster collection (output)
-  mutable DataHandle<edm4hep::ClusterCollection> m_clusterCollection{"clusters", Gaudi::DataHandle::Writer, this};
+  mutable k4FWCore::DataHandle<edm4hep::ClusterCollection> m_clusterCollection{"clusters", Gaudi::DataHandle::Writer,
+                                                                               this};
   // Cluster cells in collection (output)
-  mutable DataHandle<edm4hep::CalorimeterHitCollection> m_clusterCellsCollection{"clusterCells",
-                                                                                 Gaudi::DataHandle::Writer, this};
+  mutable k4FWCore::DataHandle<edm4hep::CalorimeterHitCollection> m_clusterCellsCollection{
+      "clusterCells", Gaudi::DataHandle::Writer, this};
   /// Handle for the cluster shape metadata to write
-  MetaDataHandle<std::vector<std::string>> m_shapeParametersHandle{
+  k4FWCore::MetaDataHandle<std::vector<std::string>> m_shapeParametersHandle{
       m_clusterCollection, edm4hep::labels::ShapeParameterNames, Gaudi::DataHandle::Writer};
   /// Handle for the cells noise tool
   mutable ToolHandle<INoiseConstTool> m_noiseTool{"TopoCaloNoisyCells", this};
@@ -125,7 +126,8 @@ private:
   // use GeoSvc when the neighbor map is not present
   SmartIF<IGeoSvc> m_geoSvc;
   // name of the readout: only needed if useNeighborMap is set to false
-  Gaudi::Property<std::string> m_readoutName{this, "readoutName", "", "name of the readout (needed if useNeighborMap=false)"};
+  Gaudi::Property<std::string> m_readoutName{this, "readoutName", "",
+                                             "name of the readout (needed if useNeighborMap=false)"};
   // pointer to the segmentation object
   dd4hep::DDSegmentation::Segmentation* m_segmentation = nullptr;
 

--- a/RecFCCeeCalorimeter/src/components/CaloTowerToolFCCee.cpp
+++ b/RecFCCeeCalorimeter/src/components/CaloTowerToolFCCee.cpp
@@ -25,7 +25,7 @@ StatusCode CaloTowerToolFCCee::initialize() {
     debug() << "Creating handle for input cell (CalorimeterHit) collection : " << col << endmsg;
     try {
       m_cellCollectionHandles.push_back(
-          new DataHandle<edm4hep::CalorimeterHitCollection>(col, Gaudi::DataHandle::Reader, this));
+          new k4FWCore::DataHandle<edm4hep::CalorimeterHitCollection>(col, Gaudi::DataHandle::Reader, this));
     } catch (...) {
       error() << "Error creating handle for input collection: " << col << endmsg;
       return StatusCode::FAILURE;
@@ -39,10 +39,10 @@ StatusCode CaloTowerToolFCCee::initialize() {
   m_nPhiTower = ceil((m_phiMax - m_phiMin - epsilon) / m_deltaPhiTower);
   // number of theta bins
   m_nThetaTower = ceil((m_thetaMax - m_thetaMin - epsilon) / m_deltaThetaTower);
-  debug() << "Towers: thetaMin " << m_thetaMin.value() <<  ", thetaMax " << m_thetaMax.value()
-          << ", deltaThetaTower " << m_deltaThetaTower.value() << ", nThetaTower " << m_nThetaTower << endmsg;
-  debug() << "Towers: phiMin " << m_phiMin.value() << ", phiMax " << m_phiMax.value()
-          << ", deltaPhiTower " << m_deltaPhiTower.value() << ", nPhiTower " << m_nPhiTower << endmsg;
+  debug() << "Towers: thetaMin " << m_thetaMin.value() << ", thetaMax " << m_thetaMax.value() << ", deltaThetaTower "
+          << m_deltaThetaTower.value() << ", nThetaTower " << m_nThetaTower << endmsg;
+  debug() << "Towers: phiMin " << m_phiMin.value() << ", phiMax " << m_phiMax.value() << ", deltaPhiTower "
+          << m_deltaPhiTower.value() << ", nPhiTower " << m_nPhiTower << endmsg;
 
   return StatusCode::SUCCESS;
 }
@@ -151,19 +151,20 @@ uint CaloTowerToolFCCee::CellsIntoTowers(std::vector<std::vector<float>>& aTower
     float cellTheta = atan2(sqrt(cellX * cellX + cellY * cellY), cellZ);
     float cellPhi = atan2(cellY, cellX);
     // skip cells outside of specified ranges
-    if (cellTheta<m_thetaMin || cellTheta>m_thetaMax) {
+    if (cellTheta < m_thetaMin || cellTheta > m_thetaMax) {
       warning() << "Cell theta " << cellTheta << " outside of theta range of towers, will not be clustered" << endmsg;
       continue;
     }
-    if (cellPhi<m_phiMin || cellPhi>m_phiMax) {
+    if (cellPhi < m_phiMin || cellPhi > m_phiMax) {
       warning() << "Cell phi " << cellPhi << " outside of phi range of towers, will not be clustered" << endmsg;
       continue;
     }
     iTheta = idTheta(cellTheta);
     iPhi = idPhi(cellPhi);
-    //debug() << "Cell: x = " << cellX << " y = " << cellY << " z = " << cellZ << endmsg;
-    //debug() << "Cell: theta = " << cellTheta << " phi = " << cellPhi << endmsg;
-    //debug() << "Cell: iTheta = " << iTheta << " iPhi = " << iPhi << " iPhi(cyclic) = " << phiIndexTower(iPhi) << endmsg;
+    // debug() << "Cell: x = " << cellX << " y = " << cellY << " z = " << cellZ << endmsg;
+    // debug() << "Cell: theta = " << cellTheta << " phi = " << cellPhi << endmsg;
+    // debug() << "Cell: iTheta = " << iTheta << " iPhi = " << iPhi << " iPhi(cyclic) = " << phiIndexTower(iPhi) <<
+    // endmsg;
     aTowers[iTheta][phiIndexTower(iPhi)] += cell.getEnergy() * sin(cellTheta);
     if (fillTowersCells) {
       clusteredCells++;
@@ -203,19 +204,17 @@ void CaloTowerToolFCCee::attachCells(float theta, float phi, uint halfThetaFin, 
               auto cellclone = cell.clone();
               aEdmClusterCells->push_back(cellclone);
               aEdmCluster.addToHits(cellclone);
-            }
-            else {
+            } else {
               aEdmCluster.addToHits(cell);
             }
 
-            if (m_nSubDetectors>0) {
+            if (m_nSubDetectors > 0) {
               // caloID: 1 = ecal, 2 = hcal, 3 = yoke - see how m_caloid is computed and encoded in cell type in
               // https://github.com/HEP-FCC/k4RecCalorimeter/blob/main/RecCalorimeter/src/components/CreatePositionedCaloCells.cpp
-              int caloID = ((cell.getType() / 10) % 10) -1 ;
-              if (caloID < 0 or caloID > (int) m_nSubDetectors) {
+              int caloID = ((cell.getType() / 10) % 10) - 1;
+              if (caloID < 0 or caloID > (int)m_nSubDetectors) {
                 warning() << "Wrong caloID " << caloID << endmsg;
-              }
-              else {
+              } else {
                 subDetectorEnergies[caloID] += cell.getEnergy();
               }
             }
@@ -236,16 +235,14 @@ void CaloTowerToolFCCee::attachCells(float theta, float phi, uint halfThetaFin, 
             auto cellclone = cell.clone();
             aEdmClusterCells->push_back(cellclone);
             aEdmCluster.addToHits(cellclone);
-          }
-          else {
+          } else {
             aEdmCluster.addToHits(cell);
           }
-          if (m_nSubDetectors>0) {
+          if (m_nSubDetectors > 0) {
             int caloID = ((cell.getType() / 10) % 10 - 1);
-            if (caloID < 0 or caloID > (int) m_nSubDetectors) {
+            if (caloID < 0 or caloID > (int)m_nSubDetectors) {
               warning() << "Wrong caloID " << caloID << endmsg;
-            }
-            else {
+            } else {
               subDetectorEnergies[caloID] += cell.getEnergy();
             }
           }
@@ -253,7 +250,7 @@ void CaloTowerToolFCCee::attachCells(float theta, float phi, uint halfThetaFin, 
       }
     }
   }
-  for (auto energy: subDetectorEnergies) {
+  for (auto energy : subDetectorEnergies) {
     aEdmCluster.addToSubdetectorEnergies(energy);
   }
   return;

--- a/RecFCCeeCalorimeter/src/components/CaloTowerToolFCCee.h
+++ b/RecFCCeeCalorimeter/src/components/CaloTowerToolFCCee.h
@@ -101,7 +101,7 @@ public:
    */
   inline std::vector<std::string> getInputCollections() {
     std::vector<std::string> v;
-    for (auto coll: m_cellCollections) {
+    for (auto coll : m_cellCollections) {
       v.push_back(coll);
     }
     return v;
@@ -112,11 +112,12 @@ public:
    */
   inline std::vector<int> getInputSystemIDs() {
     std::vector<int> v;
-    for (auto ID: m_caloIDs) {
+    for (auto ID : m_caloIDs) {
       v.push_back(ID);
     }
     return v;
   }
+
 private:
   /**  Correct way to obtain the phi index of a tower, taking into account
    * the phi periodicity.
@@ -135,17 +136,16 @@ private:
 
   /// List of input cell collections
   Gaudi::Property<std::vector<std::string>> m_cellCollections{
-    this, "cells", {}, "Names of CalorimeterHit collections to read"};
+      this, "cells", {}, "Names of CalorimeterHit collections to read"};
 
   /// Corresponding list of calorimeter IDs
   /// Only needed by SW clustering algorithm that uses this tool
   /// if new output cell collection with clustered cells is created,
   /// to record in metadata the map of systemID vs collectionName
   /// which is then used to determine the appropriate cellID enconding
-  Gaudi::Property<std::vector<int>> m_caloIDs{
-    this, "calorimeterIDs", {}, "Corresponding list of calorimeter IDs"};
+  Gaudi::Property<std::vector<int>> m_caloIDs{this, "calorimeterIDs", {}, "Corresponding list of calorimeter IDs"};
 
-  /// The vector of input DataHandles for the input cell collections
+  /// The vector of input k4FWCore::DataHandles for the input cell collections
   std::vector<DataHandle<edm4hep::CalorimeterHitCollection>*> m_cellCollectionHandles;
 
   /// Maximum theta of towers
@@ -159,9 +159,9 @@ private:
   /// Minimum phi of towers
   Gaudi::Property<float> m_phiMin{this, "phiMin", -M_PI, "Minimum phi of towers"};
   /// Size of the tower in theta (default: pi/314 ~ 0.01 rad)
-  Gaudi::Property<float> m_deltaThetaTower{this, "deltaThetaTower", M_PI/314, "Size of the tower in theta"};
+  Gaudi::Property<float> m_deltaThetaTower{this, "deltaThetaTower", M_PI / 314, "Size of the tower in theta"};
   /// Size of the tower in phi (default: pi/314 ~ 0.01 rad)
-  Gaudi::Property<float> m_deltaPhiTower{this, "deltaPhiTower", M_PI/314, "Size of the tower in phi"};
+  Gaudi::Property<float> m_deltaPhiTower{this, "deltaPhiTower", M_PI / 314, "Size of the tower in phi"};
 
   /// Number of calorimeters (e.g. ecal/hcal/muon) for which to calculate the
   /// total subdetector energy of the cluster and save it in the subdetectorEnergies vector

--- a/RecFCCeeCalorimeter/src/components/CaloTowerToolFCCee.h
+++ b/RecFCCeeCalorimeter/src/components/CaloTowerToolFCCee.h
@@ -146,7 +146,7 @@ private:
   Gaudi::Property<std::vector<int>> m_caloIDs{this, "calorimeterIDs", {}, "Corresponding list of calorimeter IDs"};
 
   /// The vector of input k4FWCore::DataHandles for the input cell collections
-  std::vector<DataHandle<edm4hep::CalorimeterHitCollection>*> m_cellCollectionHandles;
+  std::vector<k4FWCore::DataHandle<edm4hep::CalorimeterHitCollection>*> m_cellCollectionHandles;
 
   /// Maximum theta of towers
   /// Can be left to pi, it won't hurt

--- a/RecFCCeeCalorimeter/src/components/CreateCaloCellPositionsFCCee.h
+++ b/RecFCCeeCalorimeter/src/components/CreateCaloCellPositionsFCCee.h
@@ -50,15 +50,16 @@ private:
   /// Handle for tool to get positions
   ToolHandle<ICellPositionsTool> m_cellPositionsTool{};
   /// Input collection
-  mutable DataHandle<edm4hep::CalorimeterHitCollection> m_hits{"hits/hits", Gaudi::DataHandle::Reader, this};
+  mutable k4FWCore::DataHandle<edm4hep::CalorimeterHitCollection> m_hits{"hits/hits", Gaudi::DataHandle::Reader, this};
   /// Input collection metadata handle
-  MetaDataHandle<std::string> m_hitsCellIDEncoding{m_hits, edm4hep::labels::CellIDEncoding, Gaudi::DataHandle::Reader};
+  k4FWCore::MetaDataHandle<std::string> m_hitsCellIDEncoding{m_hits, edm4hep::labels::CellIDEncoding,
+                                                             Gaudi::DataHandle::Reader};
   /// Output collection
-  mutable DataHandle<edm4hep::CalorimeterHitCollection> m_positionedHits{"hits/positionedHits",
-                                                                         Gaudi::DataHandle::Writer, this};
+  mutable k4FWCore::DataHandle<edm4hep::CalorimeterHitCollection> m_positionedHits{"hits/positionedHits",
+                                                                                   Gaudi::DataHandle::Writer, this};
   /// Output collection metadata handle
-  MetaDataHandle<std::string> m_positionedHitsCellIDEncoding{m_positionedHits, edm4hep::labels::CellIDEncoding,
-                                                             Gaudi::DataHandle::Writer};
+  k4FWCore::MetaDataHandle<std::string> m_positionedHitsCellIDEncoding{
+      m_positionedHits, edm4hep::labels::CellIDEncoding, Gaudi::DataHandle::Writer};
 
   // Cache
   mutable std::unordered_map<dd4hep::DDSegmentation::CellID, edm4hep::Vector3f> m_positions_cache{};

--- a/RecFCCeeCalorimeter/src/components/CreateCaloClustersSlidingWindowFCCee.cpp
+++ b/RecFCCeeCalorimeter/src/components/CreateCaloClustersSlidingWindowFCCee.cpp
@@ -46,12 +46,12 @@ StatusCode CreateCaloClustersSlidingWindowFCCee::initialize() {
     if (tool) {
       std::vector<int> IDs = tool->getInputSystemIDs();
       std::vector<std::string> colls = tool->getInputCollections();
-      if (IDs.size()==colls.size()) {
+      if (IDs.size() == colls.size()) {
         m_caloIDsMetaData.put(IDs);
         m_cellsMetaData.put(colls);
-      }
-      else {
-        warning() << "Sizes of input cell and systemID collections of tower tool are different, no metadata written" << endmsg;
+      } else {
+        warning() << "Sizes of input cell and systemID collections of tower tool are different, no metadata written"
+                  << endmsg;
       }
     } else {
       warning() << "Failed to get CaloTowerToolFCCee instance, no metadata written" << endmsg;

--- a/RecFCCeeCalorimeter/src/components/CreateCaloClustersSlidingWindowFCCee.h
+++ b/RecFCCeeCalorimeter/src/components/CreateCaloClustersSlidingWindowFCCee.h
@@ -88,15 +88,14 @@ private:
    */
   unsigned int phiNeighbour(int aIPhi) const;
   /// Handle for calo clusters (output collection)
-  mutable DataHandle<edm4hep::ClusterCollection> m_clusters{"calo/clusters", Gaudi::DataHandle::Writer, this};
+  mutable k4FWCore::DataHandle<edm4hep::ClusterCollection> m_clusters{"calo/clusters", Gaudi::DataHandle::Writer, this};
   /// Handle for calo cluster cells (output collection)
-  mutable DataHandle<edm4hep::CalorimeterHitCollection> m_clusterCells{"calo/clusterCells", Gaudi::DataHandle::Writer,
-                                                                       this};
+  mutable k4FWCore::DataHandle<edm4hep::CalorimeterHitCollection> m_clusterCells{"calo/clusterCells",
+                                                                                 Gaudi::DataHandle::Writer, this};
   /// Output collection metadata handles (saving a map of ID:collection does not work)
-  MetaDataHandle<std::vector<int>> m_caloIDsMetaData{m_clusters, "inputSystemIDs",
-    Gaudi::DataHandle::Writer};
-  MetaDataHandle<std::vector<std::string>> m_cellsMetaData{m_clusters, "inputCellCollections",
-      Gaudi::DataHandle::Writer};
+  k4FWCore::MetaDataHandle<std::vector<int>> m_caloIDsMetaData{m_clusters, "inputSystemIDs", Gaudi::DataHandle::Writer};
+  k4FWCore::MetaDataHandle<std::vector<std::string>> m_cellsMetaData{m_clusters, "inputCellCollections",
+                                                                     Gaudi::DataHandle::Writer};
   /// Handle for the tower building tool
   mutable ToolHandle<ITowerToolThetaModule> m_towerTool;
   /// Calorimeter towers

--- a/RecFCCeeCalorimeter/src/components/PhotonIDTool.h
+++ b/RecFCCeeCalorimeter/src/components/PhotonIDTool.h
@@ -74,15 +74,16 @@ private:
                                 edm4hep::ClusterCollection* outClusters) const;
 
   /// Handle for input calorimeter clusters collection
-  mutable DataHandle<edm4hep::ClusterCollection> m_inClusters{"inClusters", Gaudi::DataHandle::Reader, this};
+  mutable k4FWCore::DataHandle<edm4hep::ClusterCollection> m_inClusters{"inClusters", Gaudi::DataHandle::Reader, this};
 
   /// Handle for output calorimeter clusters collection
-  mutable DataHandle<edm4hep::ClusterCollection> m_outClusters{"outClusters", Gaudi::DataHandle::Writer, this};
+  mutable k4FWCore::DataHandle<edm4hep::ClusterCollection> m_outClusters{"outClusters", Gaudi::DataHandle::Writer,
+                                                                         this};
 
   /// Handles for the cluster shower shape metadata to read and to write
-  MetaDataHandle<std::vector<std::string>> m_inShapeParameterHandle{m_inClusters, edm4hep::labels::ShapeParameterNames,
-                                                                    Gaudi::DataHandle::Reader};
-  MetaDataHandle<std::vector<std::string>> m_outShapeParameterHandle{
+  k4FWCore::MetaDataHandle<std::vector<std::string>> m_inShapeParameterHandle{
+      m_inClusters, edm4hep::labels::ShapeParameterNames, Gaudi::DataHandle::Reader};
+  k4FWCore::MetaDataHandle<std::vector<std::string>> m_outShapeParameterHandle{
       m_outClusters, edm4hep::labels::ShapeParameterNames, Gaudi::DataHandle::Writer};
 
   /// Files with the MVA model and list of inputs

--- a/RecFCChhCalorimeter/src/components/CreateCaloCellPositions.h
+++ b/RecFCChhCalorimeter/src/components/CreateCaloCellPositions.h
@@ -59,10 +59,10 @@ private:
   /// Decoder for system ID
   dd4hep::DDSegmentation::BitFieldCoder* m_decoder = new dd4hep::DDSegmentation::BitFieldCoder("system:4");
   /// Input collection
-  mutable DataHandle<edm4hep::CalorimeterHitCollection> m_hits{"hits/hits", Gaudi::DataHandle::Reader, this};
+  mutable k4FWCore::DataHandle<edm4hep::CalorimeterHitCollection> m_hits{"hits/hits", Gaudi::DataHandle::Reader, this};
   /// Output collection
-  mutable DataHandle<edm4hep::CalorimeterHitCollection> m_positionedHits{"hits/positionedHits",
-                                                                         Gaudi::DataHandle::Writer, this};
+  mutable k4FWCore::DataHandle<edm4hep::CalorimeterHitCollection> m_positionedHits{"hits/positionedHits",
+                                                                                   Gaudi::DataHandle::Writer, this};
 };
 
 #endif /* DETCOMPONENTS_CREATECELLPOSITIONS_H */

--- a/RecFCChhCalorimeter/src/components/CreateCellPositions.h
+++ b/RecFCChhCalorimeter/src/components/CreateCellPositions.h
@@ -46,10 +46,10 @@ private:
   /// Handle for tool to get positions
   mutable ToolHandle<ICellPositionsTool> m_cellPositionsTool;
   /// Input collection
-  mutable DataHandle<edm4hep::CalorimeterHitCollection> m_hits{"hits/hits", Gaudi::DataHandle::Reader, this};
+  mutable k4FWCore::DataHandle<edm4hep::CalorimeterHitCollection> m_hits{"hits/hits", Gaudi::DataHandle::Reader, this};
   /// Output collection
-  mutable DataHandle<edm4hep::CalorimeterHitCollection> m_positionedHits{"hits/positionedHits",
-                                                                         Gaudi::DataHandle::Writer, this};
+  mutable k4FWCore::DataHandle<edm4hep::CalorimeterHitCollection> m_positionedHits{"hits/positionedHits",
+                                                                                   Gaudi::DataHandle::Writer, this};
 };
 
 #endif /* DETCOMPONENTS_CREATECELLPOSITIONS_H */


### PR DESCRIPTION
BEGINRELEASENOTES
- Move DataHandle and MetaDataHandle to the k4FWCore namespace, done in k4FWCore in https://github.com/key4hep/k4FWCore/pull/317
- Bump the required version of k4FWCore

ENDRELEASENOTES