### PR TITLE
Reduce the output size when running ALLEGRO_o1_v03_digi_reco

### DIFF
--- a/RecFCCeeCalorimeter/tests/options/ALLEGRO_o1_v03_digi_reco.py
+++ b/RecFCCeeCalorimeter/tests/options/ALLEGRO_o1_v03_digi_reco.py
@@ -849,7 +849,7 @@ createTruthLinks = CreateTruthLinks("CreateTruthLinks",
                                     mcparticles="MCParticles",
                                     cell_mcparticle_links="CaloHitMCParticleLinks",
                                     cluster_mcparticle_links="ClusterMCParticleLinks",
-                                    OutputLevel=DEBUG)
+                                    OutputLevel=INFO)
 TopAlg += [createTruthLinks]
 
 


### PR DESCRIPTION
BEGINRELEASENOTES
- Reduce the output size when running ALLEGRO_o1_v03_digi_reco

ENDRELEASENOTES

The output of this test is currently 261 MB, which makes it hard to display if it fails on CI. After this change it is 6.7 MB.