### PR TITLE
TopoCluster cell link update

### DIFF
--- a/RecFCCeeCalorimeter/src/components/CaloTopoClusterFCCee.cpp
+++ b/RecFCCeeCalorimeter/src/components/CaloTopoClusterFCCee.cpp
@@ -198,17 +198,14 @@ StatusCode CaloTopoClusterFCCee::execute(const EventContext&) const {
         outClusterCells->push_back(cell);
         cluster.addToHits(cell);
       } else {
-        std::cout << "Cell ID: " << count << "\t" << protoCell.getCellID() << "\t" << protoCell.getEnergy() << "\t" << protoCell.getType() << std::endl;
         for (size_t ih = 0; ih < m_cellCollectionHandles.size(); ih++) {
           const edm4hep::CalorimeterHitCollection* coll = m_cellCollectionHandles[ih]->get();
           for (const auto& hit : *coll) {
             if(hit.id() == protoCell.id()){
-              std::cout << "Found match" << std::endl;
               cluster.addToHits(hit);
             }
           }
         }
-        //cluster.addToHits(protoCell);
       }
     }
 

--- a/RecFCCeeCalorimeter/src/components/CaloTopoClusterFCCee.h
+++ b/RecFCCeeCalorimeter/src/components/CaloTopoClusterFCCee.h
@@ -142,6 +142,9 @@ private:
 
   /// System encoding string
   Gaudi::Property<std::string> m_systemEncoding{this, "systemEncoding", "system:4", "System encoding string"};
+
+  /// Flag if a new output cell collection of clustered cells should be created
+  Gaudi::Property<bool> m_createClusterCellCollection{this, "createClusterCellCollection", false};
   /// General decoder to encode the calorimeter sub-system to determine which
   /// positions tool to use
   dd4hep::DDSegmentation::BitFieldCoder* m_decoder;


### PR DESCRIPTION

BEGINRELEASENOTES
* Add possibility to create links from topoclusters to existing input cell collections rather than creating a new output cell collections (similarly to what is done by LC / Pandora), based on the value of m_createClusterCellCollection (true: create new output collection; false: set links to pre-existing input collections)

ENDRELEASENOTES

This PR is based on the changes from https://github.com/HEP-FCC/k4RecCalorimeter/pull/151, but extends this to apply to TopoClusters, and not just the sliding window clusters.

The tool can be called like

`    clusterAlg = CaloTopoClusterFCCee("Create" + outputClusters,
                                      cells=cells,
                                      clusters=outputClusters,
                                      clusterCells=outputClusters.replace("Clusters", "Cluster") + "Cells",
                                      neigboursTool=neighboursTool,
                                      noiseTool=noiseTool,
                                      seedSigma=seedSigma,
                                      neighbourSigma=neighbourSigma,
                                      lastNeighbourSigma=lastNeighbourSigma,
                                      minClusterEnergy=clusteringThreshold,
                                      calorimeterIDs=caloIDs,
                                      createClusterCellCollection=doCreateCells,
                                      OutputLevel=INFO)`
