### PR TITLE
Pull z out of sqrt in theta calculation

### DIFF
--- a/RecCalorimeter/src/components/CreateCaloJet.cpp
+++ b/RecCalorimeter/src/components/CreateCaloJet.cpp
@@ -60,7 +60,7 @@ struct CreateCaloJet final
       float x = position.x;
       float y = position.y;
       float z = position.z;
-      double theta = acos(sqrt(z * z / (x * x + y * y + z * z)));
+      double theta = acos(z / sqrt(x * x + y * y + z * z));
       double eta = -log(tan(theta / 2.));
       double phi = atan2(y, x);
       double pT = cluster.getEnergy() * sqrt((x * x + y * y) / (x * x + y * y + z * z));


### PR DESCRIPTION
With z in the square root, you can only get positive theta (and eta) values. This effectively takes the absolute value of the angle. By pulling it out of the square root, we recover the full angular distribution of the detector.