### PR TITLE
Add SiPM digitizer which uses fired cells as calohitcontributions

### DIFF
--- a/RecCalorimeter/src/components/SimulateSiPMwithContrib.cpp
+++ b/RecCalorimeter/src/components/SimulateSiPMwithContrib.cpp
@@ -5,7 +5,12 @@
 DECLARE_COMPONENT(SimulateSiPMwithContrib)
 
 SimulateSiPMwithContrib::SimulateSiPMwithContrib(const std::string& aName, ISvcLocator* aSvcLoc)
-    : Gaudi::Algorithm(aName, aSvcLoc) {}
+    : Gaudi::Algorithm(aName, aSvcLoc) {
+    
+  // Questo collega la stringa della Property al DataHandle
+  declareProperty("inputHitCollection", m_simHits, "input calo collection name");
+  declareProperty("outputHitCollection", m_digiHits, "output calo collection name");
+}
 
 StatusCode SimulateSiPMwithContrib::initialize() {
   StatusCode sc = Gaudi::Algorithm::initialize();
@@ -60,7 +65,7 @@ StatusCode SimulateSiPMwithContrib::initialize() {
 }
 
 StatusCode SimulateSiPMwithContrib::execute(const EventContext&) const {
-  const edm4hep::SimCalorimeterHitCollection* scintHits = m_scintHits.get();
+  const edm4hep::SimCalorimeterHitCollection* scintHits = m_simHits.get();
   edm4hep::CalorimeterHitCollection* digiHits = m_digiHits.createAndPut();
 
   // loop through the hits (each hit corresponds to a fiber)
@@ -89,11 +94,14 @@ StatusCode SimulateSiPMwithContrib::execute(const EventContext&) const {
 
       // get the photon arrival time at SiPM
       const double time = contrib->getTime(); // in IDEA_o2 this it the toa at SiPM in ns
-      // add scintillation decay time
-      double scintTime = time + m_rndmExp.shoot();
+      double thisTime = time;
+      // if it is a scintillation hit, add scintillation decay time
+      if (!m_isCherenkov){
+        thisTime += m_rndmExp.shoot();
+      }
 
       for (unsigned int pe=0; pe<npe; pe++){
-        vecTimes.push_back(scintTime);
+        vecTimes.push_back(thisTime);
         vecWavelens.push_back(1.);
       }
     } // contrib

--- a/RecCalorimeter/src/components/SimulateSiPMwithContrib.cpp
+++ b/RecCalorimeter/src/components/SimulateSiPMwithContrib.cpp
@@ -1,7 +1,6 @@
 #include "SimulateSiPMwithContrib.h"
 #include "DD4hep/DD4hepUnits.h"
 #include <cmath>
-#include <iostream>
 
 DECLARE_COMPONENT(SimulateSiPMwithContrib)
 
@@ -125,7 +124,6 @@ StatusCode SimulateSiPMwithContrib::execute(const EventContext&) const {
 
     // NOTE: I noticed very few digi hits have TOA > ms, clearly a bug to be investigated
     if(toa > 1e6) continue;
-    std::cout<<"integral "<<integral<<" toa "<<toa<<std::endl;
 
     auto digiHit = digiHits->create();
     digiHit.setEnergy(integral /* * m_scaleADC.value()*/); // convertition from ADC to GeV can be added here

--- a/RecCalorimeter/src/components/SimulateSiPMwithContrib.cpp
+++ b/RecCalorimeter/src/components/SimulateSiPMwithContrib.cpp
@@ -7,7 +7,7 @@ DECLARE_COMPONENT(SimulateSiPMwithContrib)
 SimulateSiPMwithContrib::SimulateSiPMwithContrib(const std::string& aName, ISvcLocator* aSvcLoc)
     : Gaudi::Algorithm(aName, aSvcLoc) {
     
-  // Questo collega la stringa della Property al DataHandle
+  // register DataHandles with hit collection names
   declareProperty("inputHitCollection", m_simHits, "input calo collection name");
   declareProperty("outputHitCollection", m_digiHits, "output calo collection name");
 }
@@ -23,11 +23,6 @@ StatusCode SimulateSiPMwithContrib::initialize() {
 
   if (!m_randSvc) {
     error() << "Couldn't get RndmGenSvc!" << endmsg;
-    return StatusCode::FAILURE;
-  }
-
-  if (m_rndmUniform.initialize(m_randSvc, Rndm::Flat(0., 1.)).isFailure()) {
-    error() << "Couldn't initialize RndmGenSvc!" << endmsg;
     return StatusCode::FAILURE;
   }
 

--- a/RecCalorimeter/src/components/SimulateSiPMwithContrib.cpp
+++ b/RecCalorimeter/src/components/SimulateSiPMwithContrib.cpp
@@ -10,6 +10,7 @@ SimulateSiPMwithContrib::SimulateSiPMwithContrib(const std::string& aName, ISvcL
   // register DataHandles with hit collection names
   declareProperty("inputHitCollection", m_simHits, "input calo collection name");
   declareProperty("outputHitCollection", m_digiHits, "output calo collection name");
+  declareProperty("outputLinkCollection", m_hitLinks, "output links collection name");
 }
 
 StatusCode SimulateSiPMwithContrib::initialize() {
@@ -44,7 +45,7 @@ StatusCode SimulateSiPMwithContrib::initialize() {
   properties.setFallTimeFast(m_falltimeFast);
   properties.setRiseTime(m_risetime);
   properties.setSnr(m_snr);
-  properties.setPdeType(sipm::SiPMProperties::PdeType::kNoPde);
+  properties.setPdeType(sipm::SiPMProperties::PdeType::kNoPde); // this forces efficiency to 1
   properties.setPdeSpectrum(m_wavelen, m_sipmEff);
 
   // set other parameters if provided
@@ -62,7 +63,8 @@ StatusCode SimulateSiPMwithContrib::initialize() {
 StatusCode SimulateSiPMwithContrib::execute(const EventContext&) const {
   const edm4hep::SimCalorimeterHitCollection* scintHits = m_simHits.get();
   edm4hep::CalorimeterHitCollection* digiHits = m_digiHits.createAndPut();
-
+  auto* links = m_hitLinks.createAndPut();
+  
   // loop through the hits (each hit corresponds to a fiber)
   for (unsigned int idx = 0; idx < scintHits->size(); idx++) {
     const auto& scintHit = scintHits->at(idx);
@@ -97,7 +99,7 @@ StatusCode SimulateSiPMwithContrib::execute(const EventContext&) const {
 
       for (unsigned int pe=0; pe<npe; pe++){
         vecTimes.push_back(thisTime);
-        vecWavelens.push_back(1.);
+        vecWavelens.push_back(1.); // photons wavelengths are dummy, we are using photo-electrons
       }
     } // contrib
 
@@ -118,12 +120,16 @@ StatusCode SimulateSiPMwithContrib::execute(const EventContext&) const {
         std::max(0., anaSignal.integral(m_gateStart, m_gateL, m_thres));           // (intStart, intGate, threshold)
     const double toa = std::max(0., anaSignal.toa(m_gateStart, m_gateL, m_thres)); // (intStart, intGate, threshold)
 
-    digiHit.setEnergy(integral/* * m_scaleADC.value()*/); // convert ADC to GeV
+    digiHit.setEnergy(integral/* * m_scaleADC.value()*/); // convertition from ADC to GeV can be added here
     digiHit.setEnergyError(/*m_scaleADC.value() **/ std::sqrt(integral));
     digiHit.setPosition(scintHit.getPosition());
     digiHit.setCellID(scintHit.getCellID());
     // Toa and m_gateStart are in ns
     digiHit.setTime(toa + m_gateStart);
+
+    auto link = links->create();
+    link.setFrom(digiHit);
+    link.setTo(scintHit);
   }
 
   return StatusCode::SUCCESS;

--- a/RecCalorimeter/src/components/SimulateSiPMwithContrib.cpp
+++ b/RecCalorimeter/src/components/SimulateSiPMwithContrib.cpp
@@ -1,6 +1,7 @@
 #include "SimulateSiPMwithContrib.h"
 #include "DD4hep/DD4hepUnits.h"
 #include <cmath>
+#include <iostream>
 
 DECLARE_COMPONENT(SimulateSiPMwithContrib)
 
@@ -45,8 +46,9 @@ StatusCode SimulateSiPMwithContrib::initialize() {
   properties.setFallTimeFast(m_falltimeFast);
   properties.setRiseTime(m_risetime);
   properties.setSnr(m_snr);
-  properties.setPdeType(sipm::SiPMProperties::PdeType::kNoPde); // this forces efficiency to 1
-  properties.setPdeSpectrum(m_wavelen, m_sipmEff);
+  properties.setPdeType(sipm::SiPMProperties::PdeType::kSimplePde); // this sets PDE to a single number
+  properties.setPde(1.0);
+  //properties.setPdeSpectrum(m_wavelen, m_sipmEff); // if you want wavelen dependency
 
   // set other parameters if provided
   for (const auto& [key, value] : m_params.value())
@@ -110,8 +112,6 @@ StatusCode SimulateSiPMwithContrib::execute(const EventContext&) const {
     m_sensor->addPhotons(vecTimes, vecWavelens); // Sets photon times & wavelengths
     m_sensor->runEvent();                        // Runs the simulation
 
-    auto digiHit = digiHits->create();
-
     // Using only analog signal (ADC conversion is still experimental)
     const sipm::SiPMAnalogSignal anaSignal = m_sensor->signal();
 
@@ -119,7 +119,15 @@ StatusCode SimulateSiPMwithContrib::execute(const EventContext&) const {
     const double integral =
         std::max(0., anaSignal.integral(m_gateStart, m_gateL, m_thres));           // (intStart, intGate, threshold)
     const double toa = std::max(0., anaSignal.toa(m_gateStart, m_gateL, m_thres)); // (intStart, intGate, threshold)
+    
+    // Do not save digi hit if the integral is 0, i.e. no signal from electronics
+    if(integral < 0.01) continue;
 
+    // NOTE: I noticed very few digi hits have TOA > ms, clearly a bug to be investigated
+    if(toa > 1e6) continue;
+    std::cout<<"integral "<<integral<<" toa "<<toa<<std::endl;
+
+    auto digiHit = digiHits->create();
     digiHit.setEnergy(integral /* * m_scaleADC.value()*/); // convertition from ADC to GeV can be added here
     digiHit.setEnergyError(/*m_scaleADC.value() **/ std::sqrt(integral));
     digiHit.setPosition(scintHit.getPosition());

--- a/RecCalorimeter/src/components/SimulateSiPMwithContrib.cpp
+++ b/RecCalorimeter/src/components/SimulateSiPMwithContrib.cpp
@@ -1,0 +1,129 @@
+#include "SimulateSiPMwithContrib.h"
+#include "DD4hep/DD4hepUnits.h"
+#include <cmath>
+
+DECLARE_COMPONENT(SimulateSiPMwithContrib)
+
+SimulateSiPMwithContrib::SimulateSiPMwithContrib(const std::string& aName, ISvcLocator* aSvcLoc)
+    : Gaudi::Algorithm(aName, aSvcLoc) {}
+
+StatusCode SimulateSiPMwithContrib::initialize() {
+  StatusCode sc = Gaudi::Algorithm::initialize();
+
+  if (sc.isFailure())
+    return sc;
+
+  // Initialize random services
+  m_randSvc = service("RndmGenSvc", false);
+
+  if (!m_randSvc) {
+    error() << "Couldn't get RndmGenSvc!" << endmsg;
+    return StatusCode::FAILURE;
+  }
+
+  if (m_rndmUniform.initialize(m_randSvc, Rndm::Flat(0., 1.)).isFailure()) {
+    error() << "Couldn't initialize RndmGenSvc!" << endmsg;
+    return StatusCode::FAILURE;
+  }
+
+  if (m_rndmExp.initialize(m_randSvc, Rndm::Exponential(m_scintDecaytime.value())).isFailure()) {
+    error() << "Couldn't initialize RndmGenSvc!" << endmsg;
+    return StatusCode::FAILURE;
+  }
+
+  // initialize SiPM properties
+  sipm::SiPMProperties properties;
+  properties.setSignalLength(m_sigLength);
+  properties.setSize(m_sipmSize);
+  properties.setDcr(m_Dcr);
+  properties.setXt(m_Xt);
+  properties.setSampling(m_sampling);
+  properties.setRecoveryTime(m_recovery);
+  properties.setPitch(m_cellPitch);
+  properties.setAp(m_afterpulse);
+  properties.setFallTimeFast(m_falltimeFast);
+  properties.setRiseTime(m_risetime);
+  properties.setSnr(m_snr);
+  properties.setPdeType(sipm::SiPMProperties::PdeType::kNoPde);
+  properties.setPdeSpectrum(m_wavelen, m_sipmEff);
+
+  // set other parameters if provided
+  for (const auto& [key, value] : m_params.value())
+    properties.setProperty(key, value);
+
+  m_sensor = std::make_unique<sipm::SiPMSensor>(properties); // must be constructed from SiPMProperties
+
+  info() << "SimulateSiPMwithEdep initialized" << endmsg;
+  info() << properties << endmsg; // sipm::SiPMProperties has std::ostream& operator<<
+
+  return StatusCode::SUCCESS;
+}
+
+StatusCode SimulateSiPMwithContrib::execute(const EventContext&) const {
+  const edm4hep::SimCalorimeterHitCollection* scintHits = m_scintHits.get();
+  edm4hep::CalorimeterHitCollection* digiHits = m_digiHits.createAndPut();
+
+  // loop through the hits (each hit corresponds to a fiber)
+  for (unsigned int idx = 0; idx < scintHits->size(); idx++) {
+    const auto& scintHit = scintHits->at(idx);
+
+    if (!scintHit.isAvailable()) {
+    std::cout << "ERROR: Hit not available!" << std::endl;
+    continue;
+    }
+
+    std::vector<double> vecTimes;
+    std::vector<double> vecWavelens;
+    
+    // loop through the hit contributions
+    for (auto contrib = scintHit.contributions_begin(); contrib != scintHit.contributions_end(); ++contrib) {
+	
+      if (!contrib->isAvailable()) {
+        std::cerr << "ERROR: Hit contribution not available!" << std::endl;
+        continue;
+      }
+      const double npe = contrib->getEnergy(); // in IDEA_o2 this is the number of photo-electrons
+
+      vecTimes.reserve(vecTimes.size() + npe); // resize vector to store new p.e.
+      vecWavelens.reserve(vecTimes.size() + npe);
+
+      // get the photon arrival time at SiPM
+      const double time = contrib->getTime(); // in IDEA_o2 this it the toa at SiPM in ns
+      // add scintillation decay time
+      double scintTime = time + m_rndmExp.shoot();
+
+      for (unsigned int pe=0; pe<npe; pe++){
+        vecTimes.push_back(scintTime);
+        vecWavelens.push_back(1.);
+      }
+    } // contrib
+
+    // sort time of arrivals from shortest to longest
+    std::sort(vecTimes.begin(), vecTimes.end());
+
+    m_sensor->resetState();
+    m_sensor->addPhotons(vecTimes, vecWavelens); // Sets photon times & wavelengths
+    m_sensor->runEvent(); // Runs the simulation
+
+    auto digiHit = digiHits->create();
+
+    // Using only analog signal (ADC conversion is still experimental)
+    const sipm::SiPMAnalogSignal anaSignal = m_sensor->signal();
+
+    // if the signal never exceeds the threshold, it will return -1.
+    const double integral =
+        std::max(0., anaSignal.integral(m_gateStart, m_gateL, m_thres));           // (intStart, intGate, threshold)
+    const double toa = std::max(0., anaSignal.toa(m_gateStart, m_gateL, m_thres)); // (intStart, intGate, threshold)
+
+    digiHit.setEnergy(integral/* * m_scaleADC.value()*/); // convert ADC to GeV
+    digiHit.setEnergyError(/*m_scaleADC.value() **/ std::sqrt(integral));
+    digiHit.setPosition(scintHit.getPosition());
+    digiHit.setCellID(scintHit.getCellID());
+    // Toa and m_gateStart are in ns
+    digiHit.setTime(toa + m_gateStart);
+  }
+
+  return StatusCode::SUCCESS;
+}
+
+StatusCode SimulateSiPMwithContrib::finalize() { return Gaudi::Algorithm::finalize(); }

--- a/RecCalorimeter/src/components/SimulateSiPMwithContrib.cpp
+++ b/RecCalorimeter/src/components/SimulateSiPMwithContrib.cpp
@@ -119,8 +119,10 @@ StatusCode SimulateSiPMwithContrib::execute(const EventContext&) const {
         std::max(0., anaSignal.integral(m_gateStart, m_gateL, m_thres));           // (intStart, intGate, threshold)
     const double toa = std::max(0., anaSignal.toa(m_gateStart, m_gateL, m_thres)); // (intStart, intGate, threshold)
     
-    // Do not save digi hit if the integral is 0, i.e. no signal from electronics
-    if(integral < 0.01) continue;
+    // Apply threshold to save digi hit.
+    // By default this is a zero suppression cut, can the changed to apply 1-suppression, 2-suppression, ...
+    // Note: check the sipm gain applied in SimSipm, by default it is 1.
+    if(integral < m_suppressionThreshold) continue;
 
     // NOTE: I noticed very few digi hits have TOA > ms, clearly a bug to be investigated
     if(toa > 1e6) continue;

--- a/RecCalorimeter/src/components/SimulateSiPMwithContrib.cpp
+++ b/RecCalorimeter/src/components/SimulateSiPMwithContrib.cpp
@@ -6,7 +6,7 @@ DECLARE_COMPONENT(SimulateSiPMwithContrib)
 
 SimulateSiPMwithContrib::SimulateSiPMwithContrib(const std::string& aName, ISvcLocator* aSvcLoc)
     : Gaudi::Algorithm(aName, aSvcLoc) {
-    
+
   // register DataHandles with hit collection names
   declareProperty("inputHitCollection", m_simHits, "input calo collection name");
   declareProperty("outputHitCollection", m_digiHits, "output calo collection name");
@@ -64,22 +64,22 @@ StatusCode SimulateSiPMwithContrib::execute(const EventContext&) const {
   const edm4hep::SimCalorimeterHitCollection* scintHits = m_simHits.get();
   edm4hep::CalorimeterHitCollection* digiHits = m_digiHits.createAndPut();
   auto* links = m_hitLinks.createAndPut();
-  
+
   // loop through the hits (each hit corresponds to a fiber)
   for (unsigned int idx = 0; idx < scintHits->size(); idx++) {
     const auto& scintHit = scintHits->at(idx);
 
     if (!scintHit.isAvailable()) {
-    std::cout << "ERROR: Hit not available!" << std::endl;
-    continue;
+      std::cout << "ERROR: Hit not available!" << std::endl;
+      continue;
     }
 
     std::vector<double> vecTimes;
     std::vector<double> vecWavelens;
-    
+
     // loop through the hit contributions
     for (auto contrib = scintHit.contributions_begin(); contrib != scintHit.contributions_end(); ++contrib) {
-	
+
       if (!contrib->isAvailable()) {
         std::cerr << "ERROR: Hit contribution not available!" << std::endl;
         continue;
@@ -93,11 +93,11 @@ StatusCode SimulateSiPMwithContrib::execute(const EventContext&) const {
       const double time = contrib->getTime(); // in IDEA_o2 this it the toa at SiPM in ns
       double thisTime = time;
       // if it is a scintillation hit, add scintillation decay time
-      if (!m_isCherenkov){
+      if (!m_isCherenkov) {
         thisTime += m_rndmExp.shoot();
       }
 
-      for (unsigned int pe=0; pe<npe; pe++){
+      for (unsigned int pe = 0; pe < npe; pe++) {
         vecTimes.push_back(thisTime);
         vecWavelens.push_back(1.); // photons wavelengths are dummy, we are using photo-electrons
       }
@@ -108,7 +108,7 @@ StatusCode SimulateSiPMwithContrib::execute(const EventContext&) const {
 
     m_sensor->resetState();
     m_sensor->addPhotons(vecTimes, vecWavelens); // Sets photon times & wavelengths
-    m_sensor->runEvent(); // Runs the simulation
+    m_sensor->runEvent();                        // Runs the simulation
 
     auto digiHit = digiHits->create();
 
@@ -120,7 +120,7 @@ StatusCode SimulateSiPMwithContrib::execute(const EventContext&) const {
         std::max(0., anaSignal.integral(m_gateStart, m_gateL, m_thres));           // (intStart, intGate, threshold)
     const double toa = std::max(0., anaSignal.toa(m_gateStart, m_gateL, m_thres)); // (intStart, intGate, threshold)
 
-    digiHit.setEnergy(integral/* * m_scaleADC.value()*/); // convertition from ADC to GeV can be added here
+    digiHit.setEnergy(integral /* * m_scaleADC.value()*/); // convertition from ADC to GeV can be added here
     digiHit.setEnergyError(/*m_scaleADC.value() **/ std::sqrt(integral));
     digiHit.setPosition(scintHit.getPosition());
     digiHit.setCellID(scintHit.getCellID());

--- a/RecCalorimeter/src/components/SimulateSiPMwithContrib.h
+++ b/RecCalorimeter/src/components/SimulateSiPMwithContrib.h
@@ -108,6 +108,9 @@ private:
   // option to store full waveform (for debugging)
   // Not used for the moment, might be used in future for debugging
   // Gaudi::Property<bool> m_storeFullWaveform{this, "storeFullWaveform", false, "Store full waveform for debugging"};
+
+  // Suppression threshold parameters
+  Gaudi::Property<double> m_suppressionThreshold{this, "suppressionTreshold", 0.001, "Threshold on ADC integral to reject digi hit"};
 };
 
 #endif

--- a/RecCalorimeter/src/components/SimulateSiPMwithContrib.h
+++ b/RecCalorimeter/src/components/SimulateSiPMwithContrib.h
@@ -23,9 +23,9 @@
 
 /** @class SimulateSiPMwithContrib
  *
- *  This algorithm was created to apply the SiPM response ovet the
+ *  This algorithm was created to apply the SiPM response over the
  *  hit created with IDEA_o2 simulation.
- *  Contributions from such hits containts the photo-electrons (fired cells)
+ *  Contributions from such hits containt the photo-electrons (fired cells)
  *  and their time of arrivals at SiPMs.
  *  This algorithm takes all the input collections form the IDEA_o2
  *  hadronic calorimeter and returns corresponding digitized hits.
@@ -57,11 +57,13 @@ private:
   Rndm::Numbers m_rndmExp;
 
   // readout name and segmentation (of specific type)
+  // Not used for the moment, might be used in future
   //Gaudi::Property<std::string> m_readoutName{this, "readoutName", "", "name of the readout"};
 
   mutable k4FWCore::DataHandle<edm4hep::SimCalorimeterHitCollection> m_simHits{"", Gaudi::DataHandle::Reader, this};
   mutable k4FWCore::DataHandle<edm4hep::CalorimeterHitCollection> m_digiHits{"", Gaudi::DataHandle::Writer, this};
-  
+  mutable k4FWCore::DataHandle<edm4hep::CaloHitSimCaloHitLinkCollection> m_hitLinks{"", Gaudi::DataHandle::Writer, this};
+
   std::unique_ptr<sipm::SiPMSensor> m_sensor;
 
   // Hamamatsu S14160-1310PS
@@ -104,7 +106,8 @@ private:
   Gaudi::Property<double> m_scintDecaytime{this, "scintDecaytime", 2.8, "scintillation decay time in ns"};
 
   // option to store full waveform (for debugging)
-  Gaudi::Property<bool> m_storeFullWaveform{this, "storeFullWaveform", false, "Store full waveform for debugging"};
+  // Not used for the moment, might be used in future for debugging
+  //Gaudi::Property<bool> m_storeFullWaveform{this, "storeFullWaveform", false, "Store full waveform for debugging"};
 
 };
 

--- a/RecCalorimeter/src/components/SimulateSiPMwithContrib.h
+++ b/RecCalorimeter/src/components/SimulateSiPMwithContrib.h
@@ -1,0 +1,122 @@
+#ifndef SimulateSiPMwithContrib_h
+#define SimulateSiPMwithContrib_h 1
+
+#include "edm4hep/CalorimeterHitCollection.h"
+#include "edm4hep/EventHeaderCollection.h"
+#include "edm4hep/SimCalorimeterHitCollection.h"
+#include "edm4hep/CaloHitSimCaloHitLinkCollection.h"
+#include "edm4hep/TimeSeriesCollection.h"
+
+#include "k4FWCore/DataHandle.h"
+
+#include "Gaudi/Algorithm.h"
+#include "GaudiKernel/IRndmGenSvc.h"
+#include "GaudiKernel/RndmGenerators.h"
+#include "GaudiKernel/ToolHandle.h"
+
+// geometry (needed for timing, based on the distance btn the step and the rear end of the fiber)
+#include "k4Interface/IGeoSvc.h"
+#include "detectorSegmentations/GridDRcalo_k4geo.h"
+
+// Check for SiPMSensor header location (similar to how DigiSiPM handles this)
+#if __has_include("SiPMSensor.h")
+#include "SiPMSensor.h"
+#elif __has_include("sipm/SiPMSensor.h")
+#include "sipm/SiPMSensor.h"
+#endif
+
+/** @class SimulateSiPMwithContrib
+ *
+ *  Algorithm for digitizing the SiPM response using photolectrons
+ *  stored as calo hit contributions,
+ *  producing a CalorimeterHitCollection (ADC count from SiPM) as output.
+ *
+ *  The algorithm simulates SiPM response including effects like:
+ *  - Dark count rate (DCR)
+ *  - Crosstalk (Xt)
+ *  - Afterpulsing
+ *  - Cell recovery time
+ *  - Signal rise and fall times
+ *
+ *  @author Lorenzo Pezzotti
+ *  @date   2026-02-17
+ */
+
+class SimulateSiPMwithContrib : public Gaudi::Algorithm {
+public:
+  SimulateSiPMwithContrib(const std::string& name, ISvcLocator* svcLoc);
+  virtual ~SimulateSiPMwithContrib() {};
+
+  StatusCode initialize();
+  StatusCode execute(const EventContext&) const;
+  StatusCode finalize();
+
+private:
+
+  // Random Number Service
+  SmartIF<IRndmGenSvc> m_randSvc;
+  Rndm::Numbers m_rndmUniform;
+  Rndm::Numbers m_rndmExp;
+
+  // readout name and segmentation (of specific type)
+  Gaudi::Property<std::string> m_readoutName{this, "readoutName", "", "name of the readout"};
+
+  // input collection names
+  Gaudi::Property<std::string> m_hitColl{this, "inputHitCollection", "DRBTScin",
+                                         "input calo collection name"};
+  Gaudi::Property<std::string> m_outColl{this, "outputHitCollection", "DRBTScin_digi",
+                                         "output calo collection name"};
+
+  mutable k4FWCore::DataHandle<edm4hep::SimCalorimeterHitCollection> m_scintHits{m_hitColl, Gaudi::DataHandle::Reader,
+                                                                                 this};
+  mutable k4FWCore::DataHandle<edm4hep::CalorimeterHitCollection> m_digiHits{m_outColl, Gaudi::DataHandle::Writer,
+                                                                             this};
+
+  std::unique_ptr<sipm::SiPMSensor> m_sensor;
+
+  // Hamamatsu S14160-1310PS
+  // Signal properties
+  Gaudi::Property<double> m_sigLength{this, "signalLength", 200., "signal length in ns"};
+  Gaudi::Property<double> m_sampling{this, "sampling", 0.1, "SiPM sampling rate in ns"};
+  Gaudi::Property<double> m_risetime{this, "risetime", 1., "signal rise time in ns"};
+  Gaudi::Property<double> m_falltimeFast{this, "falltimeFast", 6.5, "signal fast component decay time in ns"};
+
+  // SiPM physical properties
+  Gaudi::Property<double> m_sipmSize{this, "SiPMsize", 1.3, "width of photosensitive area in mm"};
+  Gaudi::Property<double> m_cellPitch{this, "cellpitch", 10., "SiPM cell size in um"};
+  Gaudi::Property<double> m_recovery{this, "recovery", 10.,
+                                     "SiPM cell recovery time in ns"}; // https://arxiv.org/abs/2001.10322
+
+  // Noise parameters
+  Gaudi::Property<double> m_Dcr{this, "DCR", 120e3, "SiPM DCR"}; // dark count rate
+  Gaudi::Property<double> m_Xt{this, "Xtalk", 0.01, "SiPM crosstalk"};
+  Gaudi::Property<double> m_afterpulse{this, "afterpulse", 0.03, "afterpulse probability"};
+  Gaudi::Property<double> m_snr{this, "SNR", 20., "SNR value in dB"}; // signal-to-noise ratio
+
+  // integration parameters
+  Gaudi::Property<double> m_gateStart{this, "gateStart", 5., "Integration gate starting time in ns"};
+  Gaudi::Property<double> m_gateL{this, "gateLength", 95.,
+                                  "Integration gate length in ns"}; // Should be approx 5 times fallTimeFast (see above)
+  Gaudi::Property<double> m_thres{this, "threshold", 1.5,
+                                  "Integration threshold"}; // Threshold in p.e. (1.5 to suppress DCR)
+
+  // other parameters (attention, will override above parameters if set)
+  Gaudi::Property<std::map<std::string,double>> m_params{this, "params", {}, "optional parameters"};
+
+  // switch to use the stored edm4hep::CaloHitContribution::getTime() as it is
+  Gaudi::Property<bool> m_switchTime{this, "switchTime", false,
+                                     "switch to use the stored edm4hep::CaloHitContribution::getTime() as it is"};
+
+  // SiPM efficiency, filter efficiency
+  Gaudi::Property<std::vector<double>> m_wavelen{
+      this, "wavelength", {1000., 100.}, "wavelength vector in nm (decreasing order)"};
+  Gaudi::Property<std::vector<double>> m_sipmEff{this, "sipmEfficiency", {1.0, 1.0}, "SiPM efficiency vs wavelength"};
+
+  Gaudi::Property<double> m_scintDecaytime{this, "scintDecaytime", 2.8, "scintillation decay time in ns"};
+
+  // option to store full waveform (for debugging)
+  Gaudi::Property<bool> m_storeFullWaveform{this, "storeFullWaveform", false, "Store full waveform for debugging"};
+
+};
+
+#endif

--- a/RecCalorimeter/src/components/SimulateSiPMwithContrib.h
+++ b/RecCalorimeter/src/components/SimulateSiPMwithContrib.h
@@ -14,10 +14,6 @@
 #include "GaudiKernel/RndmGenerators.h"
 #include "GaudiKernel/ToolHandle.h"
 
-// geometry (needed for timing, based on the distance btn the step and the rear end of the fiber)
-#include "k4Interface/IGeoSvc.h"
-#include "detectorSegmentations/GridDRcalo_k4geo.h"
-
 // Check for SiPMSensor header location (similar to how DigiSiPM handles this)
 #if __has_include("SiPMSensor.h")
 #include "SiPMSensor.h"
@@ -27,9 +23,12 @@
 
 /** @class SimulateSiPMwithContrib
  *
- *  Algorithm for digitizing the SiPM response using photolectrons
- *  stored as calo hit contributions,
- *  producing a CalorimeterHitCollection (ADC count from SiPM) as output.
+ *  This algorithm was created to apply the SiPM response ovet the
+ *  hit created with IDEA_o2 simulation.
+ *  Contributions from such hits containts the photo-electrons (fired cells)
+ *  and their time of arrivals at SiPMs.
+ *  This algorithm takes all the input collections form the IDEA_o2
+ *  hadronic calorimeter and returns corresponding digitized hits.
  *
  *  The algorithm simulates SiPM response including effects like:
  *  - Dark count rate (DCR)
@@ -55,11 +54,10 @@ private:
 
   // Random Number Service
   SmartIF<IRndmGenSvc> m_randSvc;
-  Rndm::Numbers m_rndmUniform;
   Rndm::Numbers m_rndmExp;
 
   // readout name and segmentation (of specific type)
-  Gaudi::Property<std::string> m_readoutName{this, "readoutName", "", "name of the readout"};
+  //Gaudi::Property<std::string> m_readoutName{this, "readoutName", "", "name of the readout"};
 
   mutable k4FWCore::DataHandle<edm4hep::SimCalorimeterHitCollection> m_simHits{"", Gaudi::DataHandle::Reader, this};
   mutable k4FWCore::DataHandle<edm4hep::CalorimeterHitCollection> m_digiHits{"", Gaudi::DataHandle::Writer, this};
@@ -95,14 +93,10 @@ private:
   // other parameters (attention, will override above parameters if set)
   Gaudi::Property<std::map<std::string,double>> m_params{this, "params", {}, "optional parameters"};
 
-  // switch to use the stored edm4hep::CaloHitContribution::getTime() as it is
-  Gaudi::Property<bool> m_switchTime{this, "switchTime", false,
-                                     "switch to use the stored edm4hep::CaloHitContribution::getTime() as it is"};
-
   // switch to select if you are processing scintillation or Cherenkov hits
   Gaudi::Property<bool> m_isCherenkov{this, "isCherenkov", false,
                                      "switch to select if you are processing scintillation or Cherenkov hits"};
-  // SiPM efficiency, filter efficiency
+  // SiPM efficiency
   Gaudi::Property<std::vector<double>> m_wavelen{
       this, "wavelength", {1000., 100.}, "wavelength vector in nm (decreasing order)"};
   Gaudi::Property<std::vector<double>> m_sipmEff{this, "sipmEfficiency", {1.0, 1.0}, "SiPM efficiency vs wavelength"};

--- a/RecCalorimeter/src/components/SimulateSiPMwithContrib.h
+++ b/RecCalorimeter/src/components/SimulateSiPMwithContrib.h
@@ -1,10 +1,10 @@
 #ifndef SimulateSiPMwithContrib_h
 #define SimulateSiPMwithContrib_h 1
 
+#include "edm4hep/CaloHitSimCaloHitLinkCollection.h"
 #include "edm4hep/CalorimeterHitCollection.h"
 #include "edm4hep/EventHeaderCollection.h"
 #include "edm4hep/SimCalorimeterHitCollection.h"
-#include "edm4hep/CaloHitSimCaloHitLinkCollection.h"
 #include "edm4hep/TimeSeriesCollection.h"
 
 #include "k4FWCore/DataHandle.h"
@@ -51,18 +51,18 @@ public:
   StatusCode finalize();
 
 private:
-
   // Random Number Service
   SmartIF<IRndmGenSvc> m_randSvc;
   Rndm::Numbers m_rndmExp;
 
   // readout name and segmentation (of specific type)
   // Not used for the moment, might be used in future
-  //Gaudi::Property<std::string> m_readoutName{this, "readoutName", "", "name of the readout"};
+  // Gaudi::Property<std::string> m_readoutName{this, "readoutName", "", "name of the readout"};
 
   mutable k4FWCore::DataHandle<edm4hep::SimCalorimeterHitCollection> m_simHits{"", Gaudi::DataHandle::Reader, this};
   mutable k4FWCore::DataHandle<edm4hep::CalorimeterHitCollection> m_digiHits{"", Gaudi::DataHandle::Writer, this};
-  mutable k4FWCore::DataHandle<edm4hep::CaloHitSimCaloHitLinkCollection> m_hitLinks{"", Gaudi::DataHandle::Writer, this};
+  mutable k4FWCore::DataHandle<edm4hep::CaloHitSimCaloHitLinkCollection> m_hitLinks{"", Gaudi::DataHandle::Writer,
+                                                                                    this};
 
   std::unique_ptr<sipm::SiPMSensor> m_sensor;
 
@@ -93,11 +93,11 @@ private:
                                   "Integration threshold"}; // Threshold in p.e. (1.5 to suppress DCR)
 
   // other parameters (attention, will override above parameters if set)
-  Gaudi::Property<std::map<std::string,double>> m_params{this, "params", {}, "optional parameters"};
+  Gaudi::Property<std::map<std::string, double>> m_params{this, "params", {}, "optional parameters"};
 
   // switch to select if you are processing scintillation or Cherenkov hits
   Gaudi::Property<bool> m_isCherenkov{this, "isCherenkov", false,
-                                     "switch to select if you are processing scintillation or Cherenkov hits"};
+                                      "switch to select if you are processing scintillation or Cherenkov hits"};
   // SiPM efficiency
   Gaudi::Property<std::vector<double>> m_wavelen{
       this, "wavelength", {1000., 100.}, "wavelength vector in nm (decreasing order)"};
@@ -107,8 +107,7 @@ private:
 
   // option to store full waveform (for debugging)
   // Not used for the moment, might be used in future for debugging
-  //Gaudi::Property<bool> m_storeFullWaveform{this, "storeFullWaveform", false, "Store full waveform for debugging"};
-
+  // Gaudi::Property<bool> m_storeFullWaveform{this, "storeFullWaveform", false, "Store full waveform for debugging"};
 };
 
 #endif

--- a/RecCalorimeter/src/components/SimulateSiPMwithContrib.h
+++ b/RecCalorimeter/src/components/SimulateSiPMwithContrib.h
@@ -61,17 +61,9 @@ private:
   // readout name and segmentation (of specific type)
   Gaudi::Property<std::string> m_readoutName{this, "readoutName", "", "name of the readout"};
 
-  // input collection names
-  Gaudi::Property<std::string> m_hitColl{this, "inputHitCollection", "DRBTScin",
-                                         "input calo collection name"};
-  Gaudi::Property<std::string> m_outColl{this, "outputHitCollection", "DRBTScin_digi",
-                                         "output calo collection name"};
-
-  mutable k4FWCore::DataHandle<edm4hep::SimCalorimeterHitCollection> m_scintHits{m_hitColl, Gaudi::DataHandle::Reader,
-                                                                                 this};
-  mutable k4FWCore::DataHandle<edm4hep::CalorimeterHitCollection> m_digiHits{m_outColl, Gaudi::DataHandle::Writer,
-                                                                             this};
-
+  mutable k4FWCore::DataHandle<edm4hep::SimCalorimeterHitCollection> m_simHits{"", Gaudi::DataHandle::Reader, this};
+  mutable k4FWCore::DataHandle<edm4hep::CalorimeterHitCollection> m_digiHits{"", Gaudi::DataHandle::Writer, this};
+  
   std::unique_ptr<sipm::SiPMSensor> m_sensor;
 
   // Hamamatsu S14160-1310PS
@@ -107,6 +99,9 @@ private:
   Gaudi::Property<bool> m_switchTime{this, "switchTime", false,
                                      "switch to use the stored edm4hep::CaloHitContribution::getTime() as it is"};
 
+  // switch to select if you are processing scintillation or Cherenkov hits
+  Gaudi::Property<bool> m_isCherenkov{this, "isCherenkov", false,
+                                     "switch to select if you are processing scintillation or Cherenkov hits"};
   // SiPM efficiency, filter efficiency
   Gaudi::Property<std::vector<double>> m_wavelen{
       this, "wavelength", {1000., 100.}, "wavelength vector in nm (decreasing order)"};

--- a/RecCalorimeter/tests/options/runSiPMDualReadoutTubes.py
+++ b/RecCalorimeter/tests/options/runSiPMDualReadoutTubes.py
@@ -8,21 +8,88 @@ from Configurables import PodioInput
 podioinput = PodioInput("PodioInput",
     collections = [
          "DRBTScin",
-         "DRBTScinContributions"
+         "DRBTScinContributions",
+         "DRBTCher",
+         "DRBTCherContributions",
+         "DRETScinLeft",
+         "DRETScinLeftContributions",
+         "DRETScinRight",
+         "DRETScinRightContributions",
+         "DRETCherLeft",
+         "DRETCherLeftContributions",
+         "DRETCherRight",
+         "DRETCherRightContributions",
     ],
     OutputLevel = DEBUG
 )
 
 from Configurables import SimulateSiPMwithContrib
-sipmContribBTScin = SimulateSiPMwithContrib("SimulateSiPMwithContrib",
+sipmContribBTScin = SimulateSiPMwithContrib("sipmContribBTScin",
     OutputLevel=DEBUG,
     inputHitCollection = "DRBTScin",
     outputHitCollection = "DRBTScin_digi",
     readoutName = "DRTcaloSiPMreadout",
+    isCherenkov = False,
     # wavelength in nm (decreasing order)
     wavelength = [900.,300.],
     sipmEfficiency = [1.0,1.0]
 )
+
+sipmContribETScinLeft = SimulateSiPMwithContrib("sipmContribETScinLeft",
+    OutputLevel=DEBUG,
+    inputHitCollection = "DRETScinLeft",
+    outputHitCollection = "DRETScinLeft_digi",
+    readoutName = "DRTcaloSiPMreadout",
+    isCherenkov = False,
+    # wavelength in nm (decreasing order)
+    wavelength = [900.,300.],
+    sipmEfficiency = [1.0,1.0]
+)
+
+sipmContribETScinRight = SimulateSiPMwithContrib("sipmContribETScinRight",
+    OutputLevel=DEBUG,
+    inputHitCollection = "DRETScinRight",
+    outputHitCollection = "DRETScinRight_digi",
+    readoutName = "DRTcaloSiPMreadout",
+    isCherenkov = False,
+    # wavelength in nm (decreasing order)
+    wavelength = [900.,300.],
+    sipmEfficiency = [1.0,1.0]
+)
+
+sipmContribBTCher = SimulateSiPMwithContrib("sipmContribBTCher",
+    OutputLevel=DEBUG,
+    inputHitCollection = "DRBTCher",
+    outputHitCollection = "DRBTCher_digi",
+    readoutName = "DRTcaloSiPMreadout",
+    isCherenkov = True,
+    # wavelength in nm (decreasing order)
+    wavelength = [900.,300.],
+    sipmEfficiency = [1.0,1.0]
+)
+
+sipmContribETCherLeft = SimulateSiPMwithContrib("sipmContribETCherLeft",
+    OutputLevel=DEBUG,
+    inputHitCollection = "DRETCherLeft",
+    outputHitCollection = "DRETCherLeft_digi",
+    readoutName = "DRTcaloSiPMreadout",
+    isCherenkov = False,
+    # wavelength in nm (decreasing order)
+    wavelength = [900.,300.],
+    sipmEfficiency = [1.0,1.0]
+)
+
+sipmContribETCherRight = SimulateSiPMwithContrib("sipmContribETCherRight",
+    OutputLevel=DEBUG,
+    inputHitCollection = "DRETCherRight",
+    outputHitCollection = "DRETCherRight_digi",
+    readoutName = "DRTcaloSiPMreadout",
+    isCherenkov = False,
+    # wavelength in nm (decreasing order)
+    wavelength = [900.,300.],
+    sipmEfficiency = [1.0,1.0]
+)
+
 
 from Configurables import PodioOutput
 podiooutput = PodioOutput("PodioOutput", filename = "IDEA_o2_v01_digi.root", OutputLevel = DEBUG)
@@ -43,6 +110,11 @@ ApplicationMgr(
     TopAlg = [
         podioinput,
         sipmContribBTScin,
+        sipmContribETScinLeft,
+        sipmContribETScinRight,
+        sipmContribBTCher,
+        sipmContribETCherLeft,
+        sipmContribETCherRight,
         podiooutput
     ],
     EvtSel = 'NONE',

--- a/RecCalorimeter/tests/options/runSiPMDualReadoutTubes.py
+++ b/RecCalorimeter/tests/options/runSiPMDualReadoutTubes.py
@@ -7,7 +7,7 @@ dataservice = k4DataSvc("EventDataSvc", input="IDEA_o2_v01.root")
 from Configurables import PodioInput
 podioinput = PodioInput("PodioInput",
     collections = [
-         "DRBTScin",
+         "DRBTScin", # collections from IDEA_o2 hadronic calo
          "DRBTScinContributions",
          "DRBTCher",
          "DRBTCherContributions",
@@ -23,11 +23,17 @@ podioinput = PodioInput("PodioInput",
     OutputLevel = DEBUG
 )
 
+# SimulateSiPMwithContrib applied sipm digitization
+# over the output format of the IDEA_o2 hadronic calorimeter.
+# In this format we do not store photons but photo-electrons (fired cells)
+# therefore the wavelength and sipmEfficiency is dummy:
+# all photo-electrons are converted.
 from Configurables import SimulateSiPMwithContrib
 sipmContribBTScin = SimulateSiPMwithContrib("sipmContribBTScin",
     OutputLevel=DEBUG,
     inputHitCollection = "DRBTScin",
     outputHitCollection = "DRBTScin_digi",
+    outputLinkCollection = "DRBTScin_links",
     #readoutName = "DRTcaloSiPMreadout",
     isCherenkov = False,
     # wavelength in nm (decreasing order)
@@ -39,6 +45,7 @@ sipmContribETScinLeft = SimulateSiPMwithContrib("sipmContribETScinLeft",
     OutputLevel=DEBUG,
     inputHitCollection = "DRETScinLeft",
     outputHitCollection = "DRETScinLeft_digi",
+    outputLinkCollection = "DRETScinLeft_links",
     #readoutName = "DRTcaloSiPMreadout",
     isCherenkov = False,
     # wavelength in nm (decreasing order)
@@ -50,6 +57,7 @@ sipmContribETScinRight = SimulateSiPMwithContrib("sipmContribETScinRight",
     OutputLevel=DEBUG,
     inputHitCollection = "DRETScinRight",
     outputHitCollection = "DRETScinRight_digi",
+    outputLinkCollection = "DRETScinRight_links",
     #readoutName = "DRTcaloSiPMreadout",
     isCherenkov = False,
     # wavelength in nm (decreasing order)
@@ -61,6 +69,7 @@ sipmContribBTCher = SimulateSiPMwithContrib("sipmContribBTCher",
     OutputLevel=DEBUG,
     inputHitCollection = "DRBTCher",
     outputHitCollection = "DRBTCher_digi",
+    outputLinkCollection = "DRBTCher_links",
     #readoutName = "DRTcaloSiPMreadout",
     isCherenkov = True,
     # wavelength in nm (decreasing order)
@@ -72,6 +81,7 @@ sipmContribETCherLeft = SimulateSiPMwithContrib("sipmContribETCherLeft",
     OutputLevel=DEBUG,
     inputHitCollection = "DRETCherLeft",
     outputHitCollection = "DRETCherLeft_digi",
+    outputLinkCollection = "DRETCherLeft_links",
     #readoutName = "DRTcaloSiPMreadout",
     isCherenkov = True,
     # wavelength in nm (decreasing order)
@@ -83,6 +93,7 @@ sipmContribETCherRight = SimulateSiPMwithContrib("sipmContribETCherRight",
     OutputLevel=DEBUG,
     inputHitCollection = "DRETCherRight",
     outputHitCollection = "DRETCherRight_digi",
+    outputLinkCollection = "DRETCherRight_links",
     #readoutName = "DRTcaloSiPMreadout",
     isCherenkov = True,
     # wavelength in nm (decreasing order)

--- a/RecCalorimeter/tests/options/runSiPMDualReadoutTubes.py
+++ b/RecCalorimeter/tests/options/runSiPMDualReadoutTubes.py
@@ -28,7 +28,7 @@ sipmContribBTScin = SimulateSiPMwithContrib("sipmContribBTScin",
     OutputLevel=DEBUG,
     inputHitCollection = "DRBTScin",
     outputHitCollection = "DRBTScin_digi",
-    readoutName = "DRTcaloSiPMreadout",
+    #readoutName = "DRTcaloSiPMreadout",
     isCherenkov = False,
     # wavelength in nm (decreasing order)
     wavelength = [900.,300.],
@@ -39,7 +39,7 @@ sipmContribETScinLeft = SimulateSiPMwithContrib("sipmContribETScinLeft",
     OutputLevel=DEBUG,
     inputHitCollection = "DRETScinLeft",
     outputHitCollection = "DRETScinLeft_digi",
-    readoutName = "DRTcaloSiPMreadout",
+    #readoutName = "DRTcaloSiPMreadout",
     isCherenkov = False,
     # wavelength in nm (decreasing order)
     wavelength = [900.,300.],
@@ -50,7 +50,7 @@ sipmContribETScinRight = SimulateSiPMwithContrib("sipmContribETScinRight",
     OutputLevel=DEBUG,
     inputHitCollection = "DRETScinRight",
     outputHitCollection = "DRETScinRight_digi",
-    readoutName = "DRTcaloSiPMreadout",
+    #readoutName = "DRTcaloSiPMreadout",
     isCherenkov = False,
     # wavelength in nm (decreasing order)
     wavelength = [900.,300.],
@@ -61,7 +61,7 @@ sipmContribBTCher = SimulateSiPMwithContrib("sipmContribBTCher",
     OutputLevel=DEBUG,
     inputHitCollection = "DRBTCher",
     outputHitCollection = "DRBTCher_digi",
-    readoutName = "DRTcaloSiPMreadout",
+    #readoutName = "DRTcaloSiPMreadout",
     isCherenkov = True,
     # wavelength in nm (decreasing order)
     wavelength = [900.,300.],
@@ -72,8 +72,8 @@ sipmContribETCherLeft = SimulateSiPMwithContrib("sipmContribETCherLeft",
     OutputLevel=DEBUG,
     inputHitCollection = "DRETCherLeft",
     outputHitCollection = "DRETCherLeft_digi",
-    readoutName = "DRTcaloSiPMreadout",
-    isCherenkov = False,
+    #readoutName = "DRTcaloSiPMreadout",
+    isCherenkov = True,
     # wavelength in nm (decreasing order)
     wavelength = [900.,300.],
     sipmEfficiency = [1.0,1.0]
@@ -83,13 +83,12 @@ sipmContribETCherRight = SimulateSiPMwithContrib("sipmContribETCherRight",
     OutputLevel=DEBUG,
     inputHitCollection = "DRETCherRight",
     outputHitCollection = "DRETCherRight_digi",
-    readoutName = "DRTcaloSiPMreadout",
-    isCherenkov = False,
+    #readoutName = "DRTcaloSiPMreadout",
+    isCherenkov = True,
     # wavelength in nm (decreasing order)
     wavelength = [900.,300.],
     sipmEfficiency = [1.0,1.0]
 )
-
 
 from Configurables import PodioOutput
 podiooutput = PodioOutput("PodioOutput", filename = "IDEA_o2_v01_digi.root", OutputLevel = DEBUG)

--- a/RecCalorimeter/tests/options/runSiPMDualReadoutTubes.py
+++ b/RecCalorimeter/tests/options/runSiPMDualReadoutTubes.py
@@ -1,0 +1,51 @@
+from Gaudi.Configuration import *
+from Configurables import ApplicationMgr
+
+from Configurables import k4DataSvc
+dataservice = k4DataSvc("EventDataSvc", input="IDEA_o2_v01.root")
+
+from Configurables import PodioInput
+podioinput = PodioInput("PodioInput",
+    collections = [
+         "DRBTScin",
+         "DRBTScinContributions"
+    ],
+    OutputLevel = DEBUG
+)
+
+from Configurables import SimulateSiPMwithContrib
+sipmContribBTScin = SimulateSiPMwithContrib("SimulateSiPMwithContrib",
+    OutputLevel=DEBUG,
+    inputHitCollection = "DRBTScin",
+    outputHitCollection = "DRBTScin_digi",
+    readoutName = "DRTcaloSiPMreadout",
+    # wavelength in nm (decreasing order)
+    wavelength = [900.,300.],
+    sipmEfficiency = [1.0,1.0]
+)
+
+from Configurables import PodioOutput
+podiooutput = PodioOutput("PodioOutput", filename = "IDEA_o2_v01_digi.root", OutputLevel = DEBUG)
+podiooutput.outputCommands = ["keep *"]
+
+from Configurables import HepRndm__Engine_CLHEP__RanluxEngine_ as RndmEngine
+rndmEngine = RndmEngine('RndmGenSvc.Engine',
+  SetSingleton = True,
+  Seeds = [ 2345678 ] # default seed is 1234567
+)
+
+from Configurables import RndmGenSvc
+rndmGenSvc = RndmGenSvc("RndmGenSvc",
+  Engine = rndmEngine.name()
+)
+
+ApplicationMgr(
+    TopAlg = [
+        podioinput,
+        sipmContribBTScin,
+        podiooutput
+    ],
+    EvtSel = 'NONE',
+    EvtMax = -1,
+    ExtSvc = [rndmEngine,rndmGenSvc,dataservice]
+)


### PR DESCRIPTION

BEGINRELEASENOTES
- Added a new SiPM digitizer that takes as input calohitcontributions representing photo-electrons and their time of arrival at SiPMs. Added a Python config file to use with k4geo IDEA_o2 output files.

ENDRELEASENOTES

The IDEA_o2 full-simulation now stores the time of arrival of photo-electrons (fired cells) as calohitcontributions associated with simcalohits. Each simcalohit represents a fiber. Contributions represent bunches of photo-electrons contributing to the total signal for the same fiber.
This PR includes a digitizer that uses the SimSiPM library and takes as input the output file from the IDEA_o2 simulation.

I believe the same approach could be used for the SiPM digitization of the crystal em-calorimeter of IDEA_o2.