### PR TITLE
Add algorithm to create links between calo hits and mc particles

### DIFF
--- a/RecCalorimeter/src/components/CreateHitTruthLinks.cpp
+++ b/RecCalorimeter/src/components/CreateHitTruthLinks.cpp
@@ -7,10 +7,7 @@ DECLARE_COMPONENT(CreateHitTruthLinks)
 
 CreateHitTruthLinks::CreateHitTruthLinks(const std::string& name, ISvcLocator* svcLoc)
     : Gaudi::Algorithm(name, svcLoc) {
-  //declareProperty("hits", m_hits, "Hits collection (input)");
-  //declareProperty("cells", m_cells, "Cell collection (input)");
   declareProperty("mcparticles", m_mcparticles, "MC particles collection (input)");
-  //declareProperty("cell_hit_links", m_cell_hit_links, "The links between cells and hits (input)");
   declareProperty("cell_mcparticle_links", m_cell_mcparticle_links, "The links between cells and MC particles (output)");
 }
 

--- a/RecCalorimeter/src/components/CreateHitTruthLinks.cpp
+++ b/RecCalorimeter/src/components/CreateHitTruthLinks.cpp
@@ -30,6 +30,7 @@ StatusCode CreateHitTruthLinks::initialize() {
     }
   }
 
