### PR TITLE
Making methods of ICalibrateCaloHitsTool const.

### DIFF
--- a/RecCalorimeter/src/components/CalibrateCaloHitsTool.cpp
+++ b/RecCalorimeter/src/components/CalibrateCaloHitsTool.cpp
@@ -16,7 +16,7 @@ StatusCode CalibrateCaloHitsTool::initialize() {
   return sc;
 }
 
-void CalibrateCaloHitsTool::calibrate(std::unordered_map<uint64_t, double>& aHits) {
+void CalibrateCaloHitsTool::calibrate(std::unordered_map<uint64_t, double>& aHits) const {
   // Loop through energy deposits, multiply energy to get cell energy at electromagnetic scale
   std::for_each(aHits.begin(), aHits.end(),
                 [this](std::pair<const uint64_t, double>& p) { p.second *= m_invSamplingFraction; });

--- a/RecCalorimeter/src/components/CalibrateCaloHitsTool.h
+++ b/RecCalorimeter/src/components/CalibrateCaloHitsTool.h
@@ -30,7 +30,9 @@ public:
 
   /** @brief  Calibrate Geant4 hit energy to EM scale
    */
-  virtual void calibrate(std::unordered_map<uint64_t, double>& aHits) final;
+  virtual void calibrate(std::unordered_map<uint64_t, double>& aHits) const final;
+  virtual void calibrate(std::unordered_map<uint64_t, double>& aHits) final
+  { const auto* cthis = this;  cthis->calibrate(aHits); }
 
 private:
   /// Value of 1/sampling fraction

--- a/RecCalorimeter/src/components/CalibrateInLayersTool.cpp
+++ b/RecCalorimeter/src/components/CalibrateInLayersTool.cpp
@@ -26,7 +26,7 @@ StatusCode CalibrateInLayersTool::initialize() {
   return StatusCode::SUCCESS;
 }
 
-void CalibrateInLayersTool::calibrate(std::unordered_map<uint64_t, double>& aHits) {
+void CalibrateInLayersTool::calibrate(std::unordered_map<uint64_t, double>& aHits) const {
   auto decoder = m_geoSvc->getDetector()->readout(m_readoutName).idSpec().decoder();
   // Loop through energy deposits, multiply energy to get cell energy at electromagnetic scale
   std::for_each(aHits.begin(), aHits.end(), [this, decoder](std::pair<const uint64_t, double>& p) {

--- a/RecCalorimeter/src/components/CalibrateInLayersTool.h
+++ b/RecCalorimeter/src/components/CalibrateInLayersTool.h
@@ -41,7 +41,9 @@ public:
 
   /** @brief  Calibrate Geant4 hit energy to EM scale
    */
-  virtual void calibrate(std::unordered_map<uint64_t, double>& aHits) final;
+  virtual void calibrate(std::unordered_map<uint64_t, double>& aHits) const final;
+  virtual void calibrate(std::unordered_map<uint64_t, double>& aHits) final
+  { const auto* cthis = this;  cthis->calibrate(aHits); }
 
 private:
   /// Pointer to the geometry service


### PR DESCRIPTION
Make ICalibrateCaloHitsTool::calibrate const.
For now (until the interface class is changed) we retain the non-const overloads and have them call the const versions.

BEGINRELEASENOTES
- First step to make interfaces of ICalibrateCaloHitsTool const.
ENDRELEASENOTES
