### PR TITLE
Require k4geo 0.23 in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@ find_package(Gaudi REQUIRED)
 find_package(k4FWCore 1.3.0 REQUIRED)
 find_package(EDM4HEP REQUIRED) # implicit: Podio
 find_package(DD4hep REQUIRED)
-find_package(k4geo REQUIRED)
+find_package(k4geo 0.23 REQUIRED)
 find_package(FastJet REQUIRED)
 find_package(sipm REQUIRED)
 # New versions of ONNRuntime package provide onnxruntime-Config.cmake


### PR DESCRIPTION
BEGINRELEASENOTES
- Require k4geo 0.23 in CMakeLists.txt because of `SimulateSiPMwithEdep.cpp` that needs the member `sipmPosition` from `d4hep::DDSegmentation::GridDRcalo_k4geo`

ENDRELEASENOTES