### PR TITLE
cleanup and fix bugs in ecal barrel<->endcap neighbour code

### DIFF
--- a/RecFCCeeCalorimeter/scripts/draw_functions.py
+++ b/RecFCCeeCalorimeter/scripts/draw_functions.py
@@ -197,10 +197,9 @@ def prepare_double_canvas(name, title, factor = 1):
 
 def prepare_divided_canvas(name, title, N):
    c = TCanvas(name, title, 1200, 900)
-   print N
    c.Divide(int(ceil(sqrt(N))), int(ceil(N / ceil(sqrt(N)))))
-   print("=====> Dividing canvas into : ",N, sqrt(N),ceil(sqrt(N)), N / ceil(sqrt(N)), ceil(N / ceil(sqrt(N))))
-   print("=====> Dividing canvas into : ",ceil(sqrt(N)), ceil(N / ceil(sqrt(N))) )
+   print("=====> N : ", N)
+   print("=====> Dividing canvas into : ", int(ceil(sqrt(N))), int(ceil(N / ceil(sqrt(N)))) )
    for ipad in range(1, N+1):
       pad = c.cd(ipad)
       pad.SetTopMargin(0.01)

--- a/RecFCCeeCalorimeter/src/components/CreateFCCeeCaloNeighbours.cpp
+++ b/RecFCCeeCalorimeter/src/components/CreateFCCeeCaloNeighbours.cpp
@@ -1785,10 +1785,11 @@ StatusCode CreateFCCeeCaloNeighbours::initialize_lookups() {
       unsigned numECCellsRho = ecalEndcapTurbineSegmentation->numCellsRho(iWheel);
       info() << "wheel = " << iWheel << ", modules = " << numECModules << ", rho cells = " << numECCellsRho << endmsg;
 
-      // GM: dont think this is actually needed
+      // GM: dont think this is actually needed since we do push_back later..
       m_EMEC_h_module_vs_phi_pos.reserve(numECCellsRho);
       m_EMEC_h_module_vs_phi_neg.reserve(numECCellsRho);
 
+      // unused vectors
       //m_EMEC_pos_phi_lookup.reserve(numECCellsRho);
       //m_EMEC_neg_phi_lookup.reserve(numECCellsRho);
 
@@ -1823,7 +1824,7 @@ StatusCode CreateFCCeeCaloNeighbours::initialize_lookups() {
             h_pos = new TH1F(histname_pos.c_str(), histname_pos.c_str(), numECModules, -TMath::Pi(), TMath::Pi());
             m_EMEC_h_module_vs_phi_pos.push_back(h_pos);
           }
-          for (unsigned iECmodule = 0; iECmodule < numECModules; iECmodule++) {
+          for (unsigned int iECmodule = 0; iECmodule < numECModules; iECmodule++) {
             (*endcapDecoder)["module"].set(endcapCellId, iECmodule);
             (*endcapDecoder)["rho"].set(endcapCellId, iECrho);
             (*endcapDecoder)[m_activeFieldNamesSegmented[iSys]].set(endcapCellId, ecalEndcapTurbineSegmentation->expLayer(iWheel, iECrho, iECz));
@@ -1908,6 +1909,7 @@ StatusCode CreateFCCeeCaloNeighbours::initialize_lookups() {
 
 StatusCode CreateFCCeeCaloNeighbours::finalize() {
     // for debug, to be removed
+    /*
     TFile* f=new TFile("lookup.root", "RECREATE");
     for (unsigned int i=0; i<m_EMB_h_module_vs_phi.size(); i++) {
         m_EMB_h_module_vs_phi[i]->Write();
@@ -1935,6 +1937,8 @@ StatusCode CreateFCCeeCaloNeighbours::finalize() {
         std::cout << m_EMEC_theta_lookup[i] << " ";
     }
     std::cout << std::endl;
+    */
+    
     /*
     std::cout << "m_EMEC_pos_phi_lookup" << std::endl;
     for (unsigned int i=0; i<m_EMEC_pos_phi_lookup.size(); i++) {

--- a/RecFCCeeCalorimeter/src/components/CreateFCCeeCaloNeighbours.cpp
+++ b/RecFCCeeCalorimeter/src/components/CreateFCCeeCaloNeighbours.cpp
@@ -1954,7 +1954,7 @@ StatusCode CreateFCCeeCaloNeighbours::finalize() {
         }
         std::cout << std::endl;
     }
-    */
     f->Close();
+    */
     return Service::finalize();
 }

--- a/RecFCCeeCalorimeter/src/components/CreateFCCeeCaloNeighbours.h
+++ b/RecFCCeeCalorimeter/src/components/CreateFCCeeCaloNeighbours.h
@@ -79,7 +79,6 @@ private:
   Gaudi::Property<uint> m_ecalBarrelSysId{this, "ecalBarrelSysId", 4};
   Gaudi::Property<uint> m_ecalEndcapSysId{this, "ecalEndcapSysId", 5};  
   Gaudi::Property<uint> m_hcalBarrelSysId{this, "hcalBarrelSysId", 8};
-  // System ID of HCAL endcap
   Gaudi::Property<uint> m_hcalEndcapSysId{this, "hcalEndcapSysId", 9};
 
   // For combination of barrels: flag if ECal and HCal barrels should be merged
@@ -101,7 +100,8 @@ private:
   std::string m_outputFileName;
 
   // Lookup tables/histograms for cell positions in the barrel and endcap EM
-  // calorimeters. The vectors of histograms function as lookups for the module ID  // vs phi, since each histogram has bins in phi with the content set to the
+  // calorimeters. The vectors of histograms function as lookups for the module ID
+  // vs phi, since each histogram has bins in phi with the content set to the
   // module ID associated with the phi range of that bin.  Each histogram in the
   // vector represents one layer of the barrel or one rho bin of the endcap.
   // The vectors of Float_t, on the other hand, store the central value of
@@ -117,8 +117,9 @@ private:
 
   std::vector< TH1F* > m_EMEC_h_module_vs_phi_pos;
   std::vector< TH1F* > m_EMEC_h_module_vs_phi_neg;
-  std::vector< std::vector<Float_t>> m_EMEC_pos_phi_lookup;
-  std::vector< std::vector<Float_t>> m_EMEC_neg_phi_lookup;
+  // vectors to be removed
+  // std::vector< std::vector<Float_t>> m_EMEC_pos_phi_lookup;
+  // std::vector< std::vector<Float_t>> m_EMEC_neg_phi_lookup;
   std::vector<Float_t> m_EMEC_theta_lookup;
 
   StatusCode initialize_lookups();


### PR DESCRIPTION
BEGINRELEASENOTES
- Cleanup and fix bugs in code used to link noble liquid ecal barrel and endcap calorimeter cells
ENDRELEASENOTES

* move lookup initialisation outside loop over the segmentations, so that it is called only once, removing warnings like "TROOT::Append      WARNING Replacing existing TH1: h_modulevphi_pos_0 (Potential memory leak)"
* initialise h_pos and h_neg only when iSide has the proper value (before they were created twice, for iSide=+-1, leading to similar warning (TROOT::Append      WARNING)
* remove `m_EMEC_h_module_vs_phi_pos.push_back(h_neg);`  (https://github.com/HEP-FCC/k4RecCalorimeter/blob/main/RecFCCeeCalorimeter/src/components/CreateFCCeeCaloNeighbours.cpp#L1819
* correct size of vectors initialised with reserve (`m_EMEC_h_module_vs_phi_pos`, `m_EMEC_h_module_vs_phi_neg`, `m_EMEC_pos_phi_lookup`, `m_EMEC_neg_phi_lookup`)
* comment away unused vectors (`m_EMEC_neg_phi_lookup`, `m_EMEC_pos_phi_lookup`)
