### PR TITLE
Making methods of ICellPositionsTool const.

### DIFF
--- a/RecFCCeeCalorimeter/src/components/CellPositionsECalBarrelModuleThetaSegTool.cpp
+++ b/RecFCCeeCalorimeter/src/components/CellPositionsECalBarrelModuleThetaSegTool.cpp
@@ -49,7 +49,7 @@ StatusCode CellPositionsECalBarrelModuleThetaSegTool::initialize() {
 }
 
 void CellPositionsECalBarrelModuleThetaSegTool::getPositions(const edm4hep::CalorimeterHitCollection& aCells,
-                                                             edm4hep::CalorimeterHitCollection& outputColl) {
+                                                             edm4hep::CalorimeterHitCollection& outputColl) const {
 
   debug() << "Input collection size : " << aCells.size() << endmsg;
 
@@ -94,7 +94,7 @@ dd4hep::Position CellPositionsECalBarrelModuleThetaSegTool::xyzPosition(const ui
   return outSeg;
 }
 
-int CellPositionsECalBarrelModuleThetaSegTool::layerId(const uint64_t& aCellId) {
+int CellPositionsECalBarrelModuleThetaSegTool::layerId(const uint64_t& aCellId) const {
   return m_segmentation->layer(aCellId);
 }
 

--- a/RecFCCeeCalorimeter/src/components/CellPositionsECalBarrelModuleThetaSegTool.h
+++ b/RecFCCeeCalorimeter/src/components/CellPositionsECalBarrelModuleThetaSegTool.h
@@ -48,11 +48,16 @@ public:
   virtual StatusCode finalize() final;
 
   virtual void getPositions(const edm4hep::CalorimeterHitCollection& aCells,
-                            edm4hep::CalorimeterHitCollection& outputColl) final;
+                            edm4hep::CalorimeterHitCollection& outputColl) const final;
+  virtual void getPositions(const edm4hep::CalorimeterHitCollection& aCells,
+                            edm4hep::CalorimeterHitCollection& outputColl) final
+  { const auto* cthis = this;  cthis->getPositions(aCells, outputColl); }
 
   virtual dd4hep::Position xyzPosition(const uint64_t& aCellId) const final;
 
-  virtual int layerId(const uint64_t& aCellId) final;
+  virtual int layerId(const uint64_t& aCellId) const final;
+  virtual int layerId(const uint64_t& aCellId) final
+  { const auto* cthis = this;  return cthis->layerId(aCellId); }
 
 private:
   /// Pointer to the geometry service

--- a/RecFCCeeCalorimeter/src/components/CellPositionsECalBarrelPhiThetaSegTool.cpp
+++ b/RecFCCeeCalorimeter/src/components/CellPositionsECalBarrelPhiThetaSegTool.cpp
@@ -44,7 +44,7 @@ StatusCode CellPositionsECalBarrelPhiThetaSegTool::initialize() {
 }
 
 void CellPositionsECalBarrelPhiThetaSegTool::getPositions(const edm4hep::CalorimeterHitCollection& aCells,
-                                                          edm4hep::CalorimeterHitCollection& outputColl) {
+                                                          edm4hep::CalorimeterHitCollection& outputColl) const {
 
   debug() << "Input collection size : " << aCells.size() << endmsg;
   // Loop through cell collection
@@ -89,7 +89,7 @@ dd4hep::Position CellPositionsECalBarrelPhiThetaSegTool::xyzPosition(const uint6
   return outSeg;
 }
 
-int CellPositionsECalBarrelPhiThetaSegTool::layerId(const uint64_t& aCellId) {
+int CellPositionsECalBarrelPhiThetaSegTool::layerId(const uint64_t& aCellId) const {
   int layer;
   dd4hep::DDSegmentation::CellID cID = aCellId;
   layer = m_decoder->get(cID, "layer");

--- a/RecFCCeeCalorimeter/src/components/CellPositionsECalBarrelPhiThetaSegTool.h
+++ b/RecFCCeeCalorimeter/src/components/CellPositionsECalBarrelPhiThetaSegTool.h
@@ -46,11 +46,16 @@ public:
   virtual StatusCode finalize() final;
 
   virtual void getPositions(const edm4hep::CalorimeterHitCollection& aCells,
-                            edm4hep::CalorimeterHitCollection& outputColl) final;
+                            edm4hep::CalorimeterHitCollection& outputColl) const final;
+  virtual void getPositions(const edm4hep::CalorimeterHitCollection& aCells,
+                            edm4hep::CalorimeterHitCollection& outputColl) final
+  { const auto* cthis = this;  cthis->getPositions(aCells, outputColl); }
 
   virtual dd4hep::Position xyzPosition(const uint64_t& aCellId) const final;
 
-  virtual int layerId(const uint64_t& aCellId) final;
+  virtual int layerId(const uint64_t& aCellId) const final;
+  virtual int layerId(const uint64_t& aCellId) final
+  { const auto* cthis = this;  return cthis->layerId(aCellId); }
 
 private:
   /// Pointer to the geometry service

--- a/RecFCCeeCalorimeter/src/components/CellPositionsECalEndcapTurbineSegTool.cpp
+++ b/RecFCCeeCalorimeter/src/components/CellPositionsECalEndcapTurbineSegTool.cpp
@@ -52,7 +52,7 @@ StatusCode CellPositionsECalEndcapTurbineSegTool::initialize() {
 }
 
 void CellPositionsECalEndcapTurbineSegTool::getPositions(const edm4hep::CalorimeterHitCollection& aCells,
-                                                         edm4hep::CalorimeterHitCollection& outputColl) {
+                                                         edm4hep::CalorimeterHitCollection& outputColl) const {
 
   debug() << "Input collection size : " << aCells.size() << endmsg;
 
@@ -118,7 +118,7 @@ dd4hep::Position CellPositionsECalEndcapTurbineSegTool::xyzPosition(const uint64
   return outSeg;
 }
 
-int CellPositionsECalEndcapTurbineSegTool::layerId(const uint64_t& aCellId) {
+int CellPositionsECalEndcapTurbineSegTool::layerId(const uint64_t& aCellId) const {
   int layer;
   dd4hep::DDSegmentation::CellID cID = aCellId;
   layer = m_decoder->get(cID, "layer");

--- a/RecFCCeeCalorimeter/src/components/CellPositionsECalEndcapTurbineSegTool.h
+++ b/RecFCCeeCalorimeter/src/components/CellPositionsECalEndcapTurbineSegTool.h
@@ -48,11 +48,16 @@ public:
   virtual StatusCode finalize() final;
 
   virtual void getPositions(const edm4hep::CalorimeterHitCollection& aCells,
-                            edm4hep::CalorimeterHitCollection& outputColl) final;
+                            edm4hep::CalorimeterHitCollection& outputColl) const final;
+  virtual void getPositions(const edm4hep::CalorimeterHitCollection& aCells,
+                            edm4hep::CalorimeterHitCollection& outputColl) final
+  { const auto* cthis = this;  cthis->getPositions(aCells, outputColl); }
 
   virtual dd4hep::Position xyzPosition(const uint64_t& aCellId) const final;
 
-  virtual int layerId(const uint64_t& aCellId) final;
+  virtual int layerId(const uint64_t& aCellId) const final;
+  virtual int layerId(const uint64_t& aCellId) final
+  { const auto* cthis = this;  return cthis->layerId(aCellId); }
 
 private:
   /// Pointer to the geometry service

--- a/RecFCCeeCalorimeter/src/components/CellPositionsHCalPhiThetaSegTool.cpp
+++ b/RecFCCeeCalorimeter/src/components/CellPositionsHCalPhiThetaSegTool.cpp
@@ -117,7 +117,7 @@ StatusCode CellPositionsHCalPhiThetaSegTool::initialize() {
 }
 
 void CellPositionsHCalPhiThetaSegTool::getPositions(const edm4hep::CalorimeterHitCollection& aCells,
-                                                    edm4hep::CalorimeterHitCollection& outputColl) {
+                                                    edm4hep::CalorimeterHitCollection& outputColl) const {
   debug() << "Input collection size : " << aCells.size() << endmsg;
   // Loop through cell collection
   for (const auto& cell : aCells) {
@@ -177,7 +177,7 @@ dd4hep::Position CellPositionsHCalPhiThetaSegTool::xyzPosition(const uint64_t& a
   return outSeg;
 }
 
-int CellPositionsHCalPhiThetaSegTool::layerId(const uint64_t& aCellId) {
+int CellPositionsHCalPhiThetaSegTool::layerId(const uint64_t& aCellId) const {
   int layer;
   layer = m_decoder->get(aCellId, "layer");
   return layer;

--- a/RecFCCeeCalorimeter/src/components/CellPositionsHCalPhiThetaSegTool.h
+++ b/RecFCCeeCalorimeter/src/components/CellPositionsHCalPhiThetaSegTool.h
@@ -56,11 +56,16 @@ public:
   virtual StatusCode finalize() final;
 
   virtual void getPositions(const edm4hep::CalorimeterHitCollection& aCells,
-                            edm4hep::CalorimeterHitCollection& outputColl) final;
+                            edm4hep::CalorimeterHitCollection& outputColl) const final;
+  virtual void getPositions(const edm4hep::CalorimeterHitCollection& aCells,
+                            edm4hep::CalorimeterHitCollection& outputColl) final
+  { const auto* cthis = this;  cthis->getPositions(aCells, outputColl); }
 
   virtual dd4hep::Position xyzPosition(const uint64_t& aCellId) const final;
 
-  virtual int layerId(const uint64_t& aCellId) final;
+  virtual int layerId(const uint64_t& aCellId) const final;
+  virtual int layerId(const uint64_t& aCellId) final
+  { const auto* cthis = this;  return cthis->layerId(aCellId); }
 
   virtual std::vector<double> calculateLayerRadii(unsigned int startIndex, unsigned int endIndex);
 

--- a/RecFCCeeCalorimeter/src/components/CellPositionsSimpleCylinderPhiThetaSegTool.cpp
+++ b/RecFCCeeCalorimeter/src/components/CellPositionsSimpleCylinderPhiThetaSegTool.cpp
@@ -94,7 +94,7 @@ StatusCode CellPositionsSimpleCylinderPhiThetaSegTool::initialize() {
 }
 
 void CellPositionsSimpleCylinderPhiThetaSegTool::getPositions(const edm4hep::CalorimeterHitCollection& aCells,
-                                                              edm4hep::CalorimeterHitCollection& outputColl) {
+                                                              edm4hep::CalorimeterHitCollection& outputColl) const {
 
   debug() << "Input collection size : " << aCells.size() << endmsg;
   // Loop through cell collection
@@ -144,7 +144,7 @@ dd4hep::Position CellPositionsSimpleCylinderPhiThetaSegTool::xyzPosition(const u
   return outSeg;
 }
 
-int CellPositionsSimpleCylinderPhiThetaSegTool::layerId(const uint64_t& aCellId) {
+int CellPositionsSimpleCylinderPhiThetaSegTool::layerId(const uint64_t& aCellId) const {
   int layer;
   dd4hep::DDSegmentation::CellID cID = aCellId;
   layer = m_decoder->get(cID, "layer");

--- a/RecFCCeeCalorimeter/src/components/CellPositionsSimpleCylinderPhiThetaSegTool.h
+++ b/RecFCCeeCalorimeter/src/components/CellPositionsSimpleCylinderPhiThetaSegTool.h
@@ -47,11 +47,16 @@ public:
   virtual StatusCode finalize() final;
 
   virtual void getPositions(const edm4hep::CalorimeterHitCollection& aCells,
-                            edm4hep::CalorimeterHitCollection& outputColl) final;
+                            edm4hep::CalorimeterHitCollection& outputColl) const final;
+  virtual void getPositions(const edm4hep::CalorimeterHitCollection& aCells,
+                            edm4hep::CalorimeterHitCollection& outputColl) final
+  { const auto* cthis = this;  cthis->getPositions(aCells, outputColl); }
 
   virtual dd4hep::Position xyzPosition(const uint64_t& aCellId) const final;
 
-  virtual int layerId(const uint64_t& aCellId) final;
+  virtual int layerId(const uint64_t& aCellId) const final;
+  virtual int layerId(const uint64_t& aCellId) final
+  { const auto* cthis = this;  return cthis->layerId(aCellId); }
 
 private:
   /// Pointer to the geometry service

--- a/RecFCChhCalorimeter/src/components/CellPositionsCaloDiscsTool.cpp
+++ b/RecFCChhCalorimeter/src/components/CellPositionsCaloDiscsTool.cpp
@@ -42,7 +42,7 @@ StatusCode CellPositionsCaloDiscsTool::initialize() {
 }
 
 void CellPositionsCaloDiscsTool::getPositions(const edm4hep::CalorimeterHitCollection& aCells,
-                                              edm4hep::CalorimeterHitCollection& outputColl) {
+                                              edm4hep::CalorimeterHitCollection& outputColl) const {
   debug() << "Input collection size : " << aCells.size() << endmsg;
   // Loop through cell collection
   for (const auto& cell : aCells) {
@@ -87,7 +87,7 @@ dd4hep::Position CellPositionsCaloDiscsTool::xyzPosition(const uint64_t& aCellId
   return outPos;
 }
 
-int CellPositionsCaloDiscsTool::layerId(const uint64_t& aCellId) {
+int CellPositionsCaloDiscsTool::layerId(const uint64_t& aCellId) const {
   int layer;
   dd4hep::DDSegmentation::CellID cID = aCellId;
   layer = m_decoder->get(cID, "layer");

--- a/RecFCChhCalorimeter/src/components/CellPositionsCaloDiscsTool.h
+++ b/RecFCChhCalorimeter/src/components/CellPositionsCaloDiscsTool.h
@@ -47,11 +47,16 @@ public:
   virtual StatusCode finalize() final;
 
   virtual void getPositions(const edm4hep::CalorimeterHitCollection& aCells,
-                            edm4hep::CalorimeterHitCollection& outputColl) final;
+                            edm4hep::CalorimeterHitCollection& outputColl) const final;
+  virtual void getPositions(const edm4hep::CalorimeterHitCollection& aCells,
+                            edm4hep::CalorimeterHitCollection& outputColl) final
+  { const auto* cthis = this;  cthis->getPositions(aCells, outputColl); }
 
   virtual dd4hep::Position xyzPosition(const uint64_t& aCellId) const final;
 
-  virtual int layerId(const uint64_t& aCellId) final;
+  virtual int layerId(const uint64_t& aCellId) const final;
+  virtual int layerId(const uint64_t& aCellId) final
+  { const auto* cthis = this;  return cthis->layerId(aCellId); }
 
 private:
   /// Pointer to the geometry service

--- a/RecFCChhCalorimeter/src/components/CellPositionsDummyTool.cpp
+++ b/RecFCChhCalorimeter/src/components/CellPositionsDummyTool.cpp
@@ -23,7 +23,7 @@ StatusCode CellPositionsDummyTool::initialize() {
 }
 
 void CellPositionsDummyTool::getPositions(const edm4hep::CalorimeterHitCollection& aCells,
-                                          edm4hep::CalorimeterHitCollection& outputColl) {
+                                          edm4hep::CalorimeterHitCollection& outputColl) const {
   debug() << "Input collection size : " << aCells.size() << endmsg;
   // Loop through cell collection
   for (const auto& cell : aCells) {
@@ -51,7 +51,7 @@ dd4hep::Position CellPositionsDummyTool::xyzPosition(const uint64_t& /*aCellId*/
   return outPos;
 }
 
-int CellPositionsDummyTool::layerId(const uint64_t& /*aCellId*/) {
+int CellPositionsDummyTool::layerId(const uint64_t& /*aCellId*/) const {
   int layer = 0;
   return layer;
 }

--- a/RecFCChhCalorimeter/src/components/CellPositionsDummyTool.h
+++ b/RecFCChhCalorimeter/src/components/CellPositionsDummyTool.h
@@ -32,11 +32,16 @@ public:
   virtual StatusCode finalize() final;
 
   virtual void getPositions(const edm4hep::CalorimeterHitCollection& aCells,
-                            edm4hep::CalorimeterHitCollection& outputColl) final;
+                            edm4hep::CalorimeterHitCollection& outputColl) const final;
+  virtual void getPositions(const edm4hep::CalorimeterHitCollection& aCells,
+                            edm4hep::CalorimeterHitCollection& outputColl) final
+  { const auto* cthis = this;  cthis->getPositions(aCells, outputColl); }
 
   virtual dd4hep::Position xyzPosition(const uint64_t& aCellId) const final;
 
-  virtual int layerId(const uint64_t& aCellId) final;
+  virtual int layerId(const uint64_t& aCellId) const final;
+  virtual int layerId(const uint64_t& aCellId) final
+  { const auto* cthis = this;  return cthis->layerId(aCellId); }
 
 private:
   /// Pointer to the geometry service

--- a/RecFCChhCalorimeter/src/components/CellPositionsECalBarrelTool.cpp
+++ b/RecFCChhCalorimeter/src/components/CellPositionsECalBarrelTool.cpp
@@ -43,7 +43,7 @@ StatusCode CellPositionsECalBarrelTool::initialize() {
 }
 
 void CellPositionsECalBarrelTool::getPositions(const edm4hep::CalorimeterHitCollection& aCells,
-                                               edm4hep::CalorimeterHitCollection& outputColl) {
+                                               edm4hep::CalorimeterHitCollection& outputColl) const {
 
   debug() << "Input collection size : " << aCells.size() << endmsg;
   // Loop through cell collection
@@ -88,7 +88,7 @@ dd4hep::Position CellPositionsECalBarrelTool::xyzPosition(const uint64_t& aCellI
   return outSeg;
 }
 
-int CellPositionsECalBarrelTool::layerId(const uint64_t& aCellId) {
+int CellPositionsECalBarrelTool::layerId(const uint64_t& aCellId) const {
   int layer;
   dd4hep::DDSegmentation::CellID cID = aCellId;
   layer = m_decoder->get(cID, "layer");

--- a/RecFCChhCalorimeter/src/components/CellPositionsECalBarrelTool.h
+++ b/RecFCChhCalorimeter/src/components/CellPositionsECalBarrelTool.h
@@ -45,11 +45,16 @@ public:
   virtual StatusCode finalize() final;
 
   virtual void getPositions(const edm4hep::CalorimeterHitCollection& aCells,
-                            edm4hep::CalorimeterHitCollection& outputColl) final;
+                            edm4hep::CalorimeterHitCollection& outputColl) const final;
+  virtual void getPositions(const edm4hep::CalorimeterHitCollection& aCells,
+                            edm4hep::CalorimeterHitCollection& outputColl) final
+  { const auto* cthis = this;  cthis->getPositions(aCells, outputColl); }
 
   virtual dd4hep::Position xyzPosition(const uint64_t& aCellId) const final;
 
-  virtual int layerId(const uint64_t& aCellId) final;
+  virtual int layerId(const uint64_t& aCellId) const final;
+  virtual int layerId(const uint64_t& aCellId) final
+  { const auto* cthis = this;  return cthis->layerId(aCellId); }
 
 private:
   /// Pointer to the geometry service

--- a/RecFCChhCalorimeter/src/components/CellPositionsHCalBarrelNoSegTool.cpp
+++ b/RecFCChhCalorimeter/src/components/CellPositionsHCalBarrelNoSegTool.cpp
@@ -42,7 +42,7 @@ StatusCode CellPositionsHCalBarrelNoSegTool::initialize() {
 }
 
 void CellPositionsHCalBarrelNoSegTool::getPositions(const edm4hep::CalorimeterHitCollection& aCells,
-                                                    edm4hep::CalorimeterHitCollection& outputColl) {
+                                                    edm4hep::CalorimeterHitCollection& outputColl) const {
   debug() << "Input collection size : " << aCells.size() << endmsg;
   // Loop through cell collection
   for (const auto& cell : aCells) {
@@ -91,7 +91,7 @@ dd4hep::Position CellPositionsHCalBarrelNoSegTool::xyzPosition(const uint64_t& a
   return outSeg;
 }
 
-int CellPositionsHCalBarrelNoSegTool::layerId(const uint64_t& aCellId) {
+int CellPositionsHCalBarrelNoSegTool::layerId(const uint64_t& aCellId) const {
   int layer;
   dd4hep::DDSegmentation::CellID cID = aCellId;
   layer = m_decoder->get(cID, "layer");

--- a/RecFCChhCalorimeter/src/components/CellPositionsHCalBarrelNoSegTool.h
+++ b/RecFCChhCalorimeter/src/components/CellPositionsHCalBarrelNoSegTool.h
@@ -45,11 +45,16 @@ public:
   virtual StatusCode finalize() final;
 
   virtual void getPositions(const edm4hep::CalorimeterHitCollection& aCells,
-                            edm4hep::CalorimeterHitCollection& outputColl) final;
+                            edm4hep::CalorimeterHitCollection& outputColl) const final;
+  virtual void getPositions(const edm4hep::CalorimeterHitCollection& aCells,
+                            edm4hep::CalorimeterHitCollection& outputColl) final
+  { const auto* cthis = this;  cthis->getPositions(aCells, outputColl); }
 
   virtual dd4hep::Position xyzPosition(const uint64_t& aCellId) const final;
 
-  virtual int layerId(const uint64_t& aCellId) final;
+  virtual int layerId(const uint64_t& aCellId) const final;
+  virtual int layerId(const uint64_t& aCellId) final
+  { const auto* cthis = this;  return cthis->layerId(aCellId); }
 
 private:
   /// Pointer to the geometry service

--- a/RecFCChhCalorimeter/src/components/CellPositionsHCalBarrelPhiSegTool.cpp
+++ b/RecFCChhCalorimeter/src/components/CellPositionsHCalBarrelPhiSegTool.cpp
@@ -41,7 +41,7 @@ StatusCode CellPositionsHCalBarrelPhiSegTool::initialize() {
 }
 
 void CellPositionsHCalBarrelPhiSegTool::getPositions(const edm4hep::CalorimeterHitCollection& aCells,
-                                                     edm4hep::CalorimeterHitCollection& outputColl) {
+                                                     edm4hep::CalorimeterHitCollection& outputColl) const {
   debug() << "Input collection size : " << aCells.size() << endmsg;
   // Loop through cell collection
   for (const auto& cell : aCells) {
@@ -86,7 +86,7 @@ dd4hep::Position CellPositionsHCalBarrelPhiSegTool::xyzPosition(const uint64_t& 
   return outSeg;
 }
 
-int CellPositionsHCalBarrelPhiSegTool::layerId(const uint64_t& aCellId) {
+int CellPositionsHCalBarrelPhiSegTool::layerId(const uint64_t& aCellId) const {
   int layer;
   dd4hep::DDSegmentation::CellID cID = aCellId;
   layer = m_decoder->get(cID, "layer");

--- a/RecFCChhCalorimeter/src/components/CellPositionsHCalBarrelPhiSegTool.h
+++ b/RecFCChhCalorimeter/src/components/CellPositionsHCalBarrelPhiSegTool.h
@@ -45,11 +45,16 @@ public:
   virtual StatusCode finalize() final;
 
   virtual void getPositions(const edm4hep::CalorimeterHitCollection& aCells,
-                            edm4hep::CalorimeterHitCollection& outputColl) final;
+                            edm4hep::CalorimeterHitCollection& outputColl) const final;
+  virtual void getPositions(const edm4hep::CalorimeterHitCollection& aCells,
+                            edm4hep::CalorimeterHitCollection& outputColl) final
+  { const auto* cthis = this;  cthis->getPositions(aCells, outputColl); }
 
   virtual dd4hep::Position xyzPosition(const uint64_t& aCellId) const final;
 
-  virtual int layerId(const uint64_t& aCellId) final;
+  virtual int layerId(const uint64_t& aCellId) const final;
+  virtual int layerId(const uint64_t& aCellId) final
+  { const auto* cthis = this;  return cthis->layerId(aCellId); }
 
 private:
   /// Pointer to the geometry service

--- a/RecFCChhCalorimeter/src/components/CellPositionsHCalBarrelTool.cpp
+++ b/RecFCChhCalorimeter/src/components/CellPositionsHCalBarrelTool.cpp
@@ -42,7 +42,7 @@ StatusCode CellPositionsHCalBarrelTool::initialize() {
 }
 
 void CellPositionsHCalBarrelTool::getPositions(const edm4hep::CalorimeterHitCollection& aCells,
-                                               edm4hep::CalorimeterHitCollection& outputColl) {
+                                               edm4hep::CalorimeterHitCollection& outputColl) const {
   debug() << "Input collection size : " << aCells.size() << endmsg;
   // Loop through cell collection
   for (const auto& cell : aCells) {
@@ -81,7 +81,7 @@ dd4hep::Position CellPositionsHCalBarrelTool::xyzPosition(const uint64_t& aCellI
   return outSeg;
 }
 
-int CellPositionsHCalBarrelTool::layerId(const uint64_t& aCellId) {
+int CellPositionsHCalBarrelTool::layerId(const uint64_t& aCellId) const {
   int layer;
   layer = m_decoder->get(aCellId, "layer");
   return layer;

--- a/RecFCChhCalorimeter/src/components/CellPositionsHCalBarrelTool.h
+++ b/RecFCChhCalorimeter/src/components/CellPositionsHCalBarrelTool.h
@@ -39,11 +39,16 @@ public:
   virtual StatusCode finalize() final;
 
   virtual void getPositions(const edm4hep::CalorimeterHitCollection& aCells,
-                            edm4hep::CalorimeterHitCollection& outputColl) final;
+                            edm4hep::CalorimeterHitCollection& outputColl) const final;
+  virtual void getPositions(const edm4hep::CalorimeterHitCollection& aCells,
+                            edm4hep::CalorimeterHitCollection& outputColl) final
+  { const auto* cthis = this;  cthis->getPositions(aCells, outputColl); }
 
   virtual dd4hep::Position xyzPosition(const uint64_t& aCellId) const final;
 
-  virtual int layerId(const uint64_t& aCellId) final;
+  virtual int layerId(const uint64_t& aCellId) const final;
+  virtual int layerId(const uint64_t& aCellId) final
+  { const auto* cthis = this;  return cthis->layerId(aCellId); }
 
 private:
   /// Pointer to the geometry service

--- a/RecFCChhCalorimeter/src/components/CellPositionsTailCatcherTool.cpp
+++ b/RecFCChhCalorimeter/src/components/CellPositionsTailCatcherTool.cpp
@@ -42,7 +42,7 @@ StatusCode CellPositionsTailCatcherTool::initialize() {
 }
 
 void CellPositionsTailCatcherTool::getPositions(const edm4hep::CalorimeterHitCollection& aCells,
-                                                edm4hep::CalorimeterHitCollection& outputColl) {
+                                                edm4hep::CalorimeterHitCollection& outputColl) const {
   debug() << "Input collection size : " << aCells.size() << endmsg;
   // Loop through cell collection
   for (const auto& cell : aCells) {
@@ -93,6 +93,6 @@ dd4hep::Position CellPositionsTailCatcherTool::xyzPosition(const uint64_t& aCell
   return outSeg;
 }
 
-int CellPositionsTailCatcherTool::layerId(const uint64_t& /*aCellId*/) { return 0; }
+int CellPositionsTailCatcherTool::layerId(const uint64_t& /*aCellId*/) const { return 0; }
 
 StatusCode CellPositionsTailCatcherTool::finalize() { return AlgTool::finalize(); }

--- a/RecFCChhCalorimeter/src/components/CellPositionsTailCatcherTool.h
+++ b/RecFCChhCalorimeter/src/components/CellPositionsTailCatcherTool.h
@@ -45,11 +45,16 @@ public:
   virtual StatusCode finalize() final;
 
   virtual void getPositions(const edm4hep::CalorimeterHitCollection& aCells,
-                            edm4hep::CalorimeterHitCollection& outputColl) final;
+                            edm4hep::CalorimeterHitCollection& outputColl) const final;
+  virtual void getPositions(const edm4hep::CalorimeterHitCollection& aCells,
+                            edm4hep::CalorimeterHitCollection& outputColl) final
+  { const auto* cthis = this;  cthis->getPositions(aCells, outputColl); }
 
   virtual dd4hep::Position xyzPosition(const uint64_t& aCellId) const final;
 
-  virtual int layerId(const uint64_t& aCellId) final;
+  virtual int layerId(const uint64_t& aCellId) const final;
+  virtual int layerId(const uint64_t& aCellId) final
+  { const auto* cthis = this;  return cthis->layerId(aCellId); }
 
 private:
   /// Pointer to the geometry service


### PR DESCRIPTION
Make ICellPositionsTool::getPositions and layerId const. For now (until the interface class is changed) we retain the non-const overloads and have them call the const versions.



BEGINRELEASENOTES
- First step to make interfaces of ICellPositionsTool const.
ENDRELEASENOTES
