### PR TITLE
Fix bad use of return in shell script.

### DIFF
--- a/RecFCCeeCalorimeter/tests/options/ALLEGRO_o1_v03.sh
+++ b/RecFCCeeCalorimeter/tests/options/ALLEGRO_o1_v03.sh
@@ -13,7 +13,7 @@ download_file() {
 # Check that the Key4hep environment is set
 if [[ -z "${KEY4HEP_STACK}" ]]; then
   echo "Error: Key4hep environment not set"
-  return 1
+  exit 1
 fi
 
 # run the SIM step (for debug do not run it if files already present. Comment the if and fi lines for production)


### PR DESCRIPTION
Using return outside of a function in a non-sourced shell script gives an error (with bash anyway):

```
return: can only `return' from a function or sourced script
```

Use exit rather than return to exit the script.



BEGINRELEASENOTES
- Small fix to test script.
ENDRELEASENOTES