+  /*
   for (const auto& col : m_cellCollections) {
     debug() << "Creating handle for input cell (CalorimeterHit) collection : " << col << endmsg;
     try {
@@ -40,6 +41,7 @@ StatusCode CreateHitTruthLinks::initialize() {
       return StatusCode::FAILURE;
     }
   }
+  */
 
   for (const auto& col : m_cell_hit_linkCollections) {
     debug() << "Creating handle for input cell-hit link collection : " << col << endmsg;
@@ -376,7 +378,7 @@ StatusCode CreateHitTruthLinks::execute(const EventContext&) const {
                         debug() << "starts_in_tracker, has_pi0, has_bs, gmother_in_calo : " <<  starts_in_tracker << " " << has_pi0 << " " <<  has_bs << " " << gmother_in_calo << endmsg;
                         if ( starts_in_tracker == 1 ) {
                           // this_Kid is a clear-cut hit-originator
-                          // this_Kid started before the calo, and is the one\
+                          // this_Kid started before the calo, and is the one
                           // the hit should be attributed to
                           remap_as_you_go[index_mcp] = index_this_Kid;
                           index_mcp = index_this_Kid;
@@ -521,8 +523,8 @@ StatusCode CreateHitTruthLinks::finalize() {
   for (size_t ih = 0; ih < m_hitCollectionHandles.size(); ih++)
     delete m_hitCollectionHandles[ih];
 
-  for (size_t ih = 0; ih < m_cellCollectionHandles.size(); ih++)
-    delete m_cellCollectionHandles[ih];
+  // for (size_t ih = 0; ih < m_cellCollectionHandles.size(); ih++)
+  //   delete m_cellCollectionHandles[ih];
 
   for (size_t ih = 0; ih < m_cell_hit_linkCollectionHandles.size(); ih++)
     delete m_cell_hit_linkCollectionHandles[ih];

--- a/RecCalorimeter/src/components/CreateHitTruthLinks.cpp
+++ b/RecCalorimeter/src/components/CreateHitTruthLinks.cpp
@@ -184,16 +184,14 @@ StatusCode CreateHitTruthLinks::execute(const EventContext&) const {
                     // mother, or the mother decayed in the tracker
                     // (=> the kid is the particle entering the calorimeter.)
                     debug() << "in originator loop " << endmsg;
-                    {
-                      const edm4hep::MCParticle& mother = mcparticles->at(index_mother);
-                      debug() << "shower-part mother "<<mother.id()
-                              << " gs "<<mother.getGeneratorStatus()
-                              << " dint "<<mother.isDecayedInTracker()
-                              << " bs "<<mother.isBackscatter()
-                              << " ndi "<<mother.vertexIsNotEndpointOfParent()
-                              << " npar "<<mother.getParents().size()
-                              << " pdg "<<mother.getPDG() << endmsg;
-                    }
+                    const edm4hep::MCParticle& mother = mcparticles->at(index_mother);
+                    debug() << "shower-part mother "<<mother.id()
+                            << " gs "<<mother.getGeneratorStatus()
+                            << " dint "<<mother.isDecayedInTracker()
+                            << " bs "<<mother.isBackscatter()
+                            << " ndi "<<mother.vertexIsNotEndpointOfParent()
+                            << " npar "<<mother.getParents().size()
+                            << " pdg "<<mother.getPDG() << endmsg;
                     // case shower-particle (???)
                     // if ( this_Kid.vertexIsNotEndpointOfParent() != _invertedNonDestructiveInteractionLogic) {
                     if ( mcparticles->at(index_this_Kid).vertexIsNotEndpointOfParent() ) {

--- a/RecCalorimeter/src/components/CreateHitTruthLinks.cpp
+++ b/RecCalorimeter/src/components/CreateHitTruthLinks.cpp
@@ -1,8 +1,5 @@
 #include "CreateHitTruthLinks.h"
 
-// edm4hep
-// #include "edm4hep/CalorimeterHit.h"
-
 DECLARE_COMPONENT(CreateHitTruthLinks)
 
 CreateHitTruthLinks::CreateHitTruthLinks(const std::string& name, ISvcLocator* svcLoc)
@@ -19,17 +16,6 @@ StatusCode CreateHitTruthLinks::initialize() {
     return sc;
 
   // create handles for input collections
-  for (const auto& col : m_hitCollections) {
-    debug() << "Creating handle for input hit (SimCalorimeterHit) collection : " << col << endmsg;
-    try {
-      m_hitCollectionHandles.push_back(
-          new k4FWCore::DataHandle<edm4hep::SimCalorimeterHitCollection>(col, Gaudi::DataHandle::Reader, this));
-    } catch (...) {
-      error() << "Error creating handle for input collection: " << col << endmsg;
-      return StatusCode::FAILURE;
-    }
-  }
-
   for (const auto& col : m_cell_hit_linkCollections) {
     debug() << "Creating handle for input cell-hit link collection : " << col << endmsg;
     try {
@@ -51,7 +37,7 @@ StatusCode CreateHitTruthLinks::execute(const EventContext&) const {
   // map from true tracks linked to hit contributions to
   // those that really should have been linked
   std::map< int , int > remap_as_you_go ;
-  bool doRemapping = true;  // for debug
+  bool doRemapping = true;  // can turn off for debug
 
   // create cell<->particle links
   edm4hep::CaloHitMCParticleLinkCollection* caloHitMCParticleLinkCollection = m_cell_mcparticle_links.createAndPut();
@@ -59,443 +45,440 @@ StatusCode CreateHitTruthLinks::execute(const EventContext&) const {
   // retrieve MC particles
   const edm4hep::MCParticleCollection* mcparticles = m_mcparticles.get();
 
-  // loop over input sim hit collections
-  for (size_t ih = 0; ih < m_hitCollectionHandles.size(); ih++) {
-    const edm4hep::SimCalorimeterHitCollection* simCalorimeterHits = m_hitCollectionHandles[ih]->get();
-    debug() << "Processing input sim hit collection " << ih << " : " << m_hitCollectionHandles[ih]->objKey() << endmsg;
-
-    const int nsimhits = (int) simCalorimeterHits->size();
-    debug() << "Collection size: " << nsimhits << endmsg;
-
-    // retrieve corresponding calo<->sim hit collection
+  // loop over calo<->sim hit collection
+  std::map<int, int> nhits; // map of nhits with given ID in link collections
+  for (size_t ih = 0; ih < m_cell_hit_linkCollectionHandles.size(); ih++) {
+    debug() << "Processing input sim <-> calo hit link collection " << ih << " : "
+            << m_cell_hit_linkCollectionHandles[ih]->objKey() << endmsg;
     const edm4hep::CaloHitSimCaloHitLinkCollection* caloHitSimCaloHitLinks = m_cell_hit_linkCollectionHandles[ih]->get();
+    debug() << "Collection size: " << caloHitSimCaloHitLinks->size() << endmsg;
 
-    // Loop over the G4 hits, find the associated calo hits, then loop over the G4 hit contribution to calculate contribution of each MCParticle to the calo hit
-    for (const auto &simHit : *simCalorimeterHits){
+    // Loop over the G4 hits, find the associated calo hits, then loop over
+    // the G4 hit contribution to calculate contribution of each MCParticle to the calo hit
+    for (const auto &assoc : *caloHitSimCaloHitLinks){
+      debug() << "Processing new sim <-> calo hit link: " << endmsg;
+      const auto &simHit = assoc.getTo();
+      const auto &caloHit = assoc.getFrom();
+      debug() << "Sim hit id and index: " << simHit.id() << " " << simHit.id().index << endmsg;
+      debug() << "Calo hit id and index: " << caloHit.id() << " " << caloHit.id().index << endmsg;
+      if (nhits[simHit.id().index + ih*(1<<24)]>0) {
+        error() << "Sim hit with more than one calo hit!!!" << endmsg;
+        return StatusCode::FAILURE;
+      }
+      else {
+        nhits[simHit.id().index + ih*(1<<24)]=1;
+      }
 
-      debug() << "Processing new sim hit: " << endmsg;
-      std::map< size_t , double > simHitMapEnergy ;  //  counts total energy for every MCParticle
-      int nhits = 0;
-      for (const auto &assoc : *caloHitSimCaloHitLinks)
+      // extract digitised over deposited energy
+      // assuming here there is at most one simhit per calo hit (0 in the case of noise hit)
+      double calib_factor = caloHit.getEnergy()/simHit.getEnergy();
+      debug() << "Calib factor = " << calib_factor << endmsg;
+
+      // now loop over truth contributions
+      int k=-1;
+      std::map< size_t , double > simHitMapEnergy ;  //  counts total energy for every MCParticle for given sim hit
+      debug() << "Looping over contributions" << endmsg;
+      for (auto &simHitContrib: simHit.getContributions())
       {
-        if (assoc.getTo() == simHit) {
-          nhits++;
-          if (nhits>1) {
-            error() << "Sim hit with more than one calo hit!!!" << endmsg;
-            return StatusCode::FAILURE;
-          }
-          auto caloHit = assoc.getFrom();
-          debug() << "Found associated calo hit" << endmsg;
+        k++;
+        // mcp: original MCParticle associated to contribution
+        const edm4hep::MCParticle& origmcp = simHitContrib.getParticle();
+        int index_mcp = origmcp.id().index;
+        double e  = simHitContrib.getEnergy() * calib_factor;
+        debug() << "initial true contributor "<< k << " id " << origmcp.id()
+                <<" (with E = " << origmcp.getEnergy() << " and pdg " << origmcp.getPDG() << " ) e hit: " << e << endmsg;
 
-          // extract digitised over deposited energy
-          // assuming here there is at most one simhit per calo hit (0 in the case of noise hit)
-          double calib_factor = caloHit.getEnergy()/simHit.getEnergy();
+        if (doRemapping) {
+          if ( remap_as_you_go.find(index_mcp) != remap_as_you_go.end() ) {
+            // first condition: we have already found from some earlier hit how to remap this particle
+            index_mcp = remap_as_you_go.find(index_mcp)->second;
+            {
+              const edm4hep::MCParticle& amcp = mcparticles->at(index_mcp);
+              debug() << "Hit " << simHit.id() << " / " << caloHit.id()
+                      << " attributed to " << amcp.id()
+                      << " because its origin mcp has already been treated : originator case 0 " << endmsg;
+            }
+          } else {
+            // otherwise: we have not yet decided if this particle has to be remapped or not
+            int index_mother = -1;
+            int index_this_Kid = index_mcp;
 
-          // now loop over truth contributions
-          int k=-1;
-          debug() << "Looping over contributions" << endmsg;
-          for (auto &simHitContrib: simHit.getContributions())
-          {
-            k++;
-            // mcp: original MCParticle associated to contribution
-            const edm4hep::MCParticle& origmcp = simHitContrib.getParticle();
-            int index_mcp = origmcp.id().index;
-            double e  = simHitContrib.getEnergy() * calib_factor;
-            debug() << "initial true contributor "<< k << " id " << origmcp.id()
-                    <<" (with E = " << origmcp.getEnergy() << " and pdg " << origmcp.getPDG() << " ) e hit: " << e << endmsg;
+            if ( origmcp.getGeneratorStatus() == 0 && ( origmcp.getParents().empty() == false ) ) {
 
-            if (doRemapping) {
-              if ( remap_as_you_go.find(index_mcp) != remap_as_you_go.end() ) {
-                // first condition: we have already found from some earlier hit how to remap this particle
-                index_mcp = remap_as_you_go.find(index_mcp)->second;
+              // second condition: particles not from the generator that have parents
+              // find which true particle this hit should really be attributed to, by
+              // tracking back the history.
+
+              // Two cases to treat:
+              //   For some reason, the hit is not attributed to the
+              //   incoming particle, but to some particle in the shower.
+              //   Just track back to the incoming particle, which might (usually)
+              //   be a gen-stat 1 particle from the main vertex. It can also
+              //   be from a decay or interaction in the tracking made by
+              //   Geant : genstat=0, mother isDecayedInTracker, (or
+              //   the production vertex is in the track, but the mother
+              //   continues on - ticky case, see comment futher down), or a
+              //   decyed particle from the generator (genstat 2) that
+              //   hits the calo before decaying (lambdas, K^0_S)
+
+              //   Or: for back-scatterers the calorimeter hit is attributed to the
+              //   the last particle *even if this particle both
+              //   started and ended in the tracker* !!!! Then we back-track
+              //   until we find a particle which at least started inside
+              //   the calorimeter, and then go on backtracking as above.
+              //   This case is triggered by the particle linked to the
+              //   hit being DecayedInTracker, hence the case where a
+              //   back-scatter actually ends in the calorimeter is
+              //   treated as the first case.
+
+              debug() << "simHit " << simHit.id() << " not created by generator particle. backtracking ..." << endmsg;
+              debug() << "starting from particle " << origmcp.id() << " gs "<<origmcp.getGeneratorStatus()
+                      << " dint "<< origmcp.isDecayedInTracker()
+                      << " bs "<< origmcp.isBackscatter()
+                      << " ndi "<< origmcp.vertexIsNotEndpointOfParent()
+                      << " npar "<< origmcp.getParents().size()
+                      << " pdg "<< origmcp.getPDG()
+                      << " vtx"
+                      << " " << origmcp.getVertex()[0]
+                      << " " << origmcp.getVertex()[1]
+                      << " " << origmcp.getVertex()[2]
+                      << " end"
+                      << " " << origmcp.getEndpoint()[0]
+                      << " " << origmcp.getEndpoint()[1]
+                      << " " << origmcp.getEndpoint()[2] << endmsg;
+
+              index_mother = origmcp.getParents()[0].id().index;
+              if (
+                index_mother >= 0 &&
+                !mcparticles->at(index_this_Kid).isBackscatter() &&
+                mcparticles->at(index_mother).getParents().size()>0 &&
+                mcparticles->at(index_mother).getGeneratorStatus()==0 &&
+                !mcparticles->at(index_mother).isDecayedInTracker()
+              ) {
+                debug() << "going into into originator loop " << endmsg;
+              }
+              while (
+                index_mother>=0 &&
+                !mcparticles->at(index_this_Kid).isBackscatter() &&
+                mcparticles->at(index_mother).getParents().size()>0 &&
+                mcparticles->at(index_mother).getGeneratorStatus()==0 &&
+                !mcparticles->at(index_mother).isDecayedInTracker()
+              ) {
+                // back-track as long as there is a non-generator
+                // mother, or the mother decayed in the tracker
+                // (=> the kid is the particle entering the calorimeter.)
+                debug() << "in originator loop " << endmsg;
+                const edm4hep::MCParticle& mother = mcparticles->at(index_mother);
+                debug() << "shower-part mother "<<mother.id()
+                        << " gs "<<mother.getGeneratorStatus()
+                        << " dint "<<mother.isDecayedInTracker()
+                        << " bs "<<mother.isBackscatter()
+                        << " ndi "<<mother.vertexIsNotEndpointOfParent()
+                        << " npar "<<mother.getParents().size()
+                        << " pdg "<<mother.getPDG() << endmsg;
+                // case shower-particle (???)
+                // if ( this_Kid.vertexIsNotEndpointOfParent() != _invertedNonDestructiveInteractionLogic) {
+                if ( mcparticles->at(index_this_Kid).vertexIsNotEndpointOfParent() ) {
+                  const edm4hep::MCParticle& gmother = mcparticles->at(index_mother).getParents()[0];
+                  if ( gmother.isDecayedInTracker() ) {
+                    debug() << "break out : grandmother "<< gmother.id()
+                            << " gs "<< gmother.getGeneratorStatus()
+                            << " dint "<< gmother.isDecayedInTracker()
+                            << " bs "<< gmother.isBackscatter()
+                            << " ndi "<< gmother.vertexIsNotEndpointOfParent()
+                            << " npar "<< gmother.getParents().size()
+                            << " pdg "<< gmother.getPDG() << endmsg;
+                    break ;
+                  }
+                }
+                index_this_Kid = index_mother ;
+                // mother= dynamic_cast<edm4hep::MCParticle*>(mother.getParents()[0]); // (assume only one...)
+                if (mcparticles->at(index_mother).getParents().size()>0)
+                  index_mother = mcparticles->at(index_mother).getParents()[0].id().index; // (assume only one...)
+                else
+                  index_mother = -1;
+              } // end while backtracking loop
+
+              // Further treatment (basically determining if it this_Kid or mother that entered the
+              // calorimeter) based on why we left the while-loop
+
+              // here one of the while conditions is false, ie. at least one of
+              // " kid is back-scatter", "no mother" , "mother has no parents", "mother is from
+              // generator", or "mother did decay in tracker" must be true. We know that this_Kid
+              // fulfills all the while-conditions except the first: obvious if at least one iteration of
+              // the loop was done, since it was the mother in the previous iteration,
+              // but also true even if the loop wasn't transversed, due to the conditions
+              // to at all enter this block of code (explicitly must be simulator particle with
+              // mother, implicitly must have ended in the calo, since it did make calo hits.)
+              if (mcparticles->at(index_this_Kid).isBackscatter() ) {
+                // case 2: Kid is back-scatterer. It has thus started in a calo, and entered
+                // from there into the tracking volume, and did cause hits after leaving the tracker
+                // volume again ->  this_Kid started before the calo, and is the one
+                remap_as_you_go[index_mcp] = index_this_Kid;
                 {
-                  const edm4hep::MCParticle& amcp = mcparticles->at(index_mcp);
+                  const edm4hep::MCParticle& this_Kid = mcparticles->at(index_this_Kid);
                   debug() << "Hit " << simHit.id() << " / " << caloHit.id()
-                          << " attributed to " << amcp.id()
-                          << " because its origin mcp has already been treated : originator case 0 " << endmsg;
+                          << " attributed to kid " << this_Kid.id()
+                          << " because it's origin is a back-scatter : originator case 2 " << endmsg;
+                  debug() << "Kid: " << this_Kid.id()
+                          << " gs " << this_Kid.getGeneratorStatus()
+                          << " dint " << this_Kid.isDecayedInTracker()
+                          << " bs " << this_Kid.isBackscatter()
+                          << " npar " << this_Kid.getParents().size()
+                          << " pdg " << this_Kid.getPDG() << endmsg;
+                }
+              } else if (
+                index_mother >= 0 &&
+                mcparticles->at(index_mother).isDecayedInTracker()
+              ) {
+                // the clear-cut case:
+                // this_Kid started before the calo, and is the one
+                // the hit should be attributed to
+                remap_as_you_go[index_mcp] = index_this_Kid;
+                {
+                  const edm4hep::MCParticle& this_Kid = mcparticles->at(index_this_Kid);
+                  debug() << "Hit " << simHit.id() << " / " << caloHit.id()
+                          << " attributed to kid " << this_Kid.id()
+                          << " because it's origin is in tracker : originator case 3 " << endmsg;
+                  debug() << "Kid: " << this_Kid.id()
+                          << " gs " << this_Kid.getGeneratorStatus()
+                          << " dint " << this_Kid.isDecayedInTracker()
+                          << " bs " << this_Kid.isBackscatter()
+                          << " npar " << this_Kid.getParents().size()
+                          << " pdg " << this_Kid.getPDG() << endmsg;
                 }
               } else {
-                // otherwise: we have not yet decided if this particle has to be remapped or not
-                int index_mother = -1;
-                int index_this_Kid = index_mcp;
+                // the other three cases, ie. one or several of "no mother", "no grand-mother",
+                //  "generator particle" + that we know that "mother decayed in calo"
+                if ( index_mother < 0 ) {
+                  // ... which of course implies no grand-mother, and no gen stat
+                  // of the mother as well -> should not be possible !
+                  warning() << "MCparticle " << mcparticles->at(index_this_Kid).id()
+                            << " is a simulation particle, created in the calorimeter by nothing . " << endmsg;
+                  remap_as_you_go[index_mcp] = index_this_Kid;
+                  index_mcp = index_this_Kid; // can't do better than that.
+                } else {
+                  // here we know: mother exists, but decayed in calo. In addition, two possibilities:
+                  // mother is generator particle, or there was no grand-parents. One or both
+                  // must be true here. Here it gets complicated, because what we want to know is
+                  // whether this_Kid started in the tracker or not. Unluckily, we don't know that
+                  // directly, we only know where the mother ended. IF ithe mother ended in the tracker,
+                  // there is no problem, and has already been treated, but if it ended in the calo, it is
+                  // still possible that this_Kid came from a "non-destructive interaction" with the tracke-detector
+                  // material. This we now try to figure out.
 
-                if ( origmcp.getGeneratorStatus() == 0 && ( origmcp.getParents().empty() == false ) ) {
+                  if ( mcparticles->at(index_this_Kid).vertexIsNotEndpointOfParent() == false ) {
+                    // This bizare condition is due to a bug in LCIO (at least for the DBD samples. this_Kid.vertexIsNotEndpointOfParent()
+                    // should be true in the "non-destructive interaction", but it isn't: actually it is "false", but is "true" for the
+                    // particles that *do* originate at the end-vertex of their parent. This is a bug in Mokka.
+                    // Hence the above ensures that there was NO "non-destructive interaction", and it is clear this_Kid was created at the end-point
+                    // of the mother. The mother is either a generator particle (to be saved), or the "Eve" of the decay-chain (or both).
+                    // So mother is the one to save and assign the hits to:
+                    remap_as_you_go[index_mcp] = index_mother;
+                    index_mcp = index_mother;   // mother started at ip, and reached the calo, and is the one
+                                  // the hit should be attributed to.
 
-                  // second condition: particles not from the generator that have parents
-                  // find which true particle this hit should really be attributed to, by
-                  // tracking back the history.
+                    debug() << "Hit " << simHit.id() << " / " << caloHit.id()
+                            << " attributed to mother " << mcparticles->at(index_mcp).id()
+                            << " because it is a generator particle or started in tracker : originator case 4 " << endmsg;
 
-                  // Two cases to treat:
-                  //   For some reason, the hit is not attributed to the
-                  //   incoming particle, but to some particle in the shower.
-                  //   Just track back to the incoming particle, which might (usually)
-                  //   be a gen-stat 1 particle from the main vertex. It can also
-                  //   be from a decay or interaction in the tracking made by
-                  //   Geant : genstat=0, mother isDecayedInTracker, (or
-                  //   the production vertex is in the track, but the mother
-                  //   continues on - ticky case, see comment futher down), or a
-                  //   decyed particle from the generator (genstat 2) that
-                  //   hits the calo before decaying (lambdas, K^0_S)
+                  } else {
+                    // here we DO have a "non-destructive interaction". Unluckily, we cant directly know if this took place in the
+                    // tracker (in which case we should keep this_Kid as the mcp to save and assign hits to), or not.
+                    // We will play a few clean tricks to find the cases where it either certain that the
+                    // "non-destructive interation" was in the tracker, or that it was in the calo. This reduces
+                    // the number of uncertain cases to play dirty tricks with.
 
-                  //   Or: for back-scatterers the calorimeter hit is attributed to the
-                  //   the last particle *even if this particle both
-                  //   started and ended in the tracker* !!!! Then we back-track
-                  //   until we find a particle which at least started inside
-                  //   the calorimeter, and then go on backtracking as above.
-                  //   This case is triggered by the particle linked to the
-                  //   hit being DecayedInTracker, hence the case where a
-                  //   back-scatter actually ends in the calorimeter is
-                  //   treated as the first case.
+                    // Clean tricks to play: look at the sisters of this_Kid: with some luck one of them is a promptly decaying
+                    // particle, eg. a pi0.
+                    // This sister will be flagged as decayed in calo/tracker, and from that we know for certain that the
+                    // "non-destructive interaction" was in the calo/tracker.
+                    // It can also be that one of the sisters is flagged as a back-scatter, which only happens in the calo.
+                    // If the particles grand-mother is decayed in calo, and the mother isn't from a "non-destructive interaction",
+                    // the "non-destructive interaction" was in the calo.
 
-                  debug() << "simHit " << simHit.id() << " not created by generator particle. backtracking ..." << endmsg;
-                  debug() << "starting from particle " << origmcp.id() << " gs "<<origmcp.getGeneratorStatus()
-                          << " dint "<< origmcp.isDecayedInTracker()
-                          << " bs "<< origmcp.isBackscatter()
-                          << " ndi "<< origmcp.vertexIsNotEndpointOfParent()
-                          << " npar "<< origmcp.getParents().size()
-                          << " pdg "<< origmcp.getPDG()
-                          << " vtx"
-                          << " " << origmcp.getVertex()[0]
-                          << " " << origmcp.getVertex()[1]
-                          << " " << origmcp.getVertex()[2]
-                          << " end"
-                          << " " << origmcp.getEndpoint()[0]
-                          << " " << origmcp.getEndpoint()[1]
-                          << " " << origmcp.getEndpoint()[2] << endmsg;
+                    // Finally, we can check the distance of the end-point of the mother (sure to be in the calo) to
+                    // the vertex of this_Kid. If this is small, this_Kid *probably* started in the calo.
+                    int starts_in_tracker = 0 ;
+                    int has_pi0 = 0 ;
+                    int gmother_in_calo = 0;
+                    double rdist =0.;
+                    int has_bs = 0;
 
-                  index_mother = origmcp.getParents()[0].id().index;
-                  if (
-                    index_mother >= 0 &&
-                    !mcparticles->at(index_this_Kid).isBackscatter() &&
-                    mcparticles->at(index_mother).getParents().size()>0 &&
-                    mcparticles->at(index_mother).getGeneratorStatus()==0 &&
-                    !mcparticles->at(index_mother).isDecayedInTracker()
-                  ) {
-                    debug() << "going into into originator loop " << endmsg;
-                  }
-                  while (
-                    index_mother>=0 &&
-                    !mcparticles->at(index_this_Kid).isBackscatter() &&
-                    mcparticles->at(index_mother).getParents().size()>0 &&
-                    mcparticles->at(index_mother).getGeneratorStatus()==0 &&
-                    !mcparticles->at(index_mother).isDecayedInTracker()
-                  ) {
-                    // back-track as long as there is a non-generator
-                    // mother, or the mother decayed in the tracker
-                    // (=> the kid is the particle entering the calorimeter.)
-                    debug() << "in originator loop " << endmsg;
                     const edm4hep::MCParticle& mother = mcparticles->at(index_mother);
-                    debug() << "shower-part mother "<<mother.id()
-                            << " gs "<<mother.getGeneratorStatus()
-                            << " dint "<<mother.isDecayedInTracker()
-                            << " bs "<<mother.isBackscatter()
-                            << " ndi "<<mother.vertexIsNotEndpointOfParent()
-                            << " npar "<<mother.getParents().size()
-                            << " pdg "<<mother.getPDG() << endmsg;
-                    // case shower-particle (???)
-                    // if ( this_Kid.vertexIsNotEndpointOfParent() != _invertedNonDestructiveInteractionLogic) {
-                    if ( mcparticles->at(index_this_Kid).vertexIsNotEndpointOfParent() ) {
-                      const edm4hep::MCParticle& gmother = mcparticles->at(index_mother).getParents()[0];
-                      if ( gmother.isDecayedInTracker() ) {
-                        debug() << "break out : grandmother "<< gmother.id()
-                                << " gs "<< gmother.getGeneratorStatus()
-                                << " dint "<< gmother.isDecayedInTracker()
-                                << " bs "<< gmother.isBackscatter()
-                                << " ndi "<< gmother.vertexIsNotEndpointOfParent()
-                                << " npar "<< gmother.getParents().size()
-                                << " pdg "<< gmother.getPDG() << endmsg;
+                    debug() << "Non destructive interaction, looping over sisters" << endmsg;
+                    for ( unsigned kkk=0 ; kkk < mother.getDaughters().size() ; kkk++ ) {
+                      // edm4hep::MCParticle* sister = dynamic_cast<edm4hep::MCParticle*>(mother.getDaughters()[kkk]);
+
+                      const edm4hep::MCParticle& sister = mother.getDaughters()[kkk];
+                      if ( sister.id() == mcparticles->at(index_this_Kid).id() ) continue;
+                      if ( abs(sister.getVertex()[0]-mcparticles->at(index_this_Kid).getVertex()[0]) > 0.1 ||
+                            abs(sister.getVertex()[1]-mcparticles->at(index_this_Kid).getVertex()[1]) > 0.1 ||
+                            abs(sister.getVertex()[2]-mcparticles->at(index_this_Kid).getVertex()[2]) > 0.1 ) continue;
+                          // must check that it is the same vertex:
+                          // several "non-destructive interactions" can
+                          // take place (think delta-rays !)
+                      if ( sister.isBackscatter()) {
+                        has_bs = 1 ;
+                        break ;
+                      } else if ( sister.isDecayedInTracker() ) {
+                        starts_in_tracker = 1 ;
                         break ;
                       }
+                      // any pi0:s at all ? (it doesn't matter that we break at the two cases above,
+                      // because if we do, it doesn't matter if there are
+                      // pi0 sisters or not !)
+                      if ( sister.getPDG() == 111 ) {
+                        has_pi0 = 1 ;
+                      }
                     }
-                    index_this_Kid = index_mother ;
-                    // mother= dynamic_cast<edm4hep::MCParticle*>(mother.getParents()[0]); // (assume only one...)
-                    if (mcparticles->at(index_mother).getParents().size()>0)
-                      index_mother = mcparticles->at(index_mother).getParents()[0].id().index; // (assume only one...)
-                    else
-                      index_mother = -1;
-                  } // end while backtracking loop
-
-                  // Further treatment (basically determining if it this_Kid or mother that entered the
-                  // calorimeter) based on why we left the while-loop
-
-                  // here one of the while conditions is false, ie. at least one of
-                  // " kid is back-scatter", "no mother" , "mother has no parents", "mother is from
-                  // generator", or "mother did decay in tracker" must be true. We know that this_Kid
-                  // fulfills all the while-conditions except the first: obvious if at least one iteration of
-                  // the loop was done, since it was the mother in the previous iteration,
-                  // but also true even if the loop wasn't transversed, due to the conditions
-                  // to at all enter this block of code (explicitly must be simulator particle with
-                  // mother, implicitly must have ended in the calo, since it did make calo hits.)
-                  if (mcparticles->at(index_this_Kid).isBackscatter() ) {
-                    // case 2: Kid is back-scatterer. It has thus started in a calo, and entered
-                    // from there into the tracking volume, and did cause hits after leaving the tracker
-                    // volume again ->  this_Kid started before the calo, and is the one
-                    remap_as_you_go[index_mcp] = index_this_Kid;
-                    {
-                      const edm4hep::MCParticle& this_Kid = mcparticles->at(index_this_Kid);
-                      debug() << "Hit " << simHit.id() << " / " << caloHit.id()
-                              << " attributed to kid " << this_Kid.id()
-                              << " because it's origin is a back-scatter : originator case 2 " << endmsg;
-                      debug() << "Kid: " << this_Kid.id()
-                              << " gs " << this_Kid.getGeneratorStatus()
-                              << " dint " << this_Kid.isDecayedInTracker()
-                              << " bs " << this_Kid.isBackscatter()
-                              << " npar " << this_Kid.getParents().size()
-                              << " pdg " << this_Kid.getPDG() << endmsg;
-                    }
-                  } else if (
-                    index_mother >= 0 &&
-                    mcparticles->at(index_mother).isDecayedInTracker()
-                  ) {
-                    // the clear-cut case:
-                    // this_Kid started before the calo, and is the one
-                    // the hit should be attributed to
-                    remap_as_you_go[index_mcp] = index_this_Kid;
-                    {
-                      const edm4hep::MCParticle& this_Kid = mcparticles->at(index_this_Kid);
-                      debug() << "Hit " << simHit.id() << " / " << caloHit.id()
-                              << " attributed to kid " << this_Kid.id()
-                              << " because it's origin is in tracker : originator case 3 " << endmsg;
-                      debug() << "Kid: " << this_Kid.id()
-                              << " gs " << this_Kid.getGeneratorStatus()
-                              << " dint " << this_Kid.isDecayedInTracker()
-                              << " bs " << this_Kid.isBackscatter()
-                              << " npar " << this_Kid.getParents().size()
-                              << " pdg " << this_Kid.getPDG() << endmsg;
-                    }
-                  } else {
-                    // the other three cases, ie. one or several of "no mother", "no grand-mother",
-                    //  "generator particle" + that we know that "mother decayed in calo"
-                    if ( index_mother < 0 ) {
-                      // ... which of course implies no grand-mother, and no gen stat
-                      // of the mother as well -> should not be possible !
-                      warning() << "MCparticle " << mcparticles->at(index_this_Kid).id()
-                                << " is a simulation particle, created in the calorimeter by nothing . " << endmsg;
-                      remap_as_you_go[index_mcp] = index_this_Kid;
-                      index_mcp = index_this_Kid; // can't do better than that.
-                    } else {
-                      // here we know: mother exists, but decayed in calo. In addition, two possibilities:
-                      // mother is generator particle, or there was no grand-parents. One or both
-                      // must be true here. Here it gets complicated, because what we want to know is
-                      // whether this_Kid started in the tracker or not. Unluckily, we don't know that
-                      // directly, we only know where the mother ended. IF ithe mother ended in the tracker,
-                      // there is no problem, and has already been treated, but if it ended in the calo, it is
-                      // still possible that this_Kid came from a "non-destructive interaction" with the tracke-detector
-                      // material. This we now try to figure out.
-
-                      if ( mcparticles->at(index_this_Kid).vertexIsNotEndpointOfParent() == false ) {
-                        // This bizare condition is due to a bug in LCIO (at least for the DBD samples. this_Kid.vertexIsNotEndpointOfParent()
-                        // should be true in the "non-destructive interaction", but it isn't: actually it is "false", but is "true" for the
-                        // particles that *do* originate at the end-vertex of their parent. This is a bug in Mokka.
-                        // Hence the above ensures that there was NO "non-destructive interaction", and it is clear this_Kid was created at the end-point
-                        // of the mother. The mother is either a generator particle (to be saved), or the "Eve" of the decay-chain (or both).
-                        // So mother is the one to save and assign the hits to:
-                        remap_as_you_go[index_mcp] = index_mother;
-                        index_mcp = index_mother;   // mother started at ip, and reached the calo, and is the one
-                                      // the hit should be attributed to.
-
-                        debug() << "Hit " << simHit.id() << " / " << caloHit.id()
-                                << " attributed to mother " << mcparticles->at(index_mcp).id()
-                                << " because it is a generator particle or started in tracker : originator case 4 " << endmsg;
-
-                      } else {
-                        // here we DO have a "non-destructive interaction". Unluckily, we cant directly know if this took place in the
-                        // tracker (in which case we should keep this_Kid as the mcp to save and assign hits to), or not.
-                        // We will play a few clean tricks to find the cases where it either certain that the
-                        // "non-destructive interation" was in the tracker, or that it was in the calo. This reduces
-                        // the number of uncertain cases to play dirty tricks with.
-
-                        // Clean tricks to play: look at the sisters of this_Kid: with some luck one of them is a promptly decaying
-                        // particle, eg. a pi0.
-                        // This sister will be flagged as decayed in calo/tracker, and from that we know for certain that the
-                        // "non-destructive interaction" was in the calo/tracker.
-                        // It can also be that one of the sisters is flagged as a back-scatter, which only happens in the calo.
-                        // If the particles grand-mother is decayed in calo, and the mother isn't from a "non-destructive interaction",
-                        // the "non-destructive interaction" was in the calo.
-
-                        // Finally, we can check the distance of the end-point of the mother (sure to be in the calo) to
-                        // the vertex of this_Kid. If this is small, this_Kid *probably* started in the calo.
-                        int starts_in_tracker = 0 ;
-                        int has_pi0 = 0 ;
-                        int gmother_in_calo = 0;
-                        double rdist =0.;
-                        int has_bs = 0;
-
-                        const edm4hep::MCParticle& mother = mcparticles->at(index_mother);
-                        debug() << "Non destructive interaction, looping over sisters" << endmsg;
-                        for ( unsigned kkk=0 ; kkk < mother.getDaughters().size() ; kkk++ ) {
-                          // edm4hep::MCParticle* sister = dynamic_cast<edm4hep::MCParticle*>(mother.getDaughters()[kkk]);
-
-                          const edm4hep::MCParticle& sister = mother.getDaughters()[kkk];
-                          if ( sister.id() == mcparticles->at(index_this_Kid).id() ) continue;
-                          if ( abs(sister.getVertex()[0]-mcparticles->at(index_this_Kid).getVertex()[0]) > 0.1 ||
-                               abs(sister.getVertex()[1]-mcparticles->at(index_this_Kid).getVertex()[1]) > 0.1 ||
-                               abs(sister.getVertex()[2]-mcparticles->at(index_this_Kid).getVertex()[2]) > 0.1 ) continue;
-                              // must check that it is the same vertex:
-                              // several "non-destructive interactions" can
-                              // take place (think delta-rays !)
-                          if ( sister.isBackscatter()) {
-                            has_bs = 1 ;
-                            break ;
-                          } else if ( sister.isDecayedInTracker() ) {
-                            starts_in_tracker = 1 ;
-                            break ;
-                          }
-                          // any pi0:s at all ? (it doesn't matter that we break at the two cases above,
-                          // because if we do, it doesn't matter if there are
-                          // pi0 sisters or not !)
-                          if ( sister.getPDG() == 111 ) {
-                            has_pi0 = 1 ;
-                          }
-                        }
-                        // if not already clear-cut, calculate distance vertex to mother end-point
-                        if ( starts_in_tracker != 1 && has_bs != 1 && has_pi0 != 1 && gmother_in_calo != 1 ) {
-                          rdist = sqrt(pow(mother.getEndpoint()[0]-mcparticles->at(index_this_Kid).getVertex()[0],2)+
-                                      pow(mother.getEndpoint()[1]-mcparticles->at(index_this_Kid).getVertex()[1],2)+
-                                      pow(mother.getEndpoint()[2]-mcparticles->at(index_this_Kid).getVertex()[2],2));
-                          if ( mother.getParents().size() != 0 ) {
-                            const edm4hep::MCParticle& gmother = mother.getParents()[0];
-                            if ( gmother.isDecayedInCalorimeter() ) {
-                              gmother_in_calo = 1 ;
-                            }
-                          }
-                        }
-                        debug() << "starts_in_tracker, has_pi0, has_bs, gmother_in_calo : " <<  starts_in_tracker << " " << has_pi0 << " " <<  has_bs << " " << gmother_in_calo << endmsg;
-                        if ( starts_in_tracker == 1 ) {
-                          // this_Kid is a clear-cut hit-originator
-                          // this_Kid started before the calo, and is the one
-                          // the hit should be attributed to
-                          remap_as_you_go[index_mcp] = index_this_Kid;
-                          index_mcp = index_this_Kid;
-                          const edm4hep::MCParticle& this_Kid = mcparticles->at(index_this_Kid);
-                          debug() << "Hit " << simHit.id() << " / " << caloHit.id()
-                                  << " attributed to kid " << this_Kid.id()
-                                  << " because it's origin could be deduced to be in tracker : originator case 5 " << endmsg;
-
-                          debug() << "Details of case 5: "
-                                  << this_Kid.getVertex()[0] << " "
-                                  << this_Kid.getVertex()[1] << " "
-                                  << this_Kid.getVertex()[2] << " "
-                                  << mother.getEndpoint()[0] << " "
-                                  << mother.getEndpoint()[1] << " "
-                                  << mother.getEndpoint()[2] << " "
-                                  << mother.getGeneratorStatus() <<  " "
-                                  << this_Kid.vertexIsNotEndpointOfParent() << endmsg;
-                        } else if ( has_pi0 != 0 || has_bs != 0 || gmother_in_calo != 0 ) {
-                          // clear-cut case of this_Kid starting in the calo.
-                          // We do know that the mother
-                          // is a generator particle and/or the "Eve" of the cascade,
-                          // so we should attribute hits to the
-                          // mother and save it.
-                          // mother started at ip, and reached the calo, and is the one
-                          // the hit should be attributed to.
-                          remap_as_you_go[index_mcp] = index_mother;
-                          index_mcp = index_mother;
-                          const edm4hep::MCParticle& this_Kid = mcparticles->at(index_this_Kid);
-                          const edm4hep::MCParticle& mcp = mcparticles->at(index_mcp);
-                          debug() << "Hit " << simHit.id() << " / " << caloHit.id()
-                                  << " attributed to mother " << mcp.id()
-                                  << " because it's origin could be deduced to be in tracker : originator case 6 " << endmsg;
-                          debug() << "Case 6 details: kid starts in calo " << " "
-                                  << this_Kid.getVertex()[1] << " " << this_Kid.getVertex()[2] << " " << rdist <<  " "
-                                  << has_pi0  << " " << has_bs << " " <<  gmother_in_calo << endmsg;
-                        } else {
-                          // un-clear case: no pi0 nor back-scatteres among the sisters to help to decide.
-                          // Use distance this_Kid-startpoint to mother-endpoint. We know that the latter is
-                          // in the calo, so if this is small, guess that the start point of this_Kid is
-                          // also in the calo. Calos are dense, so typically in the case the "non-destructive interaction"
-                          // is in the calo, one would guess  that the distance is small, ie. large distance ->
-                          // unlikely that it was in the calo.
-
-                          if ( rdist > 200. ) {
-                            // guess "non-destructive interaction" not in calo -> this_Kid is originator
-                            // this_Kid started before the calo, and is the one
-                            // the hit should be attributed to
-                            remap_as_you_go[index_mcp] = index_this_Kid;
-                            index_mcp = index_this_Kid;
-                            const edm4hep::MCParticle& this_Kid = mcparticles->at(index_this_Kid);
-                            const edm4hep::MCParticle& mcp = mcparticles->at(index_mcp);
-
-                            debug() << "Hit " << simHit.id() << " / " << caloHit.id()
-                                    << " attributed to kid " << mcp.id()
-                                    << " because it's origin is guessed to be in tracker : originator case 7 " << endmsg;
-                            debug() << "Case 7 details: guess kid starts in tracker " << " "
-                                    << this_Kid.getVertex()[1] << " "
-                                    << this_Kid.getVertex()[2] << " "
-                                    << this_Kid.getVertex()[3] << " "
-                                    << rdist <<  " "
-                                    << has_pi0  << " " << endmsg;
-                          } else {
-                            // guess in calo -> mother is originator
-                            // mother started at ip, and reached the calo, and is the one
-                            // the hit should be attributed to.
-                            remap_as_you_go[index_mcp] = index_mother;
-                            index_mcp = index_mother;
-                            const edm4hep::MCParticle& this_Kid = mcparticles->at(index_this_Kid);
-                            const edm4hep::MCParticle& mcp = mcparticles->at(index_mcp);
-
-                            debug() << "Hit " << simHit.id() << " / " << caloHit.id()
-                                    << " attributed to mother " << mcp.id()
-                                    << " because it's origin is guessed in tracker : originator case 8 " <<endmsg;
-                            debug() << "Case 8 details: guess kid starts in calo " << " "
-                                    << this_Kid.getVertex()[1] << " "
-                                    << this_Kid.getVertex()[2] << " "
-                                    << this_Kid.getVertex()[3] << " "
-                                    << rdist <<  " "
-                                    << has_pi0  << " " << endmsg;
-                          }
+                    // if not already clear-cut, calculate distance vertex to mother end-point
+                    if ( starts_in_tracker != 1 && has_bs != 1 && has_pi0 != 1 && gmother_in_calo != 1 ) {
+                      rdist = sqrt(pow(mother.getEndpoint()[0]-mcparticles->at(index_this_Kid).getVertex()[0],2)+
+                                  pow(mother.getEndpoint()[1]-mcparticles->at(index_this_Kid).getVertex()[1],2)+
+                                  pow(mother.getEndpoint()[2]-mcparticles->at(index_this_Kid).getVertex()[2],2));
+                      if ( mother.getParents().size() != 0 ) {
+                        const edm4hep::MCParticle& gmother = mother.getParents()[0];
+                        if ( gmother.isDecayedInCalorimeter() ) {
+                          gmother_in_calo = 1 ;
                         }
                       }
                     }
+                    debug() << "starts_in_tracker, has_pi0, has_bs, gmother_in_calo : " <<  starts_in_tracker << " " << has_pi0 << " " <<  has_bs << " " << gmother_in_calo << endmsg;
+                    if ( starts_in_tracker == 1 ) {
+                      // this_Kid is a clear-cut hit-originator
+                      // this_Kid started before the calo, and is the one
+                      // the hit should be attributed to
+                      remap_as_you_go[index_mcp] = index_this_Kid;
+                      index_mcp = index_this_Kid;
+                      const edm4hep::MCParticle& this_Kid = mcparticles->at(index_this_Kid);
+                      debug() << "Hit " << simHit.id() << " / " << caloHit.id()
+                              << " attributed to kid " << this_Kid.id()
+                              << " because it's origin could be deduced to be in tracker : originator case 5 " << endmsg;
+
+                      debug() << "Details of case 5: "
+                              << this_Kid.getVertex()[0] << " "
+                              << this_Kid.getVertex()[1] << " "
+                              << this_Kid.getVertex()[2] << " "
+                              << mother.getEndpoint()[0] << " "
+                              << mother.getEndpoint()[1] << " "
+                              << mother.getEndpoint()[2] << " "
+                              << mother.getGeneratorStatus() <<  " "
+                              << this_Kid.vertexIsNotEndpointOfParent() << endmsg;
+                    } else if ( has_pi0 != 0 || has_bs != 0 || gmother_in_calo != 0 ) {
+                      // clear-cut case of this_Kid starting in the calo.
+                      // We do know that the mother
+                      // is a generator particle and/or the "Eve" of the cascade,
+                      // so we should attribute hits to the
+                      // mother and save it.
+                      // mother started at ip, and reached the calo, and is the one
+                      // the hit should be attributed to.
+                      remap_as_you_go[index_mcp] = index_mother;
+                      index_mcp = index_mother;
+                      const edm4hep::MCParticle& this_Kid = mcparticles->at(index_this_Kid);
+                      const edm4hep::MCParticle& mcp = mcparticles->at(index_mcp);
+                      debug() << "Hit " << simHit.id() << " / " << caloHit.id()
+                              << " attributed to mother " << mcp.id()
+                              << " because it's origin could be deduced to be in tracker : originator case 6 " << endmsg;
+                      debug() << "Case 6 details: kid starts in calo " << " "
+                              << this_Kid.getVertex()[1] << " " << this_Kid.getVertex()[2] << " " << rdist <<  " "
+                              << has_pi0  << " " << has_bs << " " <<  gmother_in_calo << endmsg;
+                    } else {
+                      // un-clear case: no pi0 nor back-scatteres among the sisters to help to decide.
+                      // Use distance this_Kid-startpoint to mother-endpoint. We know that the latter is
+                      // in the calo, so if this is small, guess that the start point of this_Kid is
+                      // also in the calo. Calos are dense, so typically in the case the "non-destructive interaction"
+                      // is in the calo, one would guess  that the distance is small, ie. large distance ->
+                      // unlikely that it was in the calo.
+
+                      if ( rdist > 200. ) {
+                        // guess "non-destructive interaction" not in calo -> this_Kid is originator
+                        // this_Kid started before the calo, and is the one
+                        // the hit should be attributed to
+                        remap_as_you_go[index_mcp] = index_this_Kid;
+                        index_mcp = index_this_Kid;
+                        const edm4hep::MCParticle& this_Kid = mcparticles->at(index_this_Kid);
+                        const edm4hep::MCParticle& mcp = mcparticles->at(index_mcp);
+
+                        debug() << "Hit " << simHit.id() << " / " << caloHit.id()
+                                << " attributed to kid " << mcp.id()
+                                << " because it's origin is guessed to be in tracker : originator case 7 " << endmsg;
+                        debug() << "Case 7 details: guess kid starts in tracker " << " "
+                                << this_Kid.getVertex()[1] << " "
+                                << this_Kid.getVertex()[2] << " "
+                                << this_Kid.getVertex()[3] << " "
+                                << rdist <<  " "
+                                << has_pi0  << " " << endmsg;
+                      } else {
+                        // guess in calo -> mother is originator
+                        // mother started at ip, and reached the calo, and is the one
+                        // the hit should be attributed to.
+                        remap_as_you_go[index_mcp] = index_mother;
+                        index_mcp = index_mother;
+                        const edm4hep::MCParticle& this_Kid = mcparticles->at(index_this_Kid);
+                        const edm4hep::MCParticle& mcp = mcparticles->at(index_mcp);
+
+                        debug() << "Hit " << simHit.id() << " / " << caloHit.id()
+                                << " attributed to mother " << mcp.id()
+                                << " because it's origin is guessed in tracker : originator case 8 " <<endmsg;
+                        debug() << "Case 8 details: guess kid starts in calo " << " "
+                                << this_Kid.getVertex()[1] << " "
+                                << this_Kid.getVertex()[2] << " "
+                                << this_Kid.getVertex()[3] << " "
+                                << rdist <<  " "
+                                << has_pi0  << " " << endmsg;
+                      }
+                    }
                   }
-                } else {
-                  // first case: the hit generating mcp itself already fulfills the first
-                  // criterium, ie. it is a generator particle (Gen status == 1 or no parents)
-                  debug() << "Hit " << simHit.id() << " / " << caloHit.id()
-                          << " attributed to " << origmcp.id()
-                          << " because its origin is a generator particle : originator case 1 " << endmsg;
-
-                  remap_as_you_go[index_mcp] = index_mcp;
-                } // genstat if - then - else
+                }
               }
-            } // end if do Remapping
+            } else {
+              // first case: the hit generating mcp itself already fulfills the first
+              // criterium, ie. it is a generator particle (Gen status == 1 or no parents)
+              debug() << "Hit " << simHit.id() << " / " << caloHit.id()
+                      << " attributed to " << origmcp.id()
+                      << " because its origin is a generator particle : originator case 1 " << endmsg;
 
-            const edm4hep::MCParticle& mcp = mcparticles->at(index_mcp);
-            debug() << "Final assignment for contribution " << k << " to " << simHit.id() << " / "
-                    << caloHit.id() << " : " << mcp.id() << endmsg;
-            debug() << "gs "<< mcp.getGeneratorStatus()
-                    << " dint " << mcp.isDecayedInTracker()
-                    << " bs "<< mcp.isBackscatter()
-                    << " npar "<< mcp.getParents().size()
-                    << " pdg "<< mcp.getPDG()
-                    << " end"
-                    << " " << mcp.getEndpoint()[0]
-                    << " " << mcp.getEndpoint()[1]
-                    << " " << mcp.getEndpoint()[2] << endmsg;
-
-            simHitMapEnergy[ mcp.id().index ] += e;
-          } // end loop over contributions
-          double sumw=0.0; // for debug
-          for (const auto &mcp: *mcparticles) {
-            // create calo hit<->mc particle associations
-            if (simHitMapEnergy[mcp.id().index]>0) {
-              auto link = caloHitMCParticleLinkCollection->create();
-              link.setFrom(caloHit);
-              link.setTo(mcp);
-              double w = simHitMapEnergy[mcp.id().index]/ caloHit.getEnergy();
-              sumw += w;
-              link.setWeight(w);
-            }
+              remap_as_you_go[index_mcp] = index_mcp;
+            } // genstat if - then - else
           }
-          debug() << "Sum of weights for this calo hit = " << sumw << endmsg;
-        } // end if (assoc.getTo() == simHit)
-      } // end loop over calo hit <-> sim calo hit links
-      if (nhits==0) {
-        warning() << "Sim hit with no associated  calo hit!!!" << endmsg;
-        // might happen if digitiser creates cells only if energy is above a given threshold..
+        } // end if do Remapping
+
+        const edm4hep::MCParticle& mcp = mcparticles->at(index_mcp);
+        debug() << "Final assignment for contribution " << k << " to " << simHit.id() << " / "
+                << caloHit.id() << " : " << mcp.id() << endmsg;
+        debug() << "gs "<< mcp.getGeneratorStatus()
+                << " dint " << mcp.isDecayedInTracker()
+                << " bs "<< mcp.isBackscatter()
+                << " npar "<< mcp.getParents().size()
+                << " pdg "<< mcp.getPDG()
+                << " end"
+                << " " << mcp.getEndpoint()[0]
+                << " " << mcp.getEndpoint()[1]
+                << " " << mcp.getEndpoint()[2] << endmsg;
+
+        simHitMapEnergy[ mcp.id().index ] += e;
+      } // end loop over contributions
+      double sumw=0.0; // for debug
+      for (const auto &mcp: *mcparticles) {
+        // create calo hit<->mc particle associations
+        if (simHitMapEnergy[mcp.id().index]>0) {
+          auto link = caloHitMCParticleLinkCollection->create();
+          link.setFrom(caloHit);
+          link.setTo(mcp);
+          double w = simHitMapEnergy[mcp.id().index] / caloHit.getEnergy();
+          sumw += w;
+          link.setWeight(w);
+        }
       }
-    } // end loop over sim calo hits
-  } // end loop over sim calo hit collections
+      debug() << "Sum of weights for this calo hit = " << sumw << endmsg;
+
+      if (nhits[simHit.id().index + ih*(1<<24)]==0) {
+          warning() << "Sim hit with no associated  calo hit!!!" << endmsg;
+          // might happen if digitiser creates cells only if energy is above a given threshold..
+      }
+    } // end loop over calo hit <-> sim calo hit links
+  } // end loop over calo hit <-> sim calo hit collections
 
   debug() << "Finished linking calo hits to MC particles" << endmsg;
 
@@ -503,9 +486,6 @@ StatusCode CreateHitTruthLinks::execute(const EventContext&) const {
 }
 
 StatusCode CreateHitTruthLinks::finalize() {
-  for (size_t ih = 0; ih < m_hitCollectionHandles.size(); ih++)
-    delete m_hitCollectionHandles[ih];
-
   for (size_t ih = 0; ih < m_cell_hit_linkCollectionHandles.size(); ih++)
     delete m_cell_hit_linkCollectionHandles[ih];
 

--- a/RecCalorimeter/src/components/CreateHitTruthLinks.cpp
+++ b/RecCalorimeter/src/components/CreateHitTruthLinks.cpp
@@ -59,6 +59,10 @@ StatusCode CreateHitTruthLinks::initialize() {
 
 StatusCode CreateHitTruthLinks::execute(const EventContext&) const {
 
+  // map from true tracks linked to hit contributions to
+  // those that really should have been linked
+  std::map< int , int > remap_as_you_go ;
+  bool doRemapping = true;  // for debug
 
   // create cell<->particle links
   edm4hep::CaloHitMCParticleLinkCollection* caloHitMCParticleLinkCollection = new edm4hep::CaloHitMCParticleLinkCollection();
@@ -69,10 +73,10 @@ StatusCode CreateHitTruthLinks::execute(const EventContext&) const {
   // loop over input sim hit collections
   for (size_t ih = 0; ih < m_hitCollectionHandles.size(); ih++) {
     const edm4hep::SimCalorimeterHitCollection* simCalorimeterHits = m_hitCollectionHandles[ih]->get();
-    debug() << "Processing input hit collection " << ih << " : " << m_hitCollectionHandles[ih]->objKey() << endmsg;
+    debug() << "Processing input sim hit collection " << ih << " : " << m_hitCollectionHandles[ih]->objKey() << endmsg;
 
     const int nsimhits = (int) simCalorimeterHits->size();
-    debug() << "Input Hit collection size: " << nsimhits << endmsg;
+    debug() << "Collection size: " << nsimhits << endmsg;
 
     // retrieve corresponding calo<->sim hit collection
     const edm4hep::CaloHitSimCaloHitLinkCollection* caloHitSimCaloHitLinks = m_cell_hit_linkCollectionHandles[ih]->get();
@@ -80,6 +84,7 @@ StatusCode CreateHitTruthLinks::execute(const EventContext&) const {
     // Loop over the G4 hits, find the associated calo hits, then loop over the G4 hit contribution to calculate contribution of each MCParticle to the calo hit
     for (const auto &simHit : *simCalorimeterHits){
 
+      debug() << "Processing new sim hit: " << endmsg;
       std::map< size_t , double > simHitMapEnergy ;  //  counts total energy for every MCParticle
       int nhits = 0;
       for (const auto &assoc : *caloHitSimCaloHitLinks)
@@ -98,356 +103,388 @@ StatusCode CreateHitTruthLinks::execute(const EventContext&) const {
           double calib_factor = caloHit.getEnergy()/simHit.getEnergy();
 
           // now loop over truth contributions
-          int k=0;
-          for (const auto &simHitContrib: simHit.getContributions())
+          int k=-1;
+          debug() << "Looping over contributions" << endmsg;
+          for (auto &simHitContrib: simHit.getContributions())
           {
-
-            const edm4hep::MCParticle& mcp = simHitContrib.getParticle();
+            k++;
+            // mcp: original MCParticle associated to contribution
+            const edm4hep::MCParticle& origmcp = simHitContrib.getParticle();
+            int index_mcp = origmcp.id().index;
             double e  = simHitContrib.getEnergy() * calib_factor;
+            debug() << "initial true contributor "<< k << " id " << origmcp.id()
+                    <<" (with E = " << origmcp.getEnergy() << " and pdg " << origmcp.getPDG() << " ) e hit: " << e << endmsg;
 
-            debug() << "initial true contributor "<< k << " id " << mcp.id()
-                    <<" (with E = " << mcp.getEnergy() << " and pdg " << mcp.getPDG() << " ) e hit: " << e << std::endl;
-            {
-  /*
-            if ( remap_as_you_go.find(mcp) != remap_as_you_go.end() ) {
-              // very first condition: I already know what to do from some earlier hit created by mcp.
-              mcp=remap_as_you_go.find(mcp)->second;
-              streamlog_out( DEBUG3 ) << "     Hit " << simHit->id() << " / "
-                                  << caloHit->id() << " attributed to " << mcp.id() <<
-                          " because it's origin mcp has already been treated : originator case 0 " <<std::endl;
-            } else {
-              MCParticle* mother = 0;
-              MCParticle* this_Kid = mcp ;     // ... and a true particle !
-
-              //Particle gun particles dont have parents, but are "created in the simulation" and have genStat 0
-              if ( mcp. getGeneratorStatus() == 0 && ( mcp.getParents().empty() == false ) ) {
-
-                // not from generator, find which true particle this
-                // hit should really be attributed to, by tracking back the history.
-                // (the other case, ie. if the if above is false is "case 1")
-
-                // Two cases to treat:
-                //   For some reason, the hit is not attributed to the
-                //   incomming particle, but to some particle in the shower.
-                //   Just track back to the incomming particle, which might (usually)
-                //   be a gen-stat 1 particle from the main vertex. It can also
-                //   be from a decay or interaction in the tracking made by
-                //   Geant : genstat=0, mother isDecayedInTracker, (or
-                //   the production vertex is in the track, but the mother
-                //   continues on - ticky case, see comment futher down), or a
-                //   decyed particle from the generator (genstat 2) that
-                //   hits the calo before decaying (lambdas, K^0_S)
-
-                //   Or: for back-scatterers the calorimiter hit is attributed to the
-                //   the last particle *even if this particle both
-                //   started and ended in the tracker* !!!! Then we back-track
-                //   untill we find a particle which at least started inside
-                //   the calorimeter, and then go on backtracking as above.
-                //   This case is triggered by the particle linked to the
-                //   hit being DecayedInTracker, hence the case where a
-                //   back-scatter actually ends in the calorimeter is
-                //   treated as the first case.
-
-
-
-                streamlog_out( DEBUG2 ) << "        simHit " <<simHit->id()<<","<< j <<
-                " not created by generator particle. backtracking ..."
-                << std::endl;
-                streamlog_out( DEBUG2 ) <<"          "<<mcp.id()<<" gs "<<mcp.getGeneratorStatus()<<
-                " dint "<<mcp.isDecayedInTracker()<<
-                " bs "<<mcp.isBackscatter()<<
-                " ndi "<<mcp.vertexIsNotEndpointOfParent()<<
-                " npar "<<mcp.getParents().size()<<
-                " pdg "<<mcp.getPDG()<<
-                " "<< mcp.getVertex()[0]<<
-                " "<<mcp.getVertex()[1]<<
-                " "<<mcp.getVertex()[2]<<
-                " "<< mcp.getEndpoint()[0]<<
-                " "<<mcp.getEndpoint()[1]<<
-                " "<<mcp.getEndpoint()[2]<<std::endl;
-
-
-
-                mother= dynamic_cast<MCParticle*>(mcp.getParents()[0]);
-
-
-                if ( !this_Kid->isBackscatter() &&  mother!= 0 &&
-                      mother->getParents().size()>0 &&
-                      mother->getGeneratorStatus() ==0 &&
-                      !mother->isDecayedInTracker() ) {
-
-            streamlog_out( DEBUG2 ) << "        goes into originator loop " << std::endl;
+            if (doRemapping) {
+              if ( remap_as_you_go.find(index_mcp) != remap_as_you_go.end() ) {
+                // first condition: we have already found from some earlier hit how to remap this particle
+                index_mcp = remap_as_you_go.find(index_mcp)->second;
+                {
+                  const edm4hep::MCParticle& amcp = mcparticles->at(index_mcp);
+                  debug() << "Hit " << simHit.id() << " / " << caloHit.id()
+                          << " attributed to " << amcp.id()
+                          << " because its origin mcp has already been treated : originator case 0 " << endmsg;
                 }
-          while ( !this_Kid->isBackscatter() && mother!= 0 &&   mother->getParents().size()>0 &&
-                        mother->getGeneratorStatus() ==0 &&
-                        !mother->isDecayedInTracker() ) {
-                  // back-track as long as there is a non-generator
-                  // mother, or the mother decayed in the tracker
-                  // (=> the kid is the particle entering the calorimeter.)
+              } else {
+                // otherwise: we have not yet decided if this particle has to be remapped or not
+                int index_mother = -1;
+                int index_this_Kid = index_mcp;
 
-                  // case shower-particle
-            streamlog_out( DEBUG1 ) <<"          in originator loop " << std::endl;
+                if ( origmcp.getGeneratorStatus() == 0 && ( origmcp.getParents().empty() == false ) ) {
 
-      if ( this_Kid->vertexIsNotEndpointOfParent() != _invertedNonDestructiveInteractionLogic) {
-        MCParticle* oma=dynamic_cast<MCParticle*>(mother->getParents()[0]);
-                    if ( oma->isDecayedInTracker() ) {
-                      streamlog_out( DEBUG1 ) <<"          break out : gandmother "<<oma->id()<<
-                                                " gs "<<oma->getGeneratorStatus()<<
-                                                " dint "<<oma->isDecayedInTracker()<<
-                                                " bs "<<oma->isBackscatter()<<
-                                                " ndi "<<oma->vertexIsNotEndpointOfParent()<<
-                                                " npar "<<oma->getParents().size()<<
-                                                " pdg "<<oma->getPDG()<<std::endl;
-                      break ;
+                  // second condition: particles not from the generator that have parents
+                  // find which true particle this hit should really be attributed to, by
+                  // tracking back the history.
+
+                  // Two cases to treat:
+                  //   For some reason, the hit is not attributed to the
+                  //   incoming particle, but to some particle in the shower.
+                  //   Just track back to the incoming particle, which might (usually)
+                  //   be a gen-stat 1 particle from the main vertex. It can also
+                  //   be from a decay or interaction in the tracking made by
+                  //   Geant : genstat=0, mother isDecayedInTracker, (or
+                  //   the production vertex is in the track, but the mother
+                  //   continues on - ticky case, see comment futher down), or a
+                  //   decyed particle from the generator (genstat 2) that
+                  //   hits the calo before decaying (lambdas, K^0_S)
+
+                  //   Or: for back-scatterers the calorimeter hit is attributed to the
+                  //   the last particle *even if this particle both
+                  //   started and ended in the tracker* !!!! Then we back-track
+                  //   until we find a particle which at least started inside
+                  //   the calorimeter, and then go on backtracking as above.
+                  //   This case is triggered by the particle linked to the
+                  //   hit being DecayedInTracker, hence the case where a
+                  //   back-scatter actually ends in the calorimeter is
+                  //   treated as the first case.
+
+                  debug() << "simHit " << simHit.id() << " not created by generator particle. backtracking ..." << endmsg;
+                  debug() << "starting from particle " << origmcp.id() << " gs "<<origmcp.getGeneratorStatus()
+                          << " dint "<< origmcp.isDecayedInTracker()
+                          << " bs "<< origmcp.isBackscatter()
+                          << " ndi "<< origmcp.vertexIsNotEndpointOfParent()
+                          << " npar "<< origmcp.getParents().size()
+                          << " pdg "<< origmcp.getPDG()
+                          << " vtx"
+                          << " " << origmcp.getVertex()[0]
+                          << " " << origmcp.getVertex()[1]
+                          << " " << origmcp.getVertex()[2]
+                          << " end"
+                          << " " << origmcp.getEndpoint()[0]
+                          << " " << origmcp.getEndpoint()[1]
+                          << " " << origmcp.getEndpoint()[2] << endmsg;
+
+                  index_mother = origmcp.getParents()[0].id().index;
+                  if (
+                    index_mother >= 0 &&
+                    !mcparticles->at(index_this_Kid).isBackscatter() &&
+                    mcparticles->at(index_mother).getParents().size()>0 &&
+                    mcparticles->at(index_mother).getGeneratorStatus()==0 &&
+                    !mcparticles->at(index_mother).isDecayedInTracker()
+                  ) {
+                    debug() << "going into into originator loop " << endmsg;
+                  }
+                  while (
+                    index_mother>=0 &&
+                    !mcparticles->at(index_this_Kid).isBackscatter() &&
+                    mcparticles->at(index_mother).getParents().size()>0 &&
+                    mcparticles->at(index_mother).getGeneratorStatus()==0 &&
+                    !mcparticles->at(index_mother).isDecayedInTracker()
+                  ) {
+                    // back-track as long as there is a non-generator
+                    // mother, or the mother decayed in the tracker
+                    // (=> the kid is the particle entering the calorimeter.)
+                    debug() << "in originator loop " << endmsg;
+                    {
+                      const edm4hep::MCParticle& mother = mcparticles->at(index_mother);
+                      debug() << "shower-part mother "<<mother.id()
+                              << " gs "<<mother.getGeneratorStatus()
+                              << " dint "<<mother.isDecayedInTracker()
+                              << " bs "<<mother.isBackscatter()
+                              << " ndi "<<mother.vertexIsNotEndpointOfParent()
+                              << " npar "<<mother.getParents().size()
+                              << " pdg "<<mother.getPDG() << endmsg;
                     }
-      }
-                  this_Kid=mother ;
-                  mother= dynamic_cast<MCParticle*>(mother->getParents()[0]); // (assume only one...)
+                    // case shower-particle (???)
+                    // if ( this_Kid.vertexIsNotEndpointOfParent() != _invertedNonDestructiveInteractionLogic) {
+                    if ( mcparticles->at(index_this_Kid).vertexIsNotEndpointOfParent() ) {
+                      const edm4hep::MCParticle& gmother = mcparticles->at(index_mother).getParents()[0];
+                      if ( gmother.isDecayedInTracker() ) {
+                        debug() << "break out : grandmother "<< gmother.id()
+                                << " gs "<< gmother.getGeneratorStatus()
+                                << " dint "<< gmother.isDecayedInTracker()
+                                << " bs "<< gmother.isBackscatter()
+                                << " ndi "<< gmother.vertexIsNotEndpointOfParent()
+                                << " npar "<< gmother.getParents().size()
+                                << " pdg "<< gmother.getPDG() << endmsg;
+                        break ;
+                      }
+                    }
+                    index_this_Kid = index_mother ;
+                    // mother= dynamic_cast<edm4hep::MCParticle*>(mother.getParents()[0]); // (assume only one...)
+                    if (mcparticles->at(index_mother).getParents().size()>0)
+                      index_mother = mcparticles->at(index_mother).getParents()[0].id().index; // (assume only one...)
+                    else
+                      index_mother = -1;
+                  } // end while backtracking loop
 
-                  streamlog_out( DEBUG1 ) <<"          shower-part mother "<<mother->id()<<
-                  " gs "<<mother->getGeneratorStatus()<<
-                  " dint "<<mother->isDecayedInTracker()<<
-                  " bs "<<mother->isBackscatter()<<
-                  " ndi "<<mother->vertexIsNotEndpointOfParent()<<
-                  " npar "<<mother->getParents().size()<<
-                  " pdg "<<mother->getPDG()<<std::endl;
+                  // Further treatment (basically determining if it this_Kid or mother that entered the
+                  // calorimeter) based on why we left the while-loop
 
+                  // here one of the while conditions is false, ie. at least one of
+                  // " kid is back-scatter", "no mother" , "mother has no parents", "mother is from
+                  // generator", or "mother did decay in tracker" must be true. We know that this_Kid
+                  // fulfills all the while-conditions except the first: obvious if at least one iteration of
+                  // the loop was done, since it was the mother in the previous iteration,
+                  // but also true even if the loop wasn't transversed, due to the conditions
+                  // to at all enter this block of code (explicitly must be simulator particle with
+                  // mother, implicitly must have ended in the calo, since it did make calo hits.)
+                  if (mcparticles->at(index_this_Kid).isBackscatter() ) {
+                    // case 2: Kid is back-scatterer. It has thus started in a calo, and entered
+                    // from there into the tracking volume, and did cause hits after leaving the tracker
+                    // volume again ->  this_Kid started before the calo, and is the one
+                    remap_as_you_go[index_mcp] = index_this_Kid;
+                    {
+                      const edm4hep::MCParticle& this_Kid = mcparticles->at(index_this_Kid);
+                      debug() << "Hit " << simHit.id() << " / " << caloHit.id()
+                              << " attributed to kid " << this_Kid.id()
+                              << " because it's origin is a back-scatter : originator case 2 " << endmsg;
+                      debug() << "Kid: " << this_Kid.id()
+                              << " gs " << this_Kid.getGeneratorStatus()
+                              << " dint " << this_Kid.isDecayedInTracker()
+                              << " bs " << this_Kid.isBackscatter()
+                              << " npar " << this_Kid.getParents().size()
+                              << " pdg " << this_Kid.getPDG() << endmsg;
+                    }
+                  } else if (
+                    index_mother >= 0 &&
+                    mcparticles->at(index_mother).isDecayedInTracker()
+                  ) {
+                    // the clear-cut case:
+                    // this_Kid started before the calo, and is the one
+                    // the hit should be attributed to
+                    remap_as_you_go[index_mcp] = index_this_Kid;
+                    {
+                      const edm4hep::MCParticle& this_Kid = mcparticles->at(index_this_Kid);
+                      debug() << "Hit " << simHit.id() << " / " << caloHit.id()
+                              << " attributed to kid " << this_Kid.id()
+                              << " because it's origin is in tracker : originator case 3 " << endmsg;
+                      debug() << "Kid: " << this_Kid.id()
+                              << " gs " << this_Kid.getGeneratorStatus()
+                              << " dint " << this_Kid.isDecayedInTracker()
+                              << " bs " << this_Kid.isBackscatter()
+                              << " npar " << this_Kid.getParents().size()
+                              << " pdg " << this_Kid.getPDG() << endmsg;
+                    }
+                  } else {
+                    // the other three cases, ie. one or several of "no mother", "no grand-mother",
+                    //  "generator particle" + that we know that "mother decayed in calo"
+                    if ( index_mother < 0 ) {
+                      // ... which of course implies no grand-mother, and no gen stat
+                      // of the mother as well -> should not be possible !
+                      warning() << "MCparticle " << mcparticles->at(index_this_Kid).id()
+                                << " is a simulation particle, created in the calorimeter by nothing . " << endmsg;
+                      remap_as_you_go[index_mcp] = index_this_Kid;
+                      index_mcp = index_this_Kid; // can't do better than that.
+                    } else {
+                      // here we know: mother exists, but decayed in calo. In addition, two possibilities:
+                      // mother is generator particle, or there was no grand-parents. One or both
+                      // must be true here. Here it gets complicated, because what we want to know is
+                      // whether this_Kid started in the tracker or not. Unluckily, we don't know that
+                      // directly, we only know where the mother ended. IF ithe mother ended in the tracker,
+                      // there is no problem, and has already been treated, but if it ended in the calo, it is
+                      // still possible that this_Kid came from a "non-destructive interaction" with the tracke-detector
+                      // material. This we now try to figure out.
 
-
-                }
-
-                // Further treatment (basically determining if it this_Kid or mother that enetered the
-                // calorimeter) based on why we left the while-loop
-
-                // here one of the while conditions is false, ie. at least one of
-                // " kid is back-scatter", "no mother" , "mother has no parents", "mother is from
-                // generator", or "mother did decay in tracker" must be true. We know that this_Kid
-                // fulfills all the while-conditions except the first: obvious if at least one iteration of
-                // the loop was done, since it was the mother in the previous iteration,
-                // but also true even if the loop wasn't transversed, due to the conditions
-                // to at all enter this block of code (explicitly must be simulator particle with
-                // mother, implicitly must have ended in the calo, since it did make calo hits.)
-          if (this_Kid->isBackscatter() ) {
-                  // case 2: Kid is back-scatterer. It has thus started in a calo, and entered
-                  //  from there into the tracking volume, and did cause hits after leaving the tracker
-                  //  volume again ->  this_Kid started before the calo, and is the one
-                  remap_as_you_go[mcp]=this_Kid;
-                  mcp=this_Kid;
-                  streamlog_out( DEBUG3 ) << "     Hit " << simHit->id() << " / "
-                                  << caloHit->id() << " attributed to kid " << mcp.id() <<
-                          " because it's origin is a back-scatter : originator case 2 " <<std::endl;
-                  streamlog_out( DEBUG2 ) <<"          "<<this_Kid->id()<<
-                  " gs "<<this_Kid->getGeneratorStatus()<<
-                  " dint "<<this_Kid->isDecayedInTracker()<<
-                  " bs "<<this_Kid->isBackscatter()<<
-                  " npar "<<this_Kid->getParents().size()<<
-                  " pdg "<<this_Kid->getPDG()<<std::endl;
-
-
-                } else if ( mother->isDecayedInTracker() ) { // the clear-cut case:
-                  remap_as_you_go[mcp]=this_Kid;
-                  mcp=this_Kid; // this_Kid started before the calo, and is the one
-                                // the hit should be attributed to
-
-
-                  streamlog_out( DEBUG3 ) << "     Hit " << simHit->id() << " / "
-                                  << caloHit->id() << " attributed to kid " << mcp.id() <<
-                          " because it's origin is in tracker : originator case 3 " <<std::endl;
-
-
-                } else { // the other three cases, ie. one or sveral of "no mother", "no grand-mother",
-                        //  "generator particle" + that we know that "mother decayed in calo"
-                  if ( mother == 0 ) { // ... which of course implies no grand-mother, and no gen stat
-                                      // of the mother as well -> should not be possible !
-
-                    streamlog_out( WARNING ) << "  MCparticle " << this_Kid->id() <<
-                    " is a simulation particle, created in the calorimeter by nothing . "<< std::endl;
-
-
-                    remap_as_you_go[mcp]=this_Kid;
-                    mcp=this_Kid; // can't do better than that.
-
-                  } else { // here we know: "mother exists, but decayed in calo". In addition, two posibilities:
-                          // mother is generator particle, or there was no grand-parents. One or both
-                          // must be true here. Here it gets complicated, because what we want to know is
-                          // whether this_Kid started in the tracker or not. Unluckily, we don't know that
-                          // directly, we only know where the mother ended. IF ithe mother ended in the tracker,
-                          // there is no problem, and has already been treated, but if it ended in the calo, it is
-                          // still possible that this_Kid came from a "non-destructive interaction" with the tracke-detector
-                          // material. This we now try to figure out.
-
-        if (   this_Kid->vertexIsNotEndpointOfParent() == _invertedNonDestructiveInteractionLogic ) {
-            // This bizare condition is due to a bug in LCIO (at least for the DBD samples. this_Kid->vertexIsNotEndpointOfParent()
+                      if ( mcparticles->at(index_this_Kid).vertexIsNotEndpointOfParent() == false ) {
+                        // This bizare condition is due to a bug in LCIO (at least for the DBD samples. this_Kid.vertexIsNotEndpointOfParent()
                         // should be true in the "non-destructive interaction", but it isn't: actually it is "false", but is "true" for the
-                        // for particles that *do* originate at the end-vertex of their parent. This is a bug in Mokka.
+                        // particles that *do* originate at the end-vertex of their parent. This is a bug in Mokka.
                         // Hence the above ensures that there was NO "non-destructive interaction", and it is clear this_Kid was created at the end-point
                         // of the mother. The mother is either a generator particle (to be saved), or the "Eve" of the decay-chain (or both).
                         // So mother is the one to save and assign the hits to:
-                      remap_as_you_go[mcp]=mother;
-                      mcp=mother;   // mother started at ip, and reached the calo, and is the one
-                                    // the hit should be attributed to.
-
-                      streamlog_out( DEBUG3 ) << "     Hit " << simHit->id() << " / "
-                                  << caloHit->id() << " attributed to mother " << mcp.id() <<
-                          " because it is a generator particle or started in tracker : originator case 4 " <<std::endl;
-
-                    } else { // here we DO have a "non-destructive interaction". Unluckily, we cant directly know if this took place in the
-                            // tracker (in which case we should keep this_Kid as the mcp to save and assign hits to), or not.
-                            // We will play a few clean tricks to find the cases where it either certain that the
-                            // "non-destructive interation" was in the tracker, or that it was in the calo. This reduces
-                            // the number of uncertain cases to play dirty tricks with.
-
-                            // Clean tricks to play: look at the sisters of this_Kid: with some luck one of them is a promptly decaying
-                            // particle, eg. a pi0.
-                            // This sister will be flagged as decayed in calo/tracker, and from that we know for certain that the
-                            // "non-destructive interaction" was in the calo/tracker.
-                            // It can also be that one of the sisters is flagged as a back-scatter, which only happens in the calo.
-                            // If the particles grand-mother is decayed in calo, and the mother isn't from a "non-destructive interaction",
-                            // the "non-destructive interaction" was in the calo.
-
-                            // Finally, we can check the distance of the end-point of the mother (sure to be in the calo) to
-                            // the vertex of this_Kid. If this is small, this_Kid *probably* started in the calo.
-
-
-                      int starts_in_tracker = 0 ;
-                      int has_pi0 = 0 ;
-                      int oma_in_calo = 0;
-                      double rdist =0.;
-          int has_bs = 0;
-
-          for ( unsigned kkk=0 ; kkk < mother->getDaughters().size() ; kkk++ ) {
-                        MCParticle* sister = dynamic_cast<MCParticle*>(mother->getDaughters()[kkk]);
-                        if ( sister == this_Kid ) continue;
-            if (  abs(sister->getVertex()[0]-this_Kid->getVertex()[0]) > 0.1 ||
-                              abs(sister->getVertex()[1]-this_Kid->getVertex()[1]) > 0.1 ||
-                              abs(sister->getVertex()[2]-this_Kid->getVertex()[2]) > 0.1 ) continue;  // must check that it is the same vertex:
-                                                                                                      // several "non-destructive interactions" can
-                                                                                                      // take place (think delta-rays !)
-            if ( sister->isBackscatter()) {
-                          has_bs = 1 ;
-                          break ;
-            } else if ( sister->isDecayedInTracker() ) {
-                          starts_in_tracker = 1 ;
-                          break ;
-                        }
-                        // any pi0:s at all ? (it doesn't matter that we break at the two cases above,
-                        // because if we do, it doesn't matter if there are
-                        // pi0 sisters or not !)
-                        if ( sister->getPDG() == 111 ) {
-                          has_pi0 = 1 ;
-                        }
-                      }
-                      // if not already clear-cut, calculate distance vertext to mother end-point
-                      if ( starts_in_tracker != 1 && has_bs != 1 && has_pi0 != 1 && oma_in_calo != 1 ) {
-                        rdist=sqrt(pow(mother->getEndpoint()[0]-this_Kid->getVertex()[0],2)+
-                                    pow(mother->getEndpoint()[1]-this_Kid->getVertex()[1],2)+
-                                    pow(mother->getEndpoint()[2]-this_Kid->getVertex()[2],2));
-                        if ( mother->getParents().size() != 0 ) {
-              MCParticle* oma=dynamic_cast<MCParticle*>(mother->getParents()[0]);
-                          if ( oma->isDecayedInCalorimeter() ) {
-                            oma_in_calo = 1 ;
-          streamlog_out( DEBUG1 ) << "          grandmother in calo " << std::endl;
-                          }
-                        }
-                      }
-                      streamlog_out( DEBUG1 ) << "          " <<  starts_in_tracker << " " << has_pi0 << " " <<  has_bs << " " << oma_in_calo << std::endl;
-          //                    }
-                      if ( starts_in_tracker == 1 ) { // this_Kid is a clear-cut hit-originator
-
-                        remap_as_you_go[mcp]=this_Kid;
-                        mcp=this_Kid; // this_Kid started before the calo, and is the one
-                                      // the hit should be attributed to
-
-                        streamlog_out( DEBUG3 ) << "     Hit " << simHit->id() << " / "
-                                  << caloHit->id() << " attributed to kid " << mcp.id() <<
-                          " because it's origin could be deduced to be in tracker : originator case 5 " <<std::endl;
-
-            streamlog_out( DEBUG2 ) << "        Details of case 5: "
-                                              << this_Kid->getVertex()[0] << " "
-                << this_Kid->getVertex()[1] << " " << this_Kid->getVertex()[2] << " "
-                                              << mother->getEndpoint()[0] << " "
-                << mother->getEndpoint()[1] << " " << mother->getEndpoint()[2] << " "
-                                              << mother->getGeneratorStatus() <<  " "
-                                              << this_Kid->vertexIsNotEndpointOfParent() << std::endl;
-                        streamlog_out( DEBUG1 ) << " starts in tracker " <<  std::endl;
-
-          } else if ( has_pi0 != 0 || has_bs != 0 || oma_in_calo != 0 ) { // clear-cut case of this_Kid starting in the calo.
-                                                                  // We do know that the mother
-                                                                  // is a generator particle and/or the "Eve" of the cascade,
-                                                                  // so we should attribute hits to the
-                                                                  // mother and save it.
-
-                        remap_as_you_go[mcp]=mother;
-                        mcp=mother;   // mother started at ip, and reached the calo, and is the one
+                        remap_as_you_go[index_mcp] = index_mother;
+                        index_mcp = index_mother;   // mother started at ip, and reached the calo, and is the one
                                       // the hit should be attributed to.
 
-                        streamlog_out( DEBUG3 ) << "     Hit " << simHit->id() << " / "
-                                  << caloHit->id() << " attributed to mother " << mcp.id() <<
-                                  " because it's origin could be deduced to be in tracker : originator case 6 " <<std::endl;
-            streamlog_out( DEBUG2 ) << "        Case 6 details: kid starts in calo " << " "
-                  << this_Kid->getVertex()[1] << " " << this_Kid->getVertex()[2] << " " << rdist <<  " "
-                  << has_pi0  << " " << has_bs << " " <<  oma_in_calo << std::endl;
+                        debug() << "Hit " << simHit.id() << " / " << caloHit.id()
+                                << " attributed to mother " << mcparticles->at(index_mcp).id()
+                                << " because it is a generator particle or started in tracker : originator case 4 " << endmsg;
 
+                      } else {
+                        // here we DO have a "non-destructive interaction". Unluckily, we cant directly know if this took place in the
+                        // tracker (in which case we should keep this_Kid as the mcp to save and assign hits to), or not.
+                        // We will play a few clean tricks to find the cases where it either certain that the
+                        // "non-destructive interation" was in the tracker, or that it was in the calo. This reduces
+                        // the number of uncertain cases to play dirty tricks with.
 
-          } else { // un-clear case: no pi0 nor back-scatteres among the sisters to help to decide.
-                              // Use distance this_Kid-startpoint to mother-endpoint. We know that the latter is
-                              // in the calo, so if this is small, guess that the start point of this_Kid is
-                              // also in the calo. Calos are dense, so typically in the case the "non-destructive interaction"
-                              // is in the calo, one would guess  that the distance is small, ie. large distance ->
-                              // unlikely that it was in the calo.
+                        // Clean tricks to play: look at the sisters of this_Kid: with some luck one of them is a promptly decaying
+                        // particle, eg. a pi0.
+                        // This sister will be flagged as decayed in calo/tracker, and from that we know for certain that the
+                        // "non-destructive interaction" was in the calo/tracker.
+                        // It can also be that one of the sisters is flagged as a back-scatter, which only happens in the calo.
+                        // If the particles grand-mother is decayed in calo, and the mother isn't from a "non-destructive interaction",
+                        // the "non-destructive interaction" was in the calo.
 
-            if ( rdist > 200. ) { // guess "non-destructive interaction" not in calo -> this_Kid is originator
+                        // Finally, we can check the distance of the end-point of the mother (sure to be in the calo) to
+                        // the vertex of this_Kid. If this is small, this_Kid *probably* started in the calo.
+                        int starts_in_tracker = 0 ;
+                        int has_pi0 = 0 ;
+                        int gmother_in_calo = 0;
+                        double rdist =0.;
+                        int has_bs = 0;
 
-                          remap_as_you_go[mcp]=this_Kid;
-                          mcp=this_Kid; // this_Kid started before the calo, and is the one
-                                      // the hit should be attributed to
-                          streamlog_out( DEBUG3 ) << "     Hit " << simHit->id() << " / "
-                                  << caloHit->id() << " attributed to kid " << mcp.id() <<
-                                  " because it's origin is guessed to be in tracker : originator case 7 " <<std::endl;
-              streamlog_out( DEBUG2 ) << "        Case 7 details: guess kid starts in tracker " << " "
-                << this_Kid->getVertex()[1] << " " << this_Kid->getVertex()[2] << " " << rdist <<  " "
-                                                    << has_pi0  << " " << std::endl;
+                        const edm4hep::MCParticle& mother = mcparticles->at(index_mother);
+                        debug() << "Non destructive interaction, looping over sisters" << endmsg;
+                        for ( unsigned kkk=0 ; kkk < mother.getDaughters().size() ; kkk++ ) {
+                          // edm4hep::MCParticle* sister = dynamic_cast<edm4hep::MCParticle*>(mother.getDaughters()[kkk]);
 
-                        } else { // guess in calo -> mother is originator
-                          remap_as_you_go[mcp]=mother;
-                          mcp=mother;   // mother started at ip, and reached the calo, and is the one
-                                      // the hit should be attributed to.
-                          streamlog_out( DEBUG3 ) << "     Hit " << simHit->id() << " / "
-                                  << caloHit->id() << " attributed to mother " << mcp.id() <<
-                                  " because it's origin is guessed in tracker : originator case 8 " <<std::endl;
-              streamlog_out( DEBUG2 ) << "        Case 8 details:  guess kid starts in calo " << " "
-                << this_Kid->getVertex()[1] << " " << this_Kid->getVertex()[2] << " " << rdist <<  " "
-                                                    << has_pi0  << " " << std::endl;
+                          const edm4hep::MCParticle& sister = mother.getDaughters()[kkk];
+                          if ( sister.id() == mcparticles->at(index_this_Kid).id() ) continue;
+                          if ( abs(sister.getVertex()[0]-mcparticles->at(index_this_Kid).getVertex()[0]) > 0.1 ||
+                               abs(sister.getVertex()[1]-mcparticles->at(index_this_Kid).getVertex()[1]) > 0.1 ||
+                               abs(sister.getVertex()[2]-mcparticles->at(index_this_Kid).getVertex()[2]) > 0.1 ) continue;
+                              // must check that it is the same vertex:
+                              // several "non-destructive interactions" can
+                              // take place (think delta-rays !)
+                          if ( sister.isBackscatter()) {
+                            has_bs = 1 ;
+                            break ;
+                          } else if ( sister.isDecayedInTracker() ) {
+                            starts_in_tracker = 1 ;
+                            break ;
                           }
+                          // any pi0:s at all ? (it doesn't matter that we break at the two cases above,
+                          // because if we do, it doesn't matter if there are
+                          // pi0 sisters or not !)
+                          if ( sister.getPDG() == 111 ) {
+                            has_pi0 = 1 ;
+                          }
+                        }
+                        // if not already clear-cut, calculate distance vertex to mother end-point
+                        if ( starts_in_tracker != 1 && has_bs != 1 && has_pi0 != 1 && gmother_in_calo != 1 ) {
+                          rdist = sqrt(pow(mother.getEndpoint()[0]-mcparticles->at(index_this_Kid).getVertex()[0],2)+
+                                      pow(mother.getEndpoint()[1]-mcparticles->at(index_this_Kid).getVertex()[1],2)+
+                                      pow(mother.getEndpoint()[2]-mcparticles->at(index_this_Kid).getVertex()[2],2));
+                          if ( mother.getParents().size() != 0 ) {
+                            const edm4hep::MCParticle& gmother = mother.getParents()[0];
+                            if ( gmother.isDecayedInCalorimeter() ) {
+                              gmother_in_calo = 1 ;
+                            }
+                          }
+                        }
+                        debug() << "starts_in_tracker, has_pi0, has_bs, gmother_in_calo : " <<  starts_in_tracker << " " << has_pi0 << " " <<  has_bs << " " << gmother_in_calo << endmsg;
+                        if ( starts_in_tracker == 1 ) {
+                          // this_Kid is a clear-cut hit-originator
+                          // this_Kid started before the calo, and is the one\
+                          // the hit should be attributed to
+                          remap_as_you_go[index_mcp] = index_this_Kid;
+                          index_mcp = index_this_Kid;
+                          const edm4hep::MCParticle& this_Kid = mcparticles->at(index_this_Kid);
+                          debug() << "Hit " << simHit.id() << " / " << caloHit.id()
+                                  << " attributed to kid " << this_Kid.id()
+                                  << " because it's origin could be deduced to be in tracker : originator case 5 " << endmsg;
 
+                          debug() << "Details of case 5: "
+                                  << this_Kid.getVertex()[0] << " "
+                                  << this_Kid.getVertex()[1] << " "
+                                  << this_Kid.getVertex()[2] << " "
+                                  << mother.getEndpoint()[0] << " "
+                                  << mother.getEndpoint()[1] << " "
+                                  << mother.getEndpoint()[2] << " "
+                                  << mother.getGeneratorStatus() <<  " "
+                                  << this_Kid.vertexIsNotEndpointOfParent() << endmsg;
+                        } else if ( has_pi0 != 0 || has_bs != 0 || gmother_in_calo != 0 ) {
+                          // clear-cut case of this_Kid starting in the calo.
+                          // We do know that the mother
+                          // is a generator particle and/or the "Eve" of the cascade,
+                          // so we should attribute hits to the
+                          // mother and save it.
+                          // mother started at ip, and reached the calo, and is the one
+                          // the hit should be attributed to.
+                          remap_as_you_go[index_mcp] = index_mother;
+                          index_mcp = index_mother;
+                          const edm4hep::MCParticle& this_Kid = mcparticles->at(index_this_Kid);
+                          const edm4hep::MCParticle& mcp = mcparticles->at(index_mcp);
+                          debug() << "Hit " << simHit.id() << " / " << caloHit.id()
+                                  << " attributed to mother " << mcp.id()
+                                  << " because it's origin could be deduced to be in tracker : originator case 6 " << endmsg;
+                          debug() << "Case 6 details: kid starts in calo " << " "
+                                  << this_Kid.getVertex()[1] << " " << this_Kid.getVertex()[2] << " " << rdist <<  " "
+                                  << has_pi0  << " " << has_bs << " " <<  gmother_in_calo << endmsg;
+                        } else {
+                          // un-clear case: no pi0 nor back-scatteres among the sisters to help to decide.
+                          // Use distance this_Kid-startpoint to mother-endpoint. We know that the latter is
+                          // in the calo, so if this is small, guess that the start point of this_Kid is
+                          // also in the calo. Calos are dense, so typically in the case the "non-destructive interaction"
+                          // is in the calo, one would guess  that the distance is small, ie. large distance ->
+                          // unlikely that it was in the calo.
+
+                          if ( rdist > 200. ) {
+                            // guess "non-destructive interaction" not in calo -> this_Kid is originator
+                            // this_Kid started before the calo, and is the one
+                            // the hit should be attributed to
+                            remap_as_you_go[index_mcp] = index_this_Kid;
+                            index_mcp = index_this_Kid;
+                            const edm4hep::MCParticle& this_Kid = mcparticles->at(index_this_Kid);
+                            const edm4hep::MCParticle& mcp = mcparticles->at(index_mcp);
+
+                            debug() << "Hit " << simHit.id() << " / " << caloHit.id()
+                                    << " attributed to kid " << mcp.id()
+                                    << " because it's origin is guessed to be in tracker : originator case 7 " << endmsg;
+                            debug() << "Case 7 details: guess kid starts in tracker " << " "
+                                    << this_Kid.getVertex()[1] << " "
+                                    << this_Kid.getVertex()[2] << " "
+                                    << this_Kid.getVertex()[3] << " "
+                                    << rdist <<  " "
+                                    << has_pi0  << " " << endmsg;
+                          } else {
+                            // guess in calo -> mother is originator
+                            // mother started at ip, and reached the calo, and is the one
+                            // the hit should be attributed to.
+                            remap_as_you_go[index_mcp] = index_mother;
+                            index_mcp = index_mother;
+                            const edm4hep::MCParticle& this_Kid = mcparticles->at(index_this_Kid);
+                            const edm4hep::MCParticle& mcp = mcparticles->at(index_mcp);
+
+                            debug() << "Hit " << simHit.id() << " / " << caloHit.id()
+                                    << " attributed to mother " << mcp.id()
+                                    << " because it's origin is guessed in tracker : originator case 8 " <<endmsg;
+                            debug() << "Case 8 details: guess kid starts in calo " << " "
+                                    << this_Kid.getVertex()[1] << " "
+                                    << this_Kid.getVertex()[2] << " "
+                                    << this_Kid.getVertex()[3] << " "
+                                    << rdist <<  " "
+                                    << has_pi0  << " " << endmsg;
+                          }
+                        }
                       }
                     }
                   }
-                }
+                } else {
+                  // first case: the hit generating mcp itself already fulfills the first
+                  // criterium, ie. it is a generator particle (Gen status == 1 or no parents)
+                  debug() << "Hit " << simHit.id() << " / " << caloHit.id()
+                          << " attributed to " << origmcp.id()
+                          << " because its origin is a generator particle : originator case 1 " << endmsg;
 
-              } else {
-                // first case: the hit generating mcp itself already fulfills the firest
-                // criterium, ie. it is a generator particle
-                streamlog_out( DEBUG3 ) << "     Hit " << simHit->id() << " / "
-                                  << caloHit->id() << " attributed to " << mcp.id() <<
-                          " because it's origin is a generator particle : originator case 1 " <<std::endl;
+                  remap_as_you_go[index_mcp] = index_mcp;
+                } // genstat if - then - else
+              }
+            } // end if do Remapping
 
-                remap_as_you_go[mcp]=mcp;
-        } // genstat if - then - else
-            }
-        */
-            }
-
-            debug() << "    Final assignment for contribution " << k << " to " << simHit.id() << " / "
+            const edm4hep::MCParticle& mcp = mcparticles->at(index_mcp);
+            debug() << "Final assignment for contribution " << k << " to " << simHit.id() << " / "
                     << caloHit.id() << " : " << mcp.id() << endmsg;
-            debug() << "      gs "<<mcp.getGeneratorStatus()<<
-                      " dint " <<mcp.isDecayedInTracker()<<
-                      "  bs "<< mcp.isBackscatter()<<
-                      " npar "<<mcp.getParents().size()<<
-                      " pdg "<<mcp.getPDG()<<
-                      " " <<mcp.getEndpoint()[0] <<
-                      " " <<mcp.getEndpoint()[1] <<
-                      " " <<mcp.getEndpoint()[2] << endmsg;
+            debug() << "gs "<< mcp.getGeneratorStatus()
+                    << " dint " << mcp.isDecayedInTracker()
+                    << " bs "<< mcp.isBackscatter()
+                    << " npar "<< mcp.getParents().size()
+                    << " pdg "<< mcp.getPDG()
+                    << " end"
+                    << " " << mcp.getEndpoint()[0]
+                    << " " << mcp.getEndpoint()[1]
+                    << " " << mcp.getEndpoint()[2] << endmsg;
 
             simHitMapEnergy[ mcp.id().index ] += e;
           } // end loop over contributions

--- a/RecCalorimeter/src/components/CreateHitTruthLinks.cpp
+++ b/RecCalorimeter/src/components/CreateHitTruthLinks.cpp
@@ -1,0 +1,497 @@
+#include "CreateHitTruthLinks.h"
+
+// edm4hep
+// #include "edm4hep/CalorimeterHit.h"
+
+DECLARE_COMPONENT(CreateHitTruthLinks)
+
+CreateHitTruthLinks::CreateHitTruthLinks(const std::string& name, ISvcLocator* svcLoc)
+    : Gaudi::Algorithm(name, svcLoc) {
+  //declareProperty("hits", m_hits, "Hits collection (input)");
+  //declareProperty("cells", m_cells, "Cell collection (input)");
+  declareProperty("mcparticles", m_mcparticles, "MC particles collection (input)");
+  //declareProperty("cell_hit_links", m_cell_hit_links, "The links between cells and hits (input)");
+  declareProperty("cell_mcparticle_links", m_cell_mcparticle_links, "The links between cells and MC particles (output)");
+}
+
+CreateHitTruthLinks::~CreateHitTruthLinks() { }
+
+StatusCode CreateHitTruthLinks::initialize() {
+  StatusCode sc = Gaudi::Algorithm::initialize();
+  if (sc.isFailure())
+    return sc;
+
+  // create handles for input collections
+  for (const auto& col : m_hitCollections) {
+    debug() << "Creating handle for input hit (SimCalorimeterHit) collection : " << col << endmsg;
+    try {
+      m_hitCollectionHandles.push_back(
+          new k4FWCore::DataHandle<edm4hep::SimCalorimeterHitCollection>(col, Gaudi::DataHandle::Reader, this));
+    } catch (...) {
+      error() << "Error creating handle for input collection: " << col << endmsg;
+      return StatusCode::FAILURE;
+    }
+  }
+
+  for (const auto& col : m_cellCollections) {
+    debug() << "Creating handle for input cell (CalorimeterHit) collection : " << col << endmsg;
+    try {
+      m_cellCollectionHandles.push_back(
+          new k4FWCore::DataHandle<edm4hep::CalorimeterHitCollection>(col, Gaudi::DataHandle::Reader, this));
+    } catch (...) {
+      error() << "Error creating handle for input collection: " << col << endmsg;
+      return StatusCode::FAILURE;
+    }
+  }
+
+  for (const auto& col : m_cell_hit_linkCollections) {
+    debug() << "Creating handle for input cell-hit link collection : " << col << endmsg;
+    try {
+      m_cell_hit_linkCollectionHandles.push_back(
+          new k4FWCore::DataHandle<edm4hep::CaloHitSimCaloHitLinkCollection>(col, Gaudi::DataHandle::Reader, this));
+    } catch (...) {
+      error() << "Error creating handle for input collection: " << col << endmsg;
+      return StatusCode::FAILURE;
+    }
+  }
+
+  info() << "CreateHitTruthLinks initialized" << endmsg;
+
+  return StatusCode::SUCCESS;
+}
+
+StatusCode CreateHitTruthLinks::execute(const EventContext&) const {
+
+
+  // create cell<->particle links
+  edm4hep::CaloHitMCParticleLinkCollection* caloHitMCParticleLinkCollection = new edm4hep::CaloHitMCParticleLinkCollection();
+
+  // retrieve MC particles
+  const edm4hep::MCParticleCollection* mcparticles = m_mcparticles.get();
+
+  // loop over input sim hit collections
+  for (size_t ih = 0; ih < m_hitCollectionHandles.size(); ih++) {
+    const edm4hep::SimCalorimeterHitCollection* simCalorimeterHits = m_hitCollectionHandles[ih]->get();
+    debug() << "Processing input hit collection " << ih << " : " << m_hitCollectionHandles[ih]->objKey() << endmsg;
+
+    const int nsimhits = (int) simCalorimeterHits->size();
+    debug() << "Input Hit collection size: " << nsimhits << endmsg;
+
+    // retrieve corresponding calo<->sim hit collection
+    const edm4hep::CaloHitSimCaloHitLinkCollection* caloHitSimCaloHitLinks = m_cell_hit_linkCollectionHandles[ih]->get();
+
+    // Loop over the G4 hits, find the associated calo hits, then loop over the G4 hit contribution to calculate contribution of each MCParticle to the calo hit
+    for (const auto &simHit : *simCalorimeterHits){
+
+      std::map< size_t , double > simHitMapEnergy ;  //  counts total energy for every MCParticle
+      int nhits = 0;
+      for (const auto &assoc : *caloHitSimCaloHitLinks)
+      {
+        if (assoc.getTo() == simHit) {
+          nhits++;
+          if (nhits>1) {
+            error() << "Sim hit with more than one calo hit!!!" << endmsg;
+            return StatusCode::FAILURE;
+          }
+          auto caloHit = assoc.getFrom();
+          debug() << "Found associated calo hit" << endmsg;
+
+          // extract digitised over deposited energy
+          // assuming here there is at most one simhit per calo hit (0 in the case of noise hit)
+          double calib_factor = caloHit.getEnergy()/simHit.getEnergy();
+
+          // now loop over truth contributions
+          int k=0;
+          for (const auto &simHitContrib: simHit.getContributions())
+          {
+
+            const edm4hep::MCParticle& mcp = simHitContrib.getParticle();
+            double e  = simHitContrib.getEnergy() * calib_factor;
+
+            debug() << "initial true contributor "<< k << " id " << mcp.id()
+                    <<" (with E = " << mcp.getEnergy() << " and pdg " << mcp.getPDG() << " ) e hit: " << e << std::endl;
+            {
+  /*
+            if ( remap_as_you_go.find(mcp) != remap_as_you_go.end() ) {
+              // very first condition: I already know what to do from some earlier hit created by mcp.
+              mcp=remap_as_you_go.find(mcp)->second;
+              streamlog_out( DEBUG3 ) << "     Hit " << simHit->id() << " / "
+                                  << caloHit->id() << " attributed to " << mcp.id() <<
+                          " because it's origin mcp has already been treated : originator case 0 " <<std::endl;
+            } else {
+              MCParticle* mother = 0;
+              MCParticle* this_Kid = mcp ;     // ... and a true particle !
+
+              //Particle gun particles dont have parents, but are "created in the simulation" and have genStat 0
+              if ( mcp. getGeneratorStatus() == 0 && ( mcp.getParents().empty() == false ) ) {
+
+                // not from generator, find which true particle this
+                // hit should really be attributed to, by tracking back the history.
+                // (the other case, ie. if the if above is false is "case 1")
+
+                // Two cases to treat:
+                //   For some reason, the hit is not attributed to the
+                //   incomming particle, but to some particle in the shower.
+                //   Just track back to the incomming particle, which might (usually)
+                //   be a gen-stat 1 particle from the main vertex. It can also
+                //   be from a decay or interaction in the tracking made by
+                //   Geant : genstat=0, mother isDecayedInTracker, (or
+                //   the production vertex is in the track, but the mother
+                //   continues on - ticky case, see comment futher down), or a
+                //   decyed particle from the generator (genstat 2) that
+                //   hits the calo before decaying (lambdas, K^0_S)
+
+                //   Or: for back-scatterers the calorimiter hit is attributed to the
+                //   the last particle *even if this particle both
+                //   started and ended in the tracker* !!!! Then we back-track
+                //   untill we find a particle which at least started inside
+                //   the calorimeter, and then go on backtracking as above.
+                //   This case is triggered by the particle linked to the
+                //   hit being DecayedInTracker, hence the case where a
+                //   back-scatter actually ends in the calorimeter is
+                //   treated as the first case.
+
+
+
+                streamlog_out( DEBUG2 ) << "        simHit " <<simHit->id()<<","<< j <<
+                " not created by generator particle. backtracking ..."
+                << std::endl;
+                streamlog_out( DEBUG2 ) <<"          "<<mcp.id()<<" gs "<<mcp.getGeneratorStatus()<<
+                " dint "<<mcp.isDecayedInTracker()<<
+                " bs "<<mcp.isBackscatter()<<
+                " ndi "<<mcp.vertexIsNotEndpointOfParent()<<
+                " npar "<<mcp.getParents().size()<<
+                " pdg "<<mcp.getPDG()<<
+                " "<< mcp.getVertex()[0]<<
+                " "<<mcp.getVertex()[1]<<
+                " "<<mcp.getVertex()[2]<<
+                " "<< mcp.getEndpoint()[0]<<
+                " "<<mcp.getEndpoint()[1]<<
+                " "<<mcp.getEndpoint()[2]<<std::endl;
+
+
+
+                mother= dynamic_cast<MCParticle*>(mcp.getParents()[0]);
+
+
+                if ( !this_Kid->isBackscatter() &&  mother!= 0 &&
+                      mother->getParents().size()>0 &&
+                      mother->getGeneratorStatus() ==0 &&
+                      !mother->isDecayedInTracker() ) {
+
+            streamlog_out( DEBUG2 ) << "        goes into originator loop " << std::endl;
+                }
+          while ( !this_Kid->isBackscatter() && mother!= 0 &&   mother->getParents().size()>0 &&
+                        mother->getGeneratorStatus() ==0 &&
+                        !mother->isDecayedInTracker() ) {
+                  // back-track as long as there is a non-generator
+                  // mother, or the mother decayed in the tracker
+                  // (=> the kid is the particle entering the calorimeter.)
+
+                  // case shower-particle
+            streamlog_out( DEBUG1 ) <<"          in originator loop " << std::endl;
+
+      if ( this_Kid->vertexIsNotEndpointOfParent() != _invertedNonDestructiveInteractionLogic) {
+        MCParticle* oma=dynamic_cast<MCParticle*>(mother->getParents()[0]);
+                    if ( oma->isDecayedInTracker() ) {
+                      streamlog_out( DEBUG1 ) <<"          break out : gandmother "<<oma->id()<<
+                                                " gs "<<oma->getGeneratorStatus()<<
+                                                " dint "<<oma->isDecayedInTracker()<<
+                                                " bs "<<oma->isBackscatter()<<
+                                                " ndi "<<oma->vertexIsNotEndpointOfParent()<<
+                                                " npar "<<oma->getParents().size()<<
+                                                " pdg "<<oma->getPDG()<<std::endl;
+                      break ;
+                    }
+      }
+                  this_Kid=mother ;
+                  mother= dynamic_cast<MCParticle*>(mother->getParents()[0]); // (assume only one...)
+
+                  streamlog_out( DEBUG1 ) <<"          shower-part mother "<<mother->id()<<
+                  " gs "<<mother->getGeneratorStatus()<<
+                  " dint "<<mother->isDecayedInTracker()<<
+                  " bs "<<mother->isBackscatter()<<
+                  " ndi "<<mother->vertexIsNotEndpointOfParent()<<
+                  " npar "<<mother->getParents().size()<<
+                  " pdg "<<mother->getPDG()<<std::endl;
+
+
+
+                }
+
+                // Further treatment (basically determining if it this_Kid or mother that enetered the
+                // calorimeter) based on why we left the while-loop
+
+                // here one of the while conditions is false, ie. at least one of
+                // " kid is back-scatter", "no mother" , "mother has no parents", "mother is from
+                // generator", or "mother did decay in tracker" must be true. We know that this_Kid
+                // fulfills all the while-conditions except the first: obvious if at least one iteration of
+                // the loop was done, since it was the mother in the previous iteration,
+                // but also true even if the loop wasn't transversed, due to the conditions
+                // to at all enter this block of code (explicitly must be simulator particle with
+                // mother, implicitly must have ended in the calo, since it did make calo hits.)
+          if (this_Kid->isBackscatter() ) {
+                  // case 2: Kid is back-scatterer. It has thus started in a calo, and entered
+                  //  from there into the tracking volume, and did cause hits after leaving the tracker
+                  //  volume again ->  this_Kid started before the calo, and is the one
+                  remap_as_you_go[mcp]=this_Kid;
+                  mcp=this_Kid;
+                  streamlog_out( DEBUG3 ) << "     Hit " << simHit->id() << " / "
+                                  << caloHit->id() << " attributed to kid " << mcp.id() <<
+                          " because it's origin is a back-scatter : originator case 2 " <<std::endl;
+                  streamlog_out( DEBUG2 ) <<"          "<<this_Kid->id()<<
+                  " gs "<<this_Kid->getGeneratorStatus()<<
+                  " dint "<<this_Kid->isDecayedInTracker()<<
+                  " bs "<<this_Kid->isBackscatter()<<
+                  " npar "<<this_Kid->getParents().size()<<
+                  " pdg "<<this_Kid->getPDG()<<std::endl;
+
+
+                } else if ( mother->isDecayedInTracker() ) { // the clear-cut case:
+                  remap_as_you_go[mcp]=this_Kid;
+                  mcp=this_Kid; // this_Kid started before the calo, and is the one
+                                // the hit should be attributed to
+
+
+                  streamlog_out( DEBUG3 ) << "     Hit " << simHit->id() << " / "
+                                  << caloHit->id() << " attributed to kid " << mcp.id() <<
+                          " because it's origin is in tracker : originator case 3 " <<std::endl;
+
+
+                } else { // the other three cases, ie. one or sveral of "no mother", "no grand-mother",
+                        //  "generator particle" + that we know that "mother decayed in calo"
+                  if ( mother == 0 ) { // ... which of course implies no grand-mother, and no gen stat
+                                      // of the mother as well -> should not be possible !
+
+                    streamlog_out( WARNING ) << "  MCparticle " << this_Kid->id() <<
+                    " is a simulation particle, created in the calorimeter by nothing . "<< std::endl;
+
+
+                    remap_as_you_go[mcp]=this_Kid;
+                    mcp=this_Kid; // can't do better than that.
+
+                  } else { // here we know: "mother exists, but decayed in calo". In addition, two posibilities:
+                          // mother is generator particle, or there was no grand-parents. One or both
+                          // must be true here. Here it gets complicated, because what we want to know is
+                          // whether this_Kid started in the tracker or not. Unluckily, we don't know that
+                          // directly, we only know where the mother ended. IF ithe mother ended in the tracker,
+                          // there is no problem, and has already been treated, but if it ended in the calo, it is
+                          // still possible that this_Kid came from a "non-destructive interaction" with the tracke-detector
+                          // material. This we now try to figure out.
+
+        if (   this_Kid->vertexIsNotEndpointOfParent() == _invertedNonDestructiveInteractionLogic ) {
+            // This bizare condition is due to a bug in LCIO (at least for the DBD samples. this_Kid->vertexIsNotEndpointOfParent()
+                        // should be true in the "non-destructive interaction", but it isn't: actually it is "false", but is "true" for the
+                        // for particles that *do* originate at the end-vertex of their parent. This is a bug in Mokka.
+                        // Hence the above ensures that there was NO "non-destructive interaction", and it is clear this_Kid was created at the end-point
+                        // of the mother. The mother is either a generator particle (to be saved), or the "Eve" of the decay-chain (or both).
+                        // So mother is the one to save and assign the hits to:
+                      remap_as_you_go[mcp]=mother;
+                      mcp=mother;   // mother started at ip, and reached the calo, and is the one
+                                    // the hit should be attributed to.
+
+                      streamlog_out( DEBUG3 ) << "     Hit " << simHit->id() << " / "
+                                  << caloHit->id() << " attributed to mother " << mcp.id() <<
+                          " because it is a generator particle or started in tracker : originator case 4 " <<std::endl;
+
+                    } else { // here we DO have a "non-destructive interaction". Unluckily, we cant directly know if this took place in the
+                            // tracker (in which case we should keep this_Kid as the mcp to save and assign hits to), or not.
+                            // We will play a few clean tricks to find the cases where it either certain that the
+                            // "non-destructive interation" was in the tracker, or that it was in the calo. This reduces
+                            // the number of uncertain cases to play dirty tricks with.
+
+                            // Clean tricks to play: look at the sisters of this_Kid: with some luck one of them is a promptly decaying
+                            // particle, eg. a pi0.
+                            // This sister will be flagged as decayed in calo/tracker, and from that we know for certain that the
+                            // "non-destructive interaction" was in the calo/tracker.
+                            // It can also be that one of the sisters is flagged as a back-scatter, which only happens in the calo.
+                            // If the particles grand-mother is decayed in calo, and the mother isn't from a "non-destructive interaction",
+                            // the "non-destructive interaction" was in the calo.
+
+                            // Finally, we can check the distance of the end-point of the mother (sure to be in the calo) to
+                            // the vertex of this_Kid. If this is small, this_Kid *probably* started in the calo.
+
+
+                      int starts_in_tracker = 0 ;
+                      int has_pi0 = 0 ;
+                      int oma_in_calo = 0;
+                      double rdist =0.;
+          int has_bs = 0;
+
+          for ( unsigned kkk=0 ; kkk < mother->getDaughters().size() ; kkk++ ) {
+                        MCParticle* sister = dynamic_cast<MCParticle*>(mother->getDaughters()[kkk]);
+                        if ( sister == this_Kid ) continue;
+            if (  abs(sister->getVertex()[0]-this_Kid->getVertex()[0]) > 0.1 ||
+                              abs(sister->getVertex()[1]-this_Kid->getVertex()[1]) > 0.1 ||
+                              abs(sister->getVertex()[2]-this_Kid->getVertex()[2]) > 0.1 ) continue;  // must check that it is the same vertex:
+                                                                                                      // several "non-destructive interactions" can
+                                                                                                      // take place (think delta-rays !)
+            if ( sister->isBackscatter()) {
+                          has_bs = 1 ;
+                          break ;
+            } else if ( sister->isDecayedInTracker() ) {
+                          starts_in_tracker = 1 ;
+                          break ;
+                        }
+                        // any pi0:s at all ? (it doesn't matter that we break at the two cases above,
+                        // because if we do, it doesn't matter if there are
+                        // pi0 sisters or not !)
+                        if ( sister->getPDG() == 111 ) {
+                          has_pi0 = 1 ;
+                        }
+                      }
+                      // if not already clear-cut, calculate distance vertext to mother end-point
+                      if ( starts_in_tracker != 1 && has_bs != 1 && has_pi0 != 1 && oma_in_calo != 1 ) {
+                        rdist=sqrt(pow(mother->getEndpoint()[0]-this_Kid->getVertex()[0],2)+
+                                    pow(mother->getEndpoint()[1]-this_Kid->getVertex()[1],2)+
+                                    pow(mother->getEndpoint()[2]-this_Kid->getVertex()[2],2));
+                        if ( mother->getParents().size() != 0 ) {
+              MCParticle* oma=dynamic_cast<MCParticle*>(mother->getParents()[0]);
+                          if ( oma->isDecayedInCalorimeter() ) {
+                            oma_in_calo = 1 ;
+          streamlog_out( DEBUG1 ) << "          grandmother in calo " << std::endl;
+                          }
+                        }
+                      }
+                      streamlog_out( DEBUG1 ) << "          " <<  starts_in_tracker << " " << has_pi0 << " " <<  has_bs << " " << oma_in_calo << std::endl;
+          //                    }
+                      if ( starts_in_tracker == 1 ) { // this_Kid is a clear-cut hit-originator
+
+                        remap_as_you_go[mcp]=this_Kid;
+                        mcp=this_Kid; // this_Kid started before the calo, and is the one
+                                      // the hit should be attributed to
+
+                        streamlog_out( DEBUG3 ) << "     Hit " << simHit->id() << " / "
+                                  << caloHit->id() << " attributed to kid " << mcp.id() <<
+                          " because it's origin could be deduced to be in tracker : originator case 5 " <<std::endl;
+
+            streamlog_out( DEBUG2 ) << "        Details of case 5: "
+                                              << this_Kid->getVertex()[0] << " "
+                << this_Kid->getVertex()[1] << " " << this_Kid->getVertex()[2] << " "
+                                              << mother->getEndpoint()[0] << " "
+                << mother->getEndpoint()[1] << " " << mother->getEndpoint()[2] << " "
+                                              << mother->getGeneratorStatus() <<  " "
+                                              << this_Kid->vertexIsNotEndpointOfParent() << std::endl;
+                        streamlog_out( DEBUG1 ) << " starts in tracker " <<  std::endl;
+
+          } else if ( has_pi0 != 0 || has_bs != 0 || oma_in_calo != 0 ) { // clear-cut case of this_Kid starting in the calo.
+                                                                  // We do know that the mother
+                                                                  // is a generator particle and/or the "Eve" of the cascade,
+                                                                  // so we should attribute hits to the
+                                                                  // mother and save it.
+
+                        remap_as_you_go[mcp]=mother;
+                        mcp=mother;   // mother started at ip, and reached the calo, and is the one
+                                      // the hit should be attributed to.
+
+                        streamlog_out( DEBUG3 ) << "     Hit " << simHit->id() << " / "
+                                  << caloHit->id() << " attributed to mother " << mcp.id() <<
+                                  " because it's origin could be deduced to be in tracker : originator case 6 " <<std::endl;
+            streamlog_out( DEBUG2 ) << "        Case 6 details: kid starts in calo " << " "
+                  << this_Kid->getVertex()[1] << " " << this_Kid->getVertex()[2] << " " << rdist <<  " "
+                  << has_pi0  << " " << has_bs << " " <<  oma_in_calo << std::endl;
+
+
+          } else { // un-clear case: no pi0 nor back-scatteres among the sisters to help to decide.
+                              // Use distance this_Kid-startpoint to mother-endpoint. We know that the latter is
+                              // in the calo, so if this is small, guess that the start point of this_Kid is
+                              // also in the calo. Calos are dense, so typically in the case the "non-destructive interaction"
+                              // is in the calo, one would guess  that the distance is small, ie. large distance ->
+                              // unlikely that it was in the calo.
+
+            if ( rdist > 200. ) { // guess "non-destructive interaction" not in calo -> this_Kid is originator
+
+                          remap_as_you_go[mcp]=this_Kid;
+                          mcp=this_Kid; // this_Kid started before the calo, and is the one
+                                      // the hit should be attributed to
+                          streamlog_out( DEBUG3 ) << "     Hit " << simHit->id() << " / "
+                                  << caloHit->id() << " attributed to kid " << mcp.id() <<
+                                  " because it's origin is guessed to be in tracker : originator case 7 " <<std::endl;
+              streamlog_out( DEBUG2 ) << "        Case 7 details: guess kid starts in tracker " << " "
+                << this_Kid->getVertex()[1] << " " << this_Kid->getVertex()[2] << " " << rdist <<  " "
+                                                    << has_pi0  << " " << std::endl;
+
+                        } else { // guess in calo -> mother is originator
+                          remap_as_you_go[mcp]=mother;
+                          mcp=mother;   // mother started at ip, and reached the calo, and is the one
+                                      // the hit should be attributed to.
+                          streamlog_out( DEBUG3 ) << "     Hit " << simHit->id() << " / "
+                                  << caloHit->id() << " attributed to mother " << mcp.id() <<
+                                  " because it's origin is guessed in tracker : originator case 8 " <<std::endl;
+              streamlog_out( DEBUG2 ) << "        Case 8 details:  guess kid starts in calo " << " "
+                << this_Kid->getVertex()[1] << " " << this_Kid->getVertex()[2] << " " << rdist <<  " "
+                                                    << has_pi0  << " " << std::endl;
+                          }
+
+                      }
+                    }
+                  }
+                }
+
+              } else {
+                // first case: the hit generating mcp itself already fulfills the firest
+                // criterium, ie. it is a generator particle
+                streamlog_out( DEBUG3 ) << "     Hit " << simHit->id() << " / "
+                                  << caloHit->id() << " attributed to " << mcp.id() <<
+                          " because it's origin is a generator particle : originator case 1 " <<std::endl;
+
+                remap_as_you_go[mcp]=mcp;
+        } // genstat if - then - else
+            }
+        */
+            }
+
+            debug() << "    Final assignment for contribution " << k << " to " << simHit.id() << " / "
+                    << caloHit.id() << " : " << mcp.id() << endmsg;
+            debug() << "      gs "<<mcp.getGeneratorStatus()<<
+                      " dint " <<mcp.isDecayedInTracker()<<
+                      "  bs "<< mcp.isBackscatter()<<
+                      " npar "<<mcp.getParents().size()<<
+                      " pdg "<<mcp.getPDG()<<
+                      " " <<mcp.getEndpoint()[0] <<
+                      " " <<mcp.getEndpoint()[1] <<
+                      " " <<mcp.getEndpoint()[2] << endmsg;
+
+            simHitMapEnergy[ mcp.id().index ] += e;
+          } // end loop over contributions
+          double sumw=0.0; // for debug
+          for (const auto &mcp: *mcparticles) {
+            // create calo hit<->mc particle associations
+            if (simHitMapEnergy[mcp.id().index]>0) {
+              auto link = caloHitMCParticleLinkCollection->create();
+              link.setFrom(caloHit);
+              link.setTo(mcp);
+              double w = simHitMapEnergy[mcp.id().index]/ caloHit.getEnergy();
+              sumw += w;
+              link.setWeight(w);
+            }
+          }
+          debug() << "Sum of weights for this calo hit = " << sumw << endmsg;
+        } // end if (assoc.getTo() == simHit)
+      } // end loop over calo hit <-> sim calo hit links
+      if (nhits==0) {
+        error() << "Sim hit with no associated  calo hit!!!" << endmsg;
+        return StatusCode::FAILURE;
+      }
+    } // end loop over sim calo hits
+  } // end loop over sim calo hit collections
+
+  // push the CaloHitCollection to event store
+  m_cell_mcparticle_links.put(caloHitMCParticleLinkCollection);
+  debug() << "Finished linking calo hits to MC particles" << endmsg;
+
+  return StatusCode::SUCCESS;
+}
+
+StatusCode CreateHitTruthLinks::finalize() {
+  for (size_t ih = 0; ih < m_hitCollectionHandles.size(); ih++)
+    delete m_hitCollectionHandles[ih];
+
+  for (size_t ih = 0; ih < m_cellCollectionHandles.size(); ih++)
+    delete m_cellCollectionHandles[ih];
+
+  for (size_t ih = 0; ih < m_cell_hit_linkCollectionHandles.size(); ih++)
+    delete m_cell_hit_linkCollectionHandles[ih];
+
+  return Gaudi::Algorithm::finalize();
+}

--- a/RecCalorimeter/src/components/CreateHitTruthLinks.cpp
+++ b/RecCalorimeter/src/components/CreateHitTruthLinks.cpp
@@ -506,8 +506,8 @@ StatusCode CreateHitTruthLinks::execute(const EventContext&) const {
         } // end if (assoc.getTo() == simHit)
       } // end loop over calo hit <-> sim calo hit links
       if (nhits==0) {
-        error() << "Sim hit with no associated  calo hit!!!" << endmsg;
-        return StatusCode::FAILURE;
+        warning() << "Sim hit with no associated  calo hit!!!" << endmsg;
+        // might happen if digitiser creates cells only if energy is above a given threshold..
       }
     } // end loop over sim calo hits
   } // end loop over sim calo hit collections

--- a/RecCalorimeter/src/components/CreateHitTruthLinks.cpp
+++ b/RecCalorimeter/src/components/CreateHitTruthLinks.cpp
@@ -30,19 +30,6 @@ StatusCode CreateHitTruthLinks::initialize() {
     }
   }
 
-  /*
-  for (const auto& col : m_cellCollections) {
-    debug() << "Creating handle for input cell (CalorimeterHit) collection : " << col << endmsg;
-    try {
-      m_cellCollectionHandles.push_back(
-          new k4FWCore::DataHandle<edm4hep::CalorimeterHitCollection>(col, Gaudi::DataHandle::Reader, this));
-    } catch (...) {
-      error() << "Error creating handle for input collection: " << col << endmsg;
-      return StatusCode::FAILURE;
-    }
-  }
-  */
-
   for (const auto& col : m_cell_hit_linkCollections) {
     debug() << "Creating handle for input cell-hit link collection : " << col << endmsg;
     try {
@@ -67,7 +54,7 @@ StatusCode CreateHitTruthLinks::execute(const EventContext&) const {
   bool doRemapping = true;  // for debug
 
   // create cell<->particle links
-  edm4hep::CaloHitMCParticleLinkCollection* caloHitMCParticleLinkCollection = new edm4hep::CaloHitMCParticleLinkCollection();
+  edm4hep::CaloHitMCParticleLinkCollection* caloHitMCParticleLinkCollection = m_cell_mcparticle_links.createAndPut();
 
   // retrieve MC particles
   const edm4hep::MCParticleCollection* mcparticles = m_mcparticles.get();
@@ -512,8 +499,6 @@ StatusCode CreateHitTruthLinks::execute(const EventContext&) const {
     } // end loop over sim calo hits
   } // end loop over sim calo hit collections
 
-  // push the CaloHitCollection to event store
-  m_cell_mcparticle_links.put(caloHitMCParticleLinkCollection);
   debug() << "Finished linking calo hits to MC particles" << endmsg;
 
   return StatusCode::SUCCESS;
@@ -522,9 +507,6 @@ StatusCode CreateHitTruthLinks::execute(const EventContext&) const {
 StatusCode CreateHitTruthLinks::finalize() {
   for (size_t ih = 0; ih < m_hitCollectionHandles.size(); ih++)
     delete m_hitCollectionHandles[ih];
-
-  // for (size_t ih = 0; ih < m_cellCollectionHandles.size(); ih++)
-  //   delete m_cellCollectionHandles[ih];
 
   for (size_t ih = 0; ih < m_cell_hit_linkCollectionHandles.size(); ih++)
     delete m_cell_hit_linkCollectionHandles[ih];

--- a/RecCalorimeter/src/components/CreateHitTruthLinks.h
+++ b/RecCalorimeter/src/components/CreateHitTruthLinks.h
@@ -45,12 +45,6 @@ private:
   /// the vector of input k4FWCore::DataHandles for the input hit collections
   std::vector<k4FWCore::DataHandle<edm4hep::SimCalorimeterHitCollection>*> m_hitCollectionHandles;
 
-  /// List of input cell collections (not used explicitly - should it be defined anyway?)
-  // Gaudi::Property<std::vector<std::string>> m_cellCollections{
-  //   this, "cells", {}, "Names of CalorimeterHit collections to read"};
-  /// the vector of input k4FWCore::DataHandles for the input cell collections
-  // std::vector<k4FWCore::DataHandle<edm4hep::CalorimeterHitCollection>*> m_cellCollectionHandles;
-
   /// List of input cell<->hits collections
   Gaudi::Property<std::vector<std::string>> m_cell_hit_linkCollections{
     this, "cell_hit_links", {}, "Names of CaloHitSimCaloHitLink collections to read"};

--- a/RecCalorimeter/src/components/CreateHitTruthLinks.h
+++ b/RecCalorimeter/src/components/CreateHitTruthLinks.h
@@ -39,16 +39,6 @@ public:
   virtual ~CreateHitTruthLinks();
 
 private:
-  /// Handle for sim calo hits (input collection)
-  /// mutable k4FWCore::DataHandle<edm4hep::SimCalorimeterHitCollection> m_hits{"hits", Gaudi::DataHandle::Reader, this};
-
-  /// Handle for calo hits (input collection)
-  /// mutable k4FWCore::DataHandle<edm4hep::CalorimeterHitCollection> m_cells{"cells", Gaudi::DataHandle::Reader, this};
-
-  /// Handle for hit<->cell link (input collection)
-  /// mutable k4FWCore::DataHandle<edm4hep::CaloHitSimCaloHitLinkCollection> m_cell_hit_links{"cell_hit_links", Gaudi::DataHandle::Reader,
-  ///  this};
-
   /// List of input sim calo hit collections
   Gaudi::Property<std::vector<std::string>> m_hitCollections{
     this, "hits", {}, "Names of CSimalorimeterHit collections to read"};

--- a/RecCalorimeter/src/components/CreateHitTruthLinks.h
+++ b/RecCalorimeter/src/components/CreateHitTruthLinks.h
@@ -9,8 +9,6 @@
 
 // edm4hep
 #include "edm4hep/CaloHitSimCaloHitLinkCollection.h"
-#include "edm4hep/CalorimeterHitCollection.h"
-#include "edm4hep/SimCalorimeterHitCollection.h"
 #include "edm4hep/CaloHitMCParticleLinkCollection.h"
 #include "edm4hep/MCParticleCollection.h"
 
@@ -39,12 +37,6 @@ public:
   virtual ~CreateHitTruthLinks();
 
 private:
-  /// List of input sim calo hit collections
-  Gaudi::Property<std::vector<std::string>> m_hitCollections{
-    this, "hits", {}, "Names of SimCalorimeterHit collections to read"};
-  /// the vector of input k4FWCore::DataHandles for the input hit collections
-  std::vector<k4FWCore::DataHandle<edm4hep::SimCalorimeterHitCollection>*> m_hitCollectionHandles;
-
   /// List of input cell<->hits collections
   Gaudi::Property<std::vector<std::string>> m_cell_hit_linkCollections{
     this, "cell_hit_links", {}, "Names of CaloHitSimCaloHitLink collections to read"};

--- a/RecCalorimeter/src/components/CreateHitTruthLinks.h
+++ b/RecCalorimeter/src/components/CreateHitTruthLinks.h
@@ -41,15 +41,15 @@ public:
 private:
   /// List of input sim calo hit collections
   Gaudi::Property<std::vector<std::string>> m_hitCollections{
-    this, "hits", {}, "Names of CSimalorimeterHit collections to read"};
+    this, "hits", {}, "Names of SimCalorimeterHit collections to read"};
   /// the vector of input k4FWCore::DataHandles for the input hit collections
   std::vector<k4FWCore::DataHandle<edm4hep::SimCalorimeterHitCollection>*> m_hitCollectionHandles;
 
   /// List of input cell collections (not used explicitly - should it be defined anyway?)
-  Gaudi::Property<std::vector<std::string>> m_cellCollections{
-    this, "cells", {}, "Names of CalorimeterHit collections to read"};
+  // Gaudi::Property<std::vector<std::string>> m_cellCollections{
+  //   this, "cells", {}, "Names of CalorimeterHit collections to read"};
   /// the vector of input k4FWCore::DataHandles for the input cell collections
-  std::vector<k4FWCore::DataHandle<edm4hep::CalorimeterHitCollection>*> m_cellCollectionHandles;
+  // std::vector<k4FWCore::DataHandle<edm4hep::CalorimeterHitCollection>*> m_cellCollectionHandles;
 
   /// List of input cell<->hits collections
   Gaudi::Property<std::vector<std::string>> m_cell_hit_linkCollections{

--- a/RecCalorimeter/src/components/CreateHitTruthLinks.h
+++ b/RecCalorimeter/src/components/CreateHitTruthLinks.h
@@ -1,0 +1,78 @@
+#ifndef RECCALORIMETER_CreateHitTruthLinks_H
+#define RECCALORIMETER_CreateHitTruthLinks_H
+
+// k4FWCore
+#include "k4FWCore/DataHandle.h"
+
+// Gaudi
+#include "Gaudi/Algorithm.h"
+
+// edm4hep
+#include "edm4hep/CaloHitSimCaloHitLinkCollection.h"
+#include "edm4hep/CalorimeterHitCollection.h"
+#include "edm4hep/SimCalorimeterHitCollection.h"
+#include "edm4hep/CaloHitMCParticleLinkCollection.h"
+#include "edm4hep/MCParticleCollection.h"
+
+
+/** @class CreateHitTruthLinks
+ *
+ *  Algorithm for creating links between calorimeter cells (CalorimeterHit) and MC particles (MCParticle)
+ *  Based on https://github.com/iLCSoft/MarlinReco/blob/master/Analysis/RecoMCTruthLink/src/RecoMCTruthLinker.cc
+ *
+ *  @author Giovanni Marchiori
+ *  @date   2025-06
+ *
+ */
+
+class CreateHitTruthLinks : public Gaudi::Algorithm {
+
+public:
+  CreateHitTruthLinks(const std::string& name, ISvcLocator* svcLoc);
+
+  StatusCode initialize();
+
+  StatusCode execute(const EventContext&) const;
+
+  StatusCode finalize();
+
+  virtual ~CreateHitTruthLinks();
+
+private:
+  /// Handle for sim calo hits (input collection)
+  /// mutable k4FWCore::DataHandle<edm4hep::SimCalorimeterHitCollection> m_hits{"hits", Gaudi::DataHandle::Reader, this};
+
+  /// Handle for calo hits (input collection)
+  /// mutable k4FWCore::DataHandle<edm4hep::CalorimeterHitCollection> m_cells{"cells", Gaudi::DataHandle::Reader, this};
+
+  /// Handle for hit<->cell link (input collection)
+  /// mutable k4FWCore::DataHandle<edm4hep::CaloHitSimCaloHitLinkCollection> m_cell_hit_links{"cell_hit_links", Gaudi::DataHandle::Reader,
+  ///  this};
+
+  /// List of input sim calo hit collections
+  Gaudi::Property<std::vector<std::string>> m_hitCollections{
+    this, "hits", {}, "Names of CSimalorimeterHit collections to read"};
+  /// the vector of input k4FWCore::DataHandles for the input hit collections
+  std::vector<k4FWCore::DataHandle<edm4hep::SimCalorimeterHitCollection>*> m_hitCollectionHandles;
+
+  /// List of input cell collections (not used explicitly - should it be defined anyway?)
+  Gaudi::Property<std::vector<std::string>> m_cellCollections{
+    this, "cells", {}, "Names of CalorimeterHit collections to read"};
+  /// the vector of input k4FWCore::DataHandles for the input cell collections
+  std::vector<k4FWCore::DataHandle<edm4hep::CalorimeterHitCollection>*> m_cellCollectionHandles;
+
+  /// List of input cell<->hits collections
+  Gaudi::Property<std::vector<std::string>> m_cell_hit_linkCollections{
+    this, "cell_hit_links", {}, "Names of CaloHitSimCaloHitLink collections to read"};
+  /// the vector of input k4FWCore::DataHandles for the input hit<->cell link collections
+  std::vector<k4FWCore::DataHandle<edm4hep::CaloHitSimCaloHitLinkCollection>*> m_cell_hit_linkCollectionHandles;
+
+  /// Handle for mc particles (input collection)
+  mutable k4FWCore::DataHandle<edm4hep::MCParticleCollection> m_mcparticles{"mcparticles", Gaudi::DataHandle::Reader, this};
+
+  /// Handle for hit<->particle link (output collection)
+  mutable k4FWCore::DataHandle<edm4hep::CaloHitMCParticleLinkCollection> m_cell_mcparticle_links{"cell_mcparticle_links", Gaudi::DataHandle::Writer,
+    this};
+};
+
+#endif /* RECCALORIMETER_CreateHitTruthLinks_H */

--- a/RecFCCeeCalorimeter/tests/options/ALLEGRO_o1_v03.sh
+++ b/RecFCCeeCalorimeter/tests/options/ALLEGRO_o1_v03.sh
@@ -38,7 +38,7 @@ else
 fi
 
 # get the files needed for calibration, noise, neighbor finding, etc
-if ! test -f ./neighbours_map_ecalB_thetamodulemerged_hcalB_thetaphi.root; then  # assumes that if the last file exists, all the other as well
+if ! test -f ./cellNoise_map_endcapTurbine_electronicsNoiseLevel.root; then  # assumes that if the last file exists, all the other as well
   echo "Downloading files needed for reconstruction"
   download_file "https://fccsw.web.cern.ch/fccsw/filesForSimDigiReco/ALLEGRO/ALLEGRO_o1_v03/capacitances_ecalBarrelFCCee_theta.root"
   download_file "https://fccsw.web.cern.ch/fccsw/filesForSimDigiReco/ALLEGRO/ALLEGRO_o1_v03/cellNoise_map_electronicsNoiseLevel_ecalB_thetamodulemerged.root"
@@ -52,7 +52,7 @@ if ! test -f ./neighbours_map_ecalB_thetamodulemerged_hcalB_thetaphi.root; then 
   download_file "https://fccsw.web.cern.ch/fccsw/filesForSimDigiReco/ALLEGRO/ALLEGRO_o1_v03/neighbours_map_ecalE_turbine.root"
   download_file "https://fccsw.web.cern.ch/fccsw/filesForSimDigiReco/ALLEGRO/ALLEGRO_o1_v03/neighbours_map_ecalB_thetamodulemerged_ecalE_turbine_hcalB_hcalEndcap_phitheta.root"
   download_file "https://fccsw.web.cern.ch/fccsw/filesForSimDigiReco/ALLEGRO/ALLEGRO_o1_v03/cellNoise_map_endcapTurbine_electronicsNoiseLevel.root"
-  
+
   # add here the lines to get the files for the photon ID
 fi
 

--- a/RecFCCeeCalorimeter/tests/options/ALLEGRO_o1_v03_digi_reco.py
+++ b/RecFCCeeCalorimeter/tests/options/ALLEGRO_o1_v03_digi_reco.py
@@ -17,8 +17,8 @@ from GaudiKernel.PhysicalConstants import pi
 inputfile = "ALLEGRO_sim_ee_z_qq.root"     # input file produced with ddsim
 outputfile = "ALLEGRO_sim_digi_reco.root"  # output file to be produced
 Nevts = -1                                 # -1 means all events
-addNoise = True                            # add noise or not to the cell energy
-addCrosstalk = True                        # switch on/off the crosstalk
+addNoise = False                           # add noise or not to the cell energy
+addCrosstalk = False                       # switch on/off the crosstalk
 dumpGDML = False                           # create GDML file of detector model
 runHCal = True                             # if false, it will produce only ECAL clusters. if true, it will also produce ECAL+HCAL clusters
 
@@ -445,31 +445,13 @@ if runHCal:
                                                       cells=hcalEndcapPositionedCellsName,
                                                       links=hcalEndcapLinks)
     TopAlg += [createHCalEndcapCells]
-# else:
-#     hcalBarrelPositionedCellsName = "emptyCaloCells"
-#     hcalEndcapPositionedCellsName = "emptyCaloCells"
-#     hcalBarrelLinks = ""
-#     hcalEndcapLinks = ""
-#     cellPositionHCalBarrelTool = None
-#     cellPositionHCalEndcapTool = None
-
-# Empty cells for parts of calorimeter not implemented yet
-# from Configurables import CreateEmptyCaloCellsCollection
-# createemptycells = CreateEmptyCaloCellsCollection("CreateEmptyCaloCells")
-# createemptycells.cells.Path = "emptyCaloCells"
 
 # Create CaloHit<->MCParticle links
 from Configurables import CreateHitTruthLinks
-caloHits = [ecalBarrelReadoutName, ecalEndcapReadoutName]
-# caloCells = [ecalBarrelPositionedCellsName, ecalEndcapPositionedCellsName]
 caloLinks = [ecalBarrelLinks, ecalEndcapLinks]
 if runHCal:
-    caloHits += [hcalBarrelReadoutName, hcalEndcapReadoutName]
-    # caloCells += [hcalBarrelPositionedCellsName, hcalEndcapPositionedCellsName]
     caloLinks += [hcalBarrelLinks, hcalEndcapLinks]
 createHitParticleLinks = CreateHitTruthLinks("CreateHitParticleLinks",
-                                             hits=caloHits,
-                                             # cells=caloCells,
                                              cell_hit_links=caloLinks,
                                              mcparticles="MCParticles",
                                              cell_mcparticle_links="CaloHitMCParticleLinks",
@@ -607,7 +589,7 @@ if doSWClustering:
                                                             OutputLevel=INFO
                                                             )
         TopAlg += [calibrateECalBarrelClusters]
-    
+
     if runPhotonIDTool:
         if not addShapeParameters:
             print("Photon ID tool cannot be run if shower shape parameters are not calculated")
@@ -660,7 +642,7 @@ if doSWClustering:
         createClusters.clusters.Path = "CaloClusters"
         createClusters.clusterCells.Path = "CaloClusterCells"
         TopAlg += [createClusters]
-    
+
         # add here E+H cluster calibration tool or anything else for E+H clusters
 
 
@@ -683,7 +665,7 @@ if doTopoClustering:
     readECalBarrelNoisyCellsMap = TopoCaloNoisyCells("ReadECalBarrelNoisyCellsMap",
                                                      fileName=ecalBarrelNoiseMap,
                                                      OutputLevel=INFO)
-    
+
     from Configurables import CaloTopoClusterFCCee
     caloIDs = [IDs["ECAL_Barrel"]]
     createECalBarrelTopoClusters = CaloTopoClusterFCCee("CreateECalBarrelTopoClusters",
@@ -727,7 +709,7 @@ if doTopoClustering:
                                                         createClusterCellCollection=True,
                                                         OutputLevel=INFO)
     TopAlg += [createECalEndcapTopoClusters]
-    
+
     if applyUpDownstreamCorrections:
         from Configurables import CorrectCaloClusters
         correctECalBarrelTopoClusters = CorrectCaloClusters(

--- a/RecFCCeeCalorimeter/tests/options/ALLEGRO_o1_v03_digi_reco.py
+++ b/RecFCCeeCalorimeter/tests/options/ALLEGRO_o1_v03_digi_reco.py
@@ -17,8 +17,8 @@ from GaudiKernel.PhysicalConstants import pi
 inputfile = "ALLEGRO_sim_ee_z_qq.root"     # input file produced with ddsim
 outputfile = "ALLEGRO_sim_digi_reco.root"  # output file to be produced
 Nevts = -1                                 # -1 means all events
-addNoise = False                           # add noise or not to the cell energy
-addCrosstalk = False                       # switch on/off the crosstalk
+addNoise = True                            # add noise or not to the cell energy
+addCrosstalk = True                        # switch on/off the crosstalk
 dumpGDML = False                           # create GDML file of detector model
 runHCal = True                             # if false, it will produce only ECAL clusters. if true, it will also produce ECAL+HCAL clusters
 

--- a/RecFCCeeCalorimeter/tests/options/ALLEGRO_o1_v03_digi_reco.py
+++ b/RecFCCeeCalorimeter/tests/options/ALLEGRO_o1_v03_digi_reco.py
@@ -3,7 +3,7 @@
 #
 
 # Logger
-from Gaudi.Configuration import INFO  # DEBUG, VERBOSE
+from Gaudi.Configuration import INFO, DEBUG, VERBOSE
 # units and physical constants
 from GaudiKernel.PhysicalConstants import pi
 
@@ -14,12 +14,13 @@ from GaudiKernel.PhysicalConstants import pi
 
 # - general settings
 #
-inputfile = "ALLEGRO_sim_ee_z_qq.root"  # input file produced with ddsim
-Nevts = -1                              # -1 means all events
-addNoise = True                         # add noise or not to the cell energy
-addCrosstalk = True                     # switch on/off the crosstalk
-dumpGDML = False                        # create GDML file of detector model
-runHCal = True                          # if false, it will produce only ECAL clusters. if true, it will also produce ECAL+HCAL clusters
+inputfile = "ALLEGRO_sim_ee_z_qq.root"     # input file produced with ddsim
+outputfile = "ALLEGRO_sim_digi_reco.root"  # output file to be produced
+Nevts = -1                                 # -1 means all events
+addNoise = True                            # add noise or not to the cell energy
+addCrosstalk = True                        # switch on/off the crosstalk
+dumpGDML = False                           # create GDML file of detector model
+runHCal = True                             # if false, it will produce only ECAL clusters. if true, it will also produce ECAL+HCAL clusters
 
 # - what to save in output file
 #
@@ -41,9 +42,23 @@ saveClusterCells = True
 ecalBarrelSamplingFraction = [0.3800493723322256] * 1 + [0.13494147915064658] * 1 + [0.142866851721152] * 1 + [0.14839315921940666] * 1 + [0.15298362570665006] * 1 + [0.15709704561942747] * 1 + [0.16063717490147533] * 1 + [0.1641723795419055] * 1 + [0.16845490287689746] * 1 + [0.17111520115997653] * 1 + [0.1730605163148862] * 1
 ecalBarrelUpstreamParameters = [[0.028158491043365624, -1.564259408365951, -76.52312805346982, 0.7442903558010191, -34.894692961350195, -74.19340877431723]]
 ecalBarrelDownstreamParameters = [[0.00010587711361028165, 0.0052371999097777355, 0.69906696456064, -0.9348243433360095, -0.0364714212117143, 8.360401126995626]]
-
 ecalBarrelLayers = len(ecalBarrelSamplingFraction)
 resegmentECalBarrel = False
+# ECAL endcap parameters for digitisation
+# the turbine endcap has calibration "layers" in the both the z and radial
+# directions, for each of the three wheels.  So the total number of layers
+# is given by:
+#
+#   ECalEndcapNumCalibZLayersWheel1*ECalEndcapNumCalibRhoLayersWheel1
+#  +ECalEndcapNumCalibZLayersWheel2*ECalEndcapNumCalibRhoLayersWheel2
+#  +ECalEndcapNumCalibZLayersWheel3*ECalEndcapNumCalibRhoLayersWheel3
+#
+# which in the current design is 5*10+1*14+1*34 = 98
+# NB some cells near the inner and outer edges of the calorimeter are difficult
+# to calibrate as they are not part of the core of well-contained showers.
+# The calibrated values can be <0 or >1 for such cells, so these nonsenical
+# numbers are replaced by 1
+ecalEndcapSamplingFraction = [0.0897818] * 1+ [0.221318] * 1+ [0.0820002] * 1+ [0.994281] * 1+ [0.0414437] * 1+ [0.1148] * 1+ [0.178831] * 1+ [0.142449] * 1+ [0.181206] * 1+ [0.342843] * 1+ [0.137479] * 1+ [0.176479] * 1+ [0.153273] * 1+ [0.195836] * 1+ [0.0780405] * 1+ [0.150202] * 1+ [0.17846] * 1+ [0.164886] * 1+ [0.175758] * 1+ [0.10836] * 1+ [0.160243] * 1+ [0.183373] * 1+ [0.171818] * 1+ [0.194848] * 1+ [0.111899] * 1+ [0.170704] * 1+ [0.188455] * 1+ [0.178164] * 1+ [0.209113] * 1+ [0.105241] * 1+ [0.180637] * 1+ [0.192206] * 1+ [0.186096] * 1+ [0.211962] * 1+ [0.112019] * 1+ [0.180344] * 1+ [0.195684] * 1+ [0.190778] * 1+ [0.218259] * 1+ [0.118516] * 1+ [0.207786] * 1+ [0.204474] * 1+ [0.207048] * 1+ [0.225913] * 1+ [0.111325] * 1+ [0.147875] * 1+ [0.195625] * 1+ [0.173326] * 1+ [0.175449] * 1+ [0.104087] * 1+ [0.153645] * 1+ [0.161263] * 1+ [0.165499] * 1+ [0.171758] * 1+ [0.175789] * 1+ [0.180657] * 1+ [0.184563] * 1+ [0.187876] * 1+ [0.191762] * 1+ [0.19426] * 1+ [0.197959] * 1+ [0.199021] * 1+ [0.204428] * 1+ [0.195709] * 1+ [0.151751] * 1+ [0.171477] * 1+ [0.165509] * 1+ [0.172565] * 1+ [0.172961] * 1+ [0.175534] * 1+ [0.177989] * 1+ [0.18026] * 1+ [0.181898] * 1+ [0.183912] * 1+ [0.185654] * 1+ [0.187515] * 1+ [0.190408] * 1+ [0.188794] * 1+ [0.193699] * 1+ [0.192287] * 1+ [0.19755] * 1+ [0.190943] * 1+ [0.218553] * 1+ [0.161085] * 1+ [0.373086] * 1+ [0.122495] * 1+ [0.21103] * 1+ [1] * 1+ [0.138686] * 1+ [0.0545171] * 1+ [1] * 1+ [1] * 1+ [0.227945] * 1+ [0.0122872] * 1+ [0.00437334] * 1+ [0.00363533] * 1+ [1] * 1+ [1] * 1
 
 # - parameters for clustering
 #
@@ -76,12 +91,25 @@ addPi0RecoTool = True
 #
 # ALGORITHMS AND SERVICES SETUP
 #
+TopAlg = []  # alg sequence
+ExtSvc = []  # list of external services
 
-# Input: load the output of the SIM step
-from Configurables import k4DataSvc, PodioInput
-podioevent = k4DataSvc('EventDataSvc')
-podioevent.input = inputfile
-input_reader = PodioInput('InputReader')
+
+# Event counter
+from Configurables import EventCounter
+eventCounter = EventCounter("EventCounter",
+                            OutputLevel=INFO,
+                            Frequency=1)
+TopAlg += [eventCounter]
+# add a message sink service if you want a summary table at the end (not needed..)
+# ExtSvc += ["Gaudi::Monitoring::MessageSvcSink"]
+
+# CPU information
+from Configurables import AuditorSvc, ChronoAuditor
+chra = ChronoAuditor()
+audsvc = AuditorSvc()
+audsvc.Auditors = [chra]
+ExtSvc += [audsvc]
 
 
 # Detector geometry
@@ -89,7 +117,11 @@ input_reader = PodioInput('InputReader')
 # if K4GEO is empty, this should use relative path to working directory
 from Configurables import GeoSvc
 import os
-geoservice = GeoSvc("GeoSvc")
+geoservice = GeoSvc("GeoSvc",
+                    # OutputLevel=INFO
+                    OutputLevel=DEBUG  # set to DEBUG to print dd4hep::DEBUG messages in k4geo C++ drivers
+                    )
+
 path_to_detector = os.environ.get("K4GEO", "") + "/FCCee/ALLEGRO/compact/ALLEGRO_o1_v03/"
 detectors_to_use = [
     'ALLEGRO_o1_v03.xml'
@@ -97,7 +129,7 @@ detectors_to_use = [
 geoservice.detectors = [
     os.path.join(path_to_detector, _det) for _det in detectors_to_use
 ]
-geoservice.OutputLevel = INFO
+ExtSvc += [geoservice]
 
 # retrieve subdetector IDs
 import xml.etree.ElementTree as ET
@@ -105,16 +137,18 @@ tree = ET.parse(path_to_detector + 'DectDimensions.xml')
 root = tree.getroot()
 IDs = {}
 for constant in root.find('define').findall('constant'):
-    if (constant.get('name') == 'DetID_VXD_Barrel' or
-        constant.get('name') == 'DetID_VXD_Disks' or
-        constant.get('name') == 'DetID_DCH' or
-        constant.get('name') == 'DetID_SiWr_Barrel' or
-        constant.get('name') == 'DetID_SiWr_Disks' or
-        constant.get('name') == 'DetID_ECAL_Barrel' or
-        constant.get('name') == 'DetID_ECAL_Endcap' or
-        constant.get('name') == 'DetID_HCAL_Barrel' or
-        constant.get('name') == 'DetID_HCAL_Endcap' or
-        constant.get('name') == 'DetID_Muon_Barrel'):
+    if (
+        constant.get('name') == 'DetID_VXD_Barrel'
+        or constant.get('name') == 'DetID_VXD_Disks'
+        or constant.get('name') == 'DetID_DCH'
+        or constant.get('name') == 'DetID_SiWr_Barrel'
+        or constant.get('name') == 'DetID_SiWr_Disks'
+        or constant.get('name') == 'DetID_ECAL_Barrel'
+        or constant.get('name') == 'DetID_ECAL_Endcap'
+        or constant.get('name') == 'DetID_HCAL_Barrel'
+        or constant.get('name') == 'DetID_HCAL_Endcap'
+        or constant.get('name') == 'DetID_Muon_Barrel'
+    ):
         IDs[constant.get("name")[6:]] = int(constant.get('value'))
     if (constant.get('name') == 'DetID_Muon_Endcap_1'):
         IDs[constant.get("name")[6:-2]] = int(constant.get('value'))
@@ -122,12 +156,29 @@ for constant in root.find('define').findall('constant'):
 print("Subdetector IDs:")
 print(IDs)
 
+# Input: load the output of the SIM step
+# from Configurables import k4DataSvc, PodioInput
+# podioevent = k4DataSvc('EventDataSvc')
+# podioevent.input = inputfile
+# input_reader = PodioInput('InputReader')
+# TopAlg += [input_reader]
+# ExtSvc += [podioevent]
+# Input/Output handling
+from k4FWCore import IOSvc
+from Configurables import EventDataSvc
+io_svc = IOSvc("IOSvc")
+io_svc.Input = inputfile
+io_svc.Output = outputfile
+ExtSvc += [EventDataSvc("EventDataSvc")]
+
+
 # GDML dump of detector model
 if dumpGDML:
     from Configurables import GeoToGdmlDumpSvc
     gdmldumpservice = GeoToGdmlDumpSvc("GeoToGdmlDumpSvc")
+    ExtSvc += [gdmldumpservice]
 
-# Digitisation (merging hits into cells, EM scale calibration via sampling fractions)
+# Calorimeter digitisation (merging hits into cells, EM scale calibration via sampling fractions)
 
 # - ECAL readouts
 ecalBarrelReadoutName = "ECalBarrelModuleThetaMerged"      # barrel, original segmentation (baseline)
@@ -135,8 +186,9 @@ ecalBarrelReadoutName2 = "ECalBarrelModuleThetaMerged2"    # barrel, after re-se
 ecalEndcapReadoutName = "ECalEndcapTurbine"                # endcap, turbine-like (baseline)
 # - HCAL readouts
 if runHCal:
-    hcalBarrelReadoutName = "HCalBarrelReadout"            # barrel, original segmentation (HCalPhiTheta)
-    hcalEndcapReadoutName = "HCalEndcapReadout"            # endcap, original segmentation (HCalPhiTheta)
+    hcalBarrelReadoutName = "HCalBarrelReadout"            # barrel, original segmentation (phi-theta)
+    # hcalBarrelReadoutName = "HCalBarrelReadoutPhiRow"    # barrel, alternative segmentation (phi-row)
+    hcalEndcapReadoutName = "HCalEndcapReadout"            # endcap, original segmentation
 else:
     hcalBarrelReadoutName = ""
     hcalEndcapReadoutName = ""
@@ -149,21 +201,8 @@ calibEcalBarrel = CalibrateInLayersTool("CalibrateECalBarrel",
                                         readoutName=ecalBarrelReadoutName,
                                         layerFieldName="layer")
 #   * ECAL endcap
-# the turbine endcap has calibration "layers" in the both the z and radial
-# directions, for each of the three wheels.  So the total number of layers
-# is given by:
-#
-#   ECalEndcapNumCalibZLayersWheel1*ECalEndcapNumCalibRhoLayersWheel1
-#  +ECalEndcapNumCalibZLayersWheel2*ECalEndcapNumCalibRhoLayersWheel2
-#  +ECalEndcapNumCalibZLayersWheel3*ECalEndcapNumCalibRhoLayersWheel3
-#
-# which in the current design is 5*10+1*14+1*34 = 98
-# NB some cells near the inner and outer edges of the calorimeter are difficult
-# to calibrate as they are not part of the core of well-contained showers.
-# The calibrated values can be <0 or >1 for such cells, so these nonsenical
-# numbers are replaced by 1
 calibEcalEndcap = CalibrateInLayersTool("CalibrateECalEndcap",
-                                        samplingFraction = [0.0897818] * 1+ [0.221318] * 1+ [0.0820002] * 1+ [0.994281] * 1+ [0.0414437] * 1+ [0.1148] * 1+ [0.178831] * 1+ [0.142449] * 1+ [0.181206] * 1+ [0.342843] * 1+ [0.137479] * 1+ [0.176479] * 1+ [0.153273] * 1+ [0.195836] * 1+ [0.0780405] * 1+ [0.150202] * 1+ [0.17846] * 1+ [0.164886] * 1+ [0.175758] * 1+ [0.10836] * 1+ [0.160243] * 1+ [0.183373] * 1+ [0.171818] * 1+ [0.194848] * 1+ [0.111899] * 1+ [0.170704] * 1+ [0.188455] * 1+ [0.178164] * 1+ [0.209113] * 1+ [0.105241] * 1+ [0.180637] * 1+ [0.192206] * 1+ [0.186096] * 1+ [0.211962] * 1+ [0.112019] * 1+ [0.180344] * 1+ [0.195684] * 1+ [0.190778] * 1+ [0.218259] * 1+ [0.118516] * 1+ [0.207786] * 1+ [0.204474] * 1+ [0.207048] * 1+ [0.225913] * 1+ [0.111325] * 1+ [0.147875] * 1+ [0.195625] * 1+ [0.173326] * 1+ [0.175449] * 1+ [0.104087] * 1+ [0.153645] * 1+ [0.161263] * 1+ [0.165499] * 1+ [0.171758] * 1+ [0.175789] * 1+ [0.180657] * 1+ [0.184563] * 1+ [0.187876] * 1+ [0.191762] * 1+ [0.19426] * 1+ [0.197959] * 1+ [0.199021] * 1+ [0.204428] * 1+ [0.195709] * 1+ [0.151751] * 1+ [0.171477] * 1+ [0.165509] * 1+ [0.172565] * 1+ [0.172961] * 1+ [0.175534] * 1+ [0.177989] * 1+ [0.18026] * 1+ [0.181898] * 1+ [0.183912] * 1+ [0.185654] * 1+ [0.187515] * 1+ [0.190408] * 1+ [0.188794] * 1+ [0.193699] * 1+ [0.192287] * 1+ [0.19755] * 1+ [0.190943] * 1+ [0.218553] * 1+ [0.161085] * 1+ [0.373086] * 1+ [0.122495] * 1+ [0.21103] * 1+ [1] * 1+ [0.138686] * 1+ [0.0545171] * 1+ [1] * 1+ [1] * 1+ [0.227945] * 1+ [0.0122872] * 1+ [0.00437334] * 1+ [0.00363533] * 1+ [1] * 1+ [1] * 1,
+                                        samplingFraction=ecalEndcapSamplingFraction,
                                         readoutName=ecalEndcapReadoutName,
                                         layerFieldName="layer")
 
@@ -229,6 +268,38 @@ if addCrosstalk:
 else:
     readCrosstalkMap = None
 
+# - noise tool
+if addNoise:
+    ecalBarrelNoisePath = "elecNoise_ecalBarrelFCCee_theta.root"
+    ecalBarrelNoiseRMSHistName = "h_elecNoise_fcc_"
+    from Configurables import NoiseCaloCellsVsThetaFromFileTool
+    ecalBarrelNoiseTool = NoiseCaloCellsVsThetaFromFileTool("ecalBarrelNoiseTool",
+                                                            cellPositionsTool=cellPositionEcalBarrelToolForNoise,
+                                                            readoutName=ecalBarrelReadoutName,
+                                                            noiseFileName=ecalBarrelNoisePath,
+                                                            elecNoiseRMSHistoName=ecalBarrelNoiseRMSHistName,
+                                                            setNoiseOffset=False,
+                                                            activeFieldName="layer",
+                                                            addPileup=False,
+                                                            filterNoiseThreshold=1,
+                                                            useAbsInFilter=True,
+                                                            numRadialLayers=ecalBarrelLayers,
+                                                            scaleFactor=1 / 1000.,  # MeV to GeV
+                                                            OutputLevel=INFO)
+
+    from Configurables import TubeLayerModuleThetaCaloTool
+    ecalBarrelGeometryTool = TubeLayerModuleThetaCaloTool("ecalBarrelGeometryTool",
+                                                          readoutName=ecalBarrelReadoutName,
+                                                          activeVolumeName="LAr_sensitive",
+                                                          activeFieldName="layer",
+                                                          activeVolumesNumber=ecalBarrelLayers,
+                                                          fieldNames=["system"],
+                                                          fieldValues=[IDs["ECAL_Barrel"]],
+                                                          OutputLevel=INFO)
+else:
+    ecalBarrelNoiseTool = None
+    ecalBarrelGeometryTool = None
+
 # Create cells in ECal barrel (calibrated and positioned - optionally with xtalk and noise added)
 # from uncalibrated cells (+cellID info) from ddsim
 ecalBarrelPositionedCellsName = ecalBarrelReadoutName + "Positioned"
@@ -236,10 +307,10 @@ ecalBarrelLinks = ecalBarrelPositionedCellsName + "SimCaloHitLinks"
 from Configurables import CreatePositionedCaloCells
 createEcalBarrelCells = CreatePositionedCaloCells("CreatePositionedECalBarrelCells",
                                                   doCellCalibration=True,
-                                                  positionsTool=cellPositionEcalBarrelTool,
                                                   calibTool=calibEcalBarrel,
-                                                  crosstalkTool=readCrosstalkMap,
+                                                  positionsTool=cellPositionEcalBarrelTool,
                                                   addCrosstalk=addCrosstalk,
+                                                  crosstalkTool=readCrosstalkMap,
                                                   addCellNoise=False,
                                                   filterCellNoise=False,
                                                   OutputLevel=INFO,
@@ -247,6 +318,7 @@ createEcalBarrelCells = CreatePositionedCaloCells("CreatePositionedECalBarrelCel
                                                   cells=ecalBarrelPositionedCellsName,
                                                   links=ecalBarrelLinks
                                                   )
+TopAlg += [createEcalBarrelCells]
 
 # -  now, if we want to also save cells with coarser granularity:
 if resegmentECalBarrel:
@@ -286,6 +358,10 @@ if resegmentECalBarrel:
                                                        hits="ECalBarrelCellsMerged",
                                                        cells=ecalBarrelPositionedCellsName2,
                                                        links=ecalBarrelLinks2)
+    TopAlg += [
+        resegmentEcalBarrelTool,
+        createEcalBarrelCells2,
+    ]
 
 # Create cells in ECal endcap (needed if one wants to apply cell calibration,
 # which is not performed by ddsim)
@@ -303,70 +379,47 @@ createEcalEndcapCells = CreatePositionedCaloCells("CreatePositionedECalEndcapCel
                                                   hits=ecalEndcapReadoutName,
                                                   cells=ecalEndcapPositionedCellsName,
                                                   links=ecalEndcapLinks)
+TopAlg += [createEcalEndcapCells]
 
 if addNoise:
-    ecalBarrelNoisePath = "elecNoise_ecalBarrelFCCee_theta.root"
-    ecalBarrelNoiseRMSHistName = "h_elecNoise_fcc_"
-    from Configurables import NoiseCaloCellsVsThetaFromFileTool
-    noiseBarrel = NoiseCaloCellsVsThetaFromFileTool("NoiseBarrel",
-                                                    cellPositionsTool=cellPositionEcalBarrelToolForNoise,
-                                                    readoutName=ecalBarrelReadoutName,
-                                                    noiseFileName=ecalBarrelNoisePath,
-                                                    elecNoiseRMSHistoName=ecalBarrelNoiseRMSHistName,
-                                                    setNoiseOffset=False,
-                                                    activeFieldName="layer",
-                                                    addPileup=False,
-                                                    filterNoiseThreshold=1,
-                                                    numRadialLayers=11,
-                                                    scaleFactor=1 / 1000.,  # MeV to GeV
-                                                    OutputLevel=INFO)
-
-    from Configurables import TubeLayerModuleThetaCaloTool
-    barrelGeometry = TubeLayerModuleThetaCaloTool("EcalBarrelGeo",
-                                                  readoutName=ecalBarrelReadoutName,
-                                                  activeVolumeName="LAr_sensitive",
-                                                  activeFieldName="layer",
-                                                  activeVolumesNumber=11,
-                                                  fieldNames=["system"],
-                                                  fieldValues=[4],
-                                                  OutputLevel=INFO)
-
     # cells with noise not filtered
     ecalBarrelCellsNoiseLinks = ecalBarrelPositionedCellsName + "WithNoise" + "SimCaloHitLinks"
     createEcalBarrelCellsNoise = CreatePositionedCaloCells("CreatePositionedECalBarrelCellsWithNoise",
                                                            doCellCalibration=True,
-                                                           positionsTool=cellPositionEcalBarrelTool,
                                                            calibTool=calibEcalBarrel,
+                                                           positionsTool=cellPositionEcalBarrelTool,
                                                            addCellNoise=True,
                                                            filterCellNoise=False,
-                                                           noiseTool=noiseBarrel,
-                                                           geometryTool=barrelGeometry,
+                                                           noiseTool=ecalBarrelNoiseTool,
+                                                           geometryTool=ecalBarrelGeometryTool,
                                                            OutputLevel=INFO,
-                                                           hits=ecalBarrelReadoutName,  # uncalibrated & unpositioned cells without noise
+                                                           hits=ecalBarrelReadoutName,
                                                            cells=ecalBarrelPositionedCellsName + "WithNoise",
                                                            links=ecalBarrelCellsNoiseLinks)
+    TopAlg += [createEcalBarrelCellsNoise]
 
     # cells with noise filtered
     ecalBarrelCellsNoiseFilteredLinks = ecalBarrelPositionedCellsName + "WithNoiseFiltered" + "SimCaloHitLinks"
-    createEcalBarrelCellsNoiseFiltered = CreatePositionedCaloCells("CreateECalBarrelCellsWithNoiseFiltered",
+    createEcalBarrelCellsNoiseFiltered = CreatePositionedCaloCells("CreatePositionedECalBarrelCellsWithNoiseFiltered",
                                                                    doCellCalibration=True,
                                                                    calibTool=calibEcalBarrel,
                                                                    positionsTool=cellPositionEcalBarrelTool,
                                                                    addCellNoise=True,
                                                                    filterCellNoise=True,
-                                                                   noiseTool=noiseBarrel,
-                                                                   geometryTool=barrelGeometry,
+                                                                   noiseTool=ecalBarrelNoiseTool,
+                                                                   geometryTool=ecalBarrelGeometryTool,
                                                                    OutputLevel=INFO,
                                                                    hits=ecalBarrelReadoutName,  # uncalibrated & unpositioned cells without noise
                                                                    cells=ecalBarrelPositionedCellsName + "WithNoiseFiltered",
                                                                    links=ecalBarrelCellsNoiseFilteredLinks
                                                                    )
+    TopAlg += [createEcalBarrelCellsNoiseFiltered]
 
 if runHCal:
     # Apply calibration and positioning to cells in HCal barrel
     hcalBarrelPositionedCellsName = hcalBarrelReadoutName + "Positioned"
     hcalBarrelLinks = hcalBarrelPositionedCellsName + "SimCaloHitLinks"
-    createHCalBarrelCells = CreatePositionedCaloCells("CreateHCalBarrelCells",
+    createHCalBarrelCells = CreatePositionedCaloCells("CreatePositionedHCalBarrelCells",
                                                       doCellCalibration=True,
                                                       calibTool=calibHCalBarrel,
                                                       positionsTool=cellPositionHCalBarrelTool,
@@ -376,11 +429,12 @@ if runHCal:
                                                       cells=hcalBarrelPositionedCellsName,
                                                       links=hcalBarrelLinks,
                                                       OutputLevel=INFO)
+    TopAlg += [createHCalBarrelCells]
 
-    # Create cells in HCal endcap
+    # Apply calibration and positioning to cells in HCal endcap
     hcalEndcapPositionedCellsName = hcalEndcapReadoutName + "Positioned"
     hcalEndcapLinks = hcalEndcapPositionedCellsName + "SimCaloHitLinks"
-    createHCalEndcapCells = CreatePositionedCaloCells("CreateHCalEndcapCells",
+    createHCalEndcapCells = CreatePositionedCaloCells("CreatePositionedHCalEndcapCells",
                                                       doCellCalibration=True,
                                                       calibTool=calibHCalEndcap,
                                                       addCellNoise=False,
@@ -390,19 +444,37 @@ if runHCal:
                                                       hits=hcalEndcapReadoutName,
                                                       cells=hcalEndcapPositionedCellsName,
                                                       links=hcalEndcapLinks)
-
-else:
-    hcalBarrelPositionedCellsName = "emptyCaloCells"
-    hcalEndcapPositionedCellsName = "emptyCaloCells"
-    hcalBarrelLinks = ""
-    hcalEndcapLinks = ""
-    cellPositionHCalBarrelTool = None
-    cellPositionHCalEndcapTool = None
+    TopAlg += [createHCalEndcapCells]
+# else:
+#     hcalBarrelPositionedCellsName = "emptyCaloCells"
+#     hcalEndcapPositionedCellsName = "emptyCaloCells"
+#     hcalBarrelLinks = ""
+#     hcalEndcapLinks = ""
+#     cellPositionHCalBarrelTool = None
+#     cellPositionHCalEndcapTool = None
 
 # Empty cells for parts of calorimeter not implemented yet
-from Configurables import CreateEmptyCaloCellsCollection
-createemptycells = CreateEmptyCaloCellsCollection("CreateEmptyCaloCells")
-createemptycells.cells.Path = "emptyCaloCells"
+# from Configurables import CreateEmptyCaloCellsCollection
+# createemptycells = CreateEmptyCaloCellsCollection("CreateEmptyCaloCells")
+# createemptycells.cells.Path = "emptyCaloCells"
+
+# Create CaloHit<->MCParticle links
+from Configurables import CreateHitTruthLinks
+caloHits = [ecalBarrelReadoutName, ecalEndcapReadoutName]
+# caloCells = [ecalBarrelPositionedCellsName, ecalEndcapPositionedCellsName]
+caloLinks = [ecalBarrelLinks, ecalEndcapLinks]
+if runHCal:
+    caloHits += [hcalBarrelReadoutName, hcalEndcapReadoutName]
+    # caloCells += [hcalBarrelPositionedCellsName, hcalEndcapPositionedCellsName]
+    caloLinks += [hcalBarrelLinks, hcalEndcapLinks]
+createHitParticleLinks = CreateHitTruthLinks("CreateHitParticleLinks",
+                                             hits=caloHits,
+                                             # cells=caloCells,
+                                             cell_hit_links=caloLinks,
+                                             mcparticles="MCParticles",
+                                             cell_mcparticle_links="CaloHitMCParticleLinks",
+                                             OutputLevel=DEBUG)
+TopAlg += [createHitParticleLinks]
 
 if doSWClustering:
 
@@ -450,6 +522,7 @@ if doSWClustering:
                                                                     )
     createECalBarrelClusters.clusters.Path = "EMBCaloClusters"
     createECalBarrelClusters.clusterCells.Path = "EMBCaloClusterCells"
+    TopAlg += [createECalBarrelClusters]
 
     cells = [ecalEndcapPositionedCellsName]
     caloIDs = [IDs["ECAL_Endcap"]]
@@ -473,13 +546,14 @@ if doSWClustering:
                                                                     )
     createECalEndcapClusters.clusters.Path = "EMECCaloClusters"
     createECalEndcapClusters.clusterCells.Path = "EMECCaloClusterCells"
+    TopAlg += [createECalEndcapClusters]
 
     if applyUpDownstreamCorrections:
         from Configurables import CorrectCaloClusters
         correctECalBarrelClusters = CorrectCaloClusters("CorrectECalBarrelClusters",
                                                         inClusters=createECalBarrelClusters.clusters.Path,
                                                         outClusters="Corrected" + createECalBarrelClusters.clusters.Path,
-                                                        systemIDs=[4],
+                                                        systemIDs=[IDs["ECAL_Barrel"]],
                                                         numLayers=[ecalBarrelLayers],
                                                         firstLayerIDs=[0],
                                                         lastLayerIDs=[ecalBarrelLayers - 1],
@@ -492,13 +566,14 @@ if doSWClustering:
                                                             ['[0]+[1]*x', '[0]+[1]/sqrt(x)', '[0]+[1]/x']],
                                                         OutputLevel=INFO
                                                         )
+        TopAlg += [correctECalBarrelClusters]
 
     if addShapeParameters:
         from Configurables import AugmentClustersFCCee
         augmentECalBarrelClusters = AugmentClustersFCCee("AugmentECalBarrelClusters",
                                                          inClusters=createECalBarrelClusters.clusters.Path,
                                                          outClusters="Augmented" + createECalBarrelClusters.clusters.Path,
-                                                         systemIDs=[4],
+                                                         systemIDs=[IDs["ECAL_Barrel"]],
                                                          systemNames=["EMB"],
                                                          numLayers=[ecalBarrelLayers],
                                                          readoutNames=[ecalBarrelReadoutName],
@@ -508,6 +583,7 @@ if doSWClustering:
                                                          do_widthTheta_logE_weights=logEWeightInPhotonID,
                                                          OutputLevel=INFO
                                                          )
+        TopAlg += [augmentECalBarrelClusters]
 
     if applyMVAClusterEnergyCalibration:
         inClusters = ""
@@ -520,7 +596,7 @@ if doSWClustering:
         calibrateECalBarrelClusters = CalibrateCaloClusters("calibrateECalBarrelClusters",
                                                             inClusters=inClusters,
                                                             outClusters="Calibrated" + createECalBarrelClusters.clusters.Path,
-                                                            systemIDs=[4],
+                                                            systemIDs=[IDs["ECAL_Barrel"]],
                                                             systemNames=["EMB"],
                                                             numLayers=[ecalBarrelLayers],
                                                             firstLayerIDs=[0],
@@ -530,7 +606,8 @@ if doSWClustering:
                                                             calibrationFile="lgbm_calibration-CaloClusters.onnx",
                                                             OutputLevel=INFO
                                                             )
-
+        TopAlg += [calibrateECalBarrelClusters]
+    
     if runPhotonIDTool:
         if not addShapeParameters:
             print("Photon ID tool cannot be run if shower shape parameters are not calculated")
@@ -550,6 +627,7 @@ if doSWClustering:
                                                       mvaInputsFile="bdt-photonid-inputs-CaloClusters.json",
                                                       OutputLevel=INFO
                                                       )
+            TopAlg += [photonIDECalBarrelClusters]
 
     # ECAL + HCAL clusters
     if runHCal:
@@ -581,7 +659,8 @@ if doSWClustering:
                                                               )
         createClusters.clusters.Path = "CaloClusters"
         createClusters.clusterCells.Path = "CaloClusterCells"
-
+        TopAlg += [createClusters]
+    
         # add here E+H cluster calibration tool or anything else for E+H clusters
 
 
@@ -620,6 +699,7 @@ if doTopoClustering:
                                                         calorimeterIDs=caloIDs,
                                                         createClusterCellCollection=True,
                                                         OutputLevel=INFO)
+    TopAlg += [createECalBarrelTopoClusters]
 
     # Neighbours map
     ecalEndcapNeighboursMap = "neighbours_map_ecalE_turbine.root"
@@ -646,14 +726,15 @@ if doTopoClustering:
                                                         calorimeterIDs=caloIDs,
                                                         createClusterCellCollection=True,
                                                         OutputLevel=INFO)
-
+    TopAlg += [createECalEndcapTopoClusters]
+    
     if applyUpDownstreamCorrections:
         from Configurables import CorrectCaloClusters
         correctECalBarrelTopoClusters = CorrectCaloClusters(
             "CorrectECalBarrelTopoClusters",
             inClusters=createECalBarrelTopoClusters.clusters.Path,
             outClusters="Corrected" + createECalBarrelTopoClusters.clusters.Path,
-            systemIDs=[4],
+            systemIDs=[IDs["ECAL_Barrel"]],
             numLayers=[ecalBarrelLayers],
             firstLayerIDs=[0],
             lastLayerIDs=[ecalBarrelLayers - 1],
@@ -666,13 +747,14 @@ if doTopoClustering:
             downstreamFormulas=[['[0]+[1]*x', '[0]+[1]/sqrt(x)', '[0]+[1]/x']],
             OutputLevel=INFO
         )
+        TopAlg += [correctECalBarrelTopoClusters]
 
     if addShapeParameters:
         from Configurables import AugmentClustersFCCee
         augmentECalBarrelTopoClusters = AugmentClustersFCCee("augmentECalBarrelTopoClusters",
                                                              inClusters=createECalBarrelTopoClusters.clusters.Path,
                                                              outClusters="Augmented" + createECalBarrelTopoClusters.clusters.Path,
-                                                             systemIDs=[4],
+                                                             systemIDs=[IDs["ECAL_Barrel"]],
                                                              systemNames=["EMB"],
                                                              numLayers=[ecalBarrelLayers],
                                                              readoutNames=[ecalBarrelReadoutName],
@@ -681,6 +763,8 @@ if doTopoClustering:
                                                              do_photon_shapeVar=runPhotonIDTool,
                                                              do_widthTheta_logE_weights=logEWeightInPhotonID,
                                                              OutputLevel=INFO)
+        TopAlg += [augmentECalBarrelTopoClusters]
+
         if addPi0RecoTool:
             from Configurables import PairCaloClustersPi0
             Pi0RecoAlg = PairCaloClustersPi0(
@@ -693,6 +777,7 @@ if doTopoClustering:
                 massHigh=0.153543,
                 OutputLevel=INFO
             )
+            TopAlg += [Pi0RecoAlg]
 
     if applyMVAClusterEnergyCalibration:
         inClusters = ""
@@ -705,7 +790,7 @@ if doTopoClustering:
         calibrateECalBarrelTopoClusters = CalibrateCaloClusters("calibrateECalBarrelTopoClusters",
                                                                 inClusters=inClusters,
                                                                 outClusters="Calibrated" + createECalBarrelTopoClusters.clusters.Path,
-                                                                systemIDs=[4],
+                                                                systemIDs=[IDs["ECAL_Barrel"]],
                                                                 systemNames=["EMB"],
                                                                 numLayers=[ecalBarrelLayers],
                                                                 firstLayerIDs=[0],
@@ -715,6 +800,7 @@ if doTopoClustering:
                                                                 calibrationFile="lgbm_calibration-CaloTopoClusters.onnx",
                                                                 OutputLevel=INFO
                                                                 )
+        TopAlg += [calibrateECalBarrelTopoClusters]
 
     if runPhotonIDTool:
         if not addShapeParameters:
@@ -734,6 +820,7 @@ if doTopoClustering:
                                                           mvaModelFile="bdt-photonid-weights-CaloTopoClusters.onnx",
                                                           mvaInputsFile="bdt-photonid-inputs-CaloTopoClusters.json",
                                                           OutputLevel=INFO)
+            TopAlg += [photonIDECalBarrelTopoClusters]
 
     # ECAL + HCAL
     if runHCal:
@@ -759,175 +846,80 @@ if doTopoClustering:
                                                   neighbourSigma=2,
                                                   lastNeighbourSigma=0,
                                                   OutputLevel=INFO)
+        TopAlg += [createTopoClusters]
 
 # Output
-from Configurables import PodioOutput
-out = PodioOutput("out",
-                  OutputLevel=INFO)
-out.filename = "ALLEGRO_sim_digi_reco.root"
+# from Configurables import PodioOutput
+# io_svc = PodioOutput("out",
+#                   OutputLevel=INFO)
+# io_svc.filename = "ALLEGRO_sim_digi_reco.root"
+# TopAlg += [io_svc]
 
-out.outputCommands = ["keep *",
-                      "drop emptyCaloCells"]
+io_svc.outputCommands = ["keep *",
+                         "drop emptyCaloCells"]
 
 # drop the uncalibrated cells
 if dropUncalibratedCells:
-    out.outputCommands.append("drop %s" % ecalBarrelReadoutName)
-    out.outputCommands.append("drop %s" % ecalBarrelReadoutName2)
-    out.outputCommands.append("drop %s" % ecalEndcapReadoutName)
+    io_svc.outputCommands.append("drop %s" % ecalBarrelReadoutName)
+    io_svc.outputCommands.append("drop %s" % ecalBarrelReadoutName2)
+    io_svc.outputCommands.append("drop %s" % ecalEndcapReadoutName)
     if runHCal:
-        out.outputCommands.append("drop %s" % hcalBarrelReadoutName)
-        out.outputCommands.append("drop %s" % hcalEndcapReadoutName)
+        io_svc.outputCommands.append("drop %s" % hcalBarrelReadoutName)
+        io_svc.outputCommands.append("drop %s" % hcalEndcapReadoutName)
     else:
-        out.outputCommands += ["drop HCal*"]
+        io_svc.outputCommands += ["drop HCal*"]
 
     # drop the intermediate ecal barrel cells in case of a resegmentation
     if resegmentECalBarrel:
-        out.outputCommands.append("drop ECalBarrelCellsMerged")
-    # drop the intermediate hcal barrel cells before resegmentation
-    if runHCal:
-        out.outputCommands.append("drop %s" % hcalBarrelPositionedCellsName)
-        out.outputCommands.append("drop %s" % hcalEndcapPositionedCellsName)
+        io_svc.outputCommands.append("drop ECalBarrelCellsMerged")
 
 # drop lumi, vertex, DCH, Muons (unless want to keep for event display)
-out.outputCommands.append("drop Lumi*")
-# out.outputCommands.append("drop Vertex*")
-# out.outputCommands.append("drop DriftChamber_simHits*")
-out.outputCommands.append("drop MuonTagger*")
+io_svc.outputCommands.append("drop Lumi*")
+# io_svc.outputCommands.append("drop Vertex*")
+# io_svc.outputCommands.append("drop DriftChamber_simHits*")
+io_svc.outputCommands.append("drop MuonTagger*")
 
 # drop hits/positioned cells/cluster cells if desired
 if not saveHits:
-    out.outputCommands.append("drop *%sContributions" % ecalBarrelReadoutName)
-    out.outputCommands.append("drop *%sContributions" % ecalBarrelReadoutName2)
-    out.outputCommands.append("drop *%sContributions" % ecalEndcapReadoutName)
-if not saveCells:
-    out.outputCommands.append("drop %s" % ecalBarrelPositionedCellsName)
-    out.outputCommands.append("drop %s" % ecalEndcapPositionedCellsName)
-    if resegmentECalBarrel:
-        out.outputCommands.append("drop %s" % ecalBarrelPositionedCellsName2)
+    io_svc.outputCommands.append("drop *%sContributions" % ecalBarrelReadoutName)
+    io_svc.outputCommands.append("drop *%sContributions" % ecalBarrelReadoutName2)
+    io_svc.outputCommands.append("drop *%sContributions" % ecalEndcapReadoutName)
     if runHCal:
-        out.outputCommands.append("drop %s" % hcalBarrelPositionedCellsName)
-        out.outputCommands.append("drop %s" % hcalEndcapPositionedCellsName)
+        io_svc.outputCommands.append("drop *%sContributions" % hcalBarrelReadoutName)
+        io_svc.outputCommands.append("drop *%sContributions" % hcalEndcapReadoutName)
+if not saveCells:
+    io_svc.outputCommands.append("drop %s" % ecalBarrelPositionedCellsName)
+    io_svc.outputCommands.append("drop %s" % ecalEndcapPositionedCellsName)
+    if resegmentECalBarrel:
+        io_svc.outputCommands.append("drop %s" % ecalBarrelPositionedCellsName2)
+    if runHCal:
+        io_svc.outputCommands.append("drop %s" % hcalBarrelPositionedCellsName)
+        io_svc.outputCommands.append("drop %s" % hcalEndcapPositionedCellsName)
 if not saveClusterCells:
-    out.outputCommands.append("drop Calo*ClusterCells*")
+    io_svc.outputCommands.append("drop *Calo*Cluster*Cells*")
+# drop hits<->cells links if either of the two collections are not saved
+if not saveHits or not saveCells:
+    io_svc.outputCommands.append("drop *SimCaloHitLinks")
 
 # if we decorate the clusters, we can drop the non-decorated ones
 # commented in tests, for debugging
 # if addShapeParameters:
-#     out.outputCommands.append("drop %s" % augmentECalBarrelClusters.inClusters)
+#     io_svc.outputCommands.append("drop %s" % augmentECalBarrelClusters.inClusters)
 
-# CPU information
-from Configurables import AuditorSvc, ChronoAuditor
-chra = ChronoAuditor()
-audsvc = AuditorSvc()
-audsvc.Auditors = [chra]
-out.AuditExecute = True
 
-# Configure list of external services
-ExtSvc = [geoservice, podioevent, audsvc]
-if dumpGDML:
-    ExtSvc += [gdmldumpservice]
-
-# Setup alg sequence
-TopAlg = [
-    input_reader,
-    createEcalBarrelCells,
-    createEcalEndcapCells,
-]
-createEcalBarrelCells.AuditExecute = True
-createEcalEndcapCells.AuditExecute = True
-if addNoise:
-    TopAlg += [
-        createEcalBarrelCellsNoise,
-        createEcalBarrelCellsNoiseFiltered
-    ]
-    createEcalBarrelCellsNoise.AuditExecute = True
-    createEcalBarrelCellsNoiseFiltered.AuditExecute = True
-
-if resegmentECalBarrel:
-    TopAlg += [
-        resegmentEcalBarrelTool,
-        createEcalBarrelCells2,
-    ]
-    resegmentEcalBarrelTool.AuditExecute = True
-    createEcalBarrelCells2.AuditExecute = True
-
-if runHCal:
-    TopAlg += [
-        createHCalBarrelCells,
-        createHCalEndcapCells,
-    ]
-    createHCalBarrelCells.AuditExecute = True
-    createHCalEndcapCells.AuditExecute = True
-
-if doSWClustering or doTopoClustering:
-    TopAlg += [createemptycells]
-    createemptycells.AuditExecute = True
-
-    if doSWClustering:
-        TopAlg += [createECalBarrelClusters, createECalEndcapClusters]
-        createECalBarrelClusters.AuditExecute = True
-        createECalEndcapClusters.AuditExecute = True
-
-        if applyUpDownstreamCorrections:
-            TopAlg += [correctECalBarrelClusters]
-            correctECalBarrelClusters.AuditExecute = True
-
-        if addShapeParameters:
-            TopAlg += [augmentECalBarrelClusters]
-            augmentECalBarrelClusters.AuditExecute = True
-
-        if applyMVAClusterEnergyCalibration:
-            TopAlg += [calibrateECalBarrelClusters]
-            calibrateECalBarrelClusters.AuditExecute = True
-
-        if runPhotonIDTool:
-            TopAlg += [photonIDECalBarrelClusters]
-            photonIDECalBarrelClusters.AuditExecute = True
-
-        if runHCal:
-            TopAlg += [createClusters]
-            createClusters.AuditExecute = True
-
-    if doTopoClustering:
-        TopAlg += [createECalBarrelTopoClusters]
-        createECalBarrelTopoClusters.AuditExecute = True
-
-        TopAlg += [createECalEndcapTopoClusters]
-        createECalEndcapTopoClusters.AuditExecute = True
-        
-        if applyUpDownstreamCorrections:
-            TopAlg += [correctECalBarrelTopoClusters]
-            correctECalBarrelTopoClusters.AuditExecute = True
-
-        if addShapeParameters:
-            TopAlg += [augmentECalBarrelTopoClusters]
-            augmentECalBarrelTopoClusters.AuditExecute = True
-
-            if addPi0RecoTool:
-                TopAlg += [Pi0RecoAlg]
-                Pi0RecoAlg.AuditExecute = True
-
-        if applyMVAClusterEnergyCalibration:
-            TopAlg += [calibrateECalBarrelTopoClusters]
-            calibrateECalBarrelTopoClusters.AuditExecute = True
-
-        if runPhotonIDTool:
-            TopAlg += [photonIDECalBarrelTopoClusters]
-            photonIDECalBarrelTopoClusters.AuditExecute = True
-
-        if runHCal:
-            TopAlg += [createTopoClusters]
-            createTopoClusters.AuditExecute = True
-
-TopAlg += [
-    out
-]
-
-from Configurables import ApplicationMgr
-ApplicationMgr(
+# configure the application
+print(TopAlg)
+print(ExtSvc)
+from k4FWCore import ApplicationMgr
+applicationMgr = ApplicationMgr(
     TopAlg=TopAlg,
     EvtSel='NONE',
     EvtMax=Nevts,
     ExtSvc=ExtSvc,
     StopOnSignal=True,
 )
+
+for algo in applicationMgr.TopAlg:
+    algo.AuditExecute = True
+    # for debug
+    # algo.OutputLevel = DEBUG

--- a/RecFCCeeCalorimeter/tests/options/ALLEGRO_o1_v03_digi_reco.py
+++ b/RecFCCeeCalorimeter/tests/options/ALLEGRO_o1_v03_digi_reco.py
@@ -156,13 +156,6 @@ for constant in root.find('define').findall('constant'):
 print("Subdetector IDs:")
 print(IDs)
 
-# Input: load the output of the SIM step
-# from Configurables import k4DataSvc, PodioInput
-# podioevent = k4DataSvc('EventDataSvc')
-# podioevent.input = inputfile
-# input_reader = PodioInput('InputReader')
-# TopAlg += [input_reader]
-# ExtSvc += [podioevent]
 # Input/Output handling
 from k4FWCore import IOSvc
 from Configurables import EventDataSvc
@@ -170,7 +163,6 @@ io_svc = IOSvc("IOSvc")
 io_svc.Input = inputfile
 io_svc.Output = outputfile
 ExtSvc += [EventDataSvc("EventDataSvc")]
-
 
 # GDML dump of detector model
 if dumpGDML:
@@ -830,13 +822,7 @@ if doTopoClustering:
                                                   OutputLevel=INFO)
         TopAlg += [createTopoClusters]
 
-# Output
-# from Configurables import PodioOutput
-# io_svc = PodioOutput("out",
-#                   OutputLevel=INFO)
-# io_svc.filename = "ALLEGRO_sim_digi_reco.root"
-# TopAlg += [io_svc]
-
+# Configure output
 io_svc.outputCommands = ["keep *",
                          "drop emptyCaloCells"]
 


### PR DESCRIPTION

BEGINRELEASENOTES
- Introduce a new Gaudi algorithm that can create a link collection between multiple input CalorimeterHit collections and MCParticles
ENDRELEASENOTES

Note: similar to what is done in Marlin in https://github.com/iLCSoft/MarlinReco/blob/master/Analysis/RecoMCTruthLink/src/RecoMCTruthLinker.cc
CLD reco uses a wrapper of that tool to save various links to truth in their output
For mlpf for ALLEGRO we need the calohit<->mcparticle links