### PR TITLE
Making methods of ICaloReadCrosstalkMap const.

### DIFF
--- a/RecCalorimeter/src/components/ReadCaloCrosstalkMap.cpp
+++ b/RecCalorimeter/src/components/ReadCaloCrosstalkMap.cpp
@@ -76,4 +76,24 @@ StatusCode ReadCaloCrosstalkMap::finalize() { return AlgTool::finalize(); }
 
 std::vector<uint64_t>& ReadCaloCrosstalkMap::getNeighbours(uint64_t aCellId) { return m_mapNeighbours[aCellId]; }
 
+const std::vector<uint64_t>&
+ReadCaloCrosstalkMap::getNeighbours(uint64_t aCellId) const {
+  auto it = m_mapNeighbours.find(aCellId);
+  if (it != m_mapNeighbours.end()) {
+    return it->second;
+  }
+  static const std::vector<uint64_t> empty;
+  return empty;
+}
+
 std::vector<double>& ReadCaloCrosstalkMap::getCrosstalks(uint64_t aCellId) { return m_mapCrosstalks[aCellId]; }
+
+const std::vector<double>&
+ReadCaloCrosstalkMap::getCrosstalks(uint64_t aCellId) const {
+  auto it = m_mapCrosstalks.find(aCellId);
+  if (it != m_mapCrosstalks.end()) {
+    return it->second;
+  }
+  static const std::vector<double> empty;
+  return empty;
+}

--- a/RecCalorimeter/src/components/ReadCaloCrosstalkMap.h
+++ b/RecCalorimeter/src/components/ReadCaloCrosstalkMap.h
@@ -31,12 +31,14 @@ public:
    *   @param[in] aCellId, cellid of the cell of interest.
    *   @return vector of cellIDs, corresponding to the crosstalk neighbours.
    */
+  virtual const std::vector<uint64_t>& getNeighbours(uint64_t aCellId) const final;
   virtual std::vector<uint64_t>& getNeighbours(uint64_t aCellId) final;
 
   /** Function to be called for the crosstalk coefficients between the input cell and its neighbouring cells.
    *   @param[in] aCellId, cellid of the cell of interest.
    *   @return vector of crosstalk coefficients.
    */
+  virtual const std::vector<double>& getCrosstalks(uint64_t aCellId) const final;
   virtual std::vector<double>& getCrosstalks(uint64_t aCellId) final;
 
 private:


### PR DESCRIPTION
We want to make the methods of ICaloReadCrosstalkMap const, for thread-safety and general cleanliness.
Here, we add change ReadCaloCrosstalkMap::getNeighbours and getCrosstalks to be const.
However, for now (until the interface class is changed) we also retain the non-const overloads.

BEGINRELEASENOTES
- Add const versions of interfaces to ReadCaloCrosstalkMap.
ENDRELEASENOTES
