### PR TITLE
Replace MetaDataHandle with MetadataUtils functionality

### DIFF
--- a/RecCalorimeter/src/components/CaloTopoCluster.cpp
+++ b/RecCalorimeter/src/components/CaloTopoCluster.cpp
@@ -2,6 +2,7 @@
 #include "NoiseCaloCellsFromFileTool.h"
 
 // k4FWCore
+#include "k4FWCore/MetadataUtils.h"
 #include "k4Interface/IGeoSvc.h"
 
 // k4geo
@@ -18,6 +19,7 @@
 #include "DD4hep/Readout.h"
 
 #include <GaudiKernel/StatusCode.h>
+
 #include <algorithm>
 #include <map>
 #include <memory>
@@ -83,7 +85,8 @@ StatusCode CaloTopoCluster::initialize() {
 
   // initialise the list of metadata for the clusters
   std::vector<std::string> shapeParameterNames = {"dR_over_E"};
-  m_shapeParametersHandle.put(shapeParameterNames);
+  k4FWCore::putCollectionParameter(m_clusterCellsCollection.objKey(), edm4hep::labels::ShapeParameterNames,
+                                   shapeParameterNames, this);
 
   return StatusCode::SUCCESS;
 }

--- a/RecCalorimeter/src/components/CaloTopoCluster.h
+++ b/RecCalorimeter/src/components/CaloTopoCluster.h
@@ -9,7 +9,6 @@
 
 // Key4HEP
 #include "k4FWCore/DataHandle.h"
-#include "k4FWCore/MetaDataHandle.h"
 #include "k4Interface/ICaloReadNeighboursMap.h"
 #include "k4Interface/ICalorimeterTool.h"
 #include "k4Interface/ICellPositionsTool.h"
@@ -108,9 +107,6 @@ private:
   // Cluster cells in collection
   mutable k4FWCore::DataHandle<edm4hep::CalorimeterHitCollection> m_clusterCellsCollection{
       "calo/clusterCells", Gaudi::DataHandle::Writer, this};
-  /// Handle for the cluster shape metadata to write
-  k4FWCore::MetaDataHandle<std::vector<std::string>> m_shapeParametersHandle{
-      m_clusterCollection, edm4hep::labels::ShapeParameterNames, Gaudi::DataHandle::Writer};
   /// Pointer to the geometry service
   SmartIF<IGeoSvc> m_geoSvc;
   /// Handle for the input tool

--- a/RecCalorimeter/src/components/CreateCaloCells.cpp
+++ b/RecCalorimeter/src/components/CreateCaloCells.cpp
@@ -5,6 +5,7 @@
 
 // k4FWCore
 #include "k4Interface/IGeoSvc.h"
+#include <k4FWCore/MetadataUtils.h>
 
 // DD4hep
 #include "DD4hep/DetType.h"
@@ -39,7 +40,6 @@ StatusCode CreateCaloCells::initialize() {
   info() << "remove cells below threshold : " << m_filterCellNoise << endmsg;
   info() << "add position information to the cell : " << m_addPosition << endmsg;
   info() << "emulate crosstalk : " << m_addCrosstalk << endmsg;
-
 
   // Initialization of tools
   // Cell crosstalk tool
@@ -85,12 +85,12 @@ StatusCode CreateCaloCells::initialize() {
   }
 
   // Copy over the CellIDEncoding string from the input collection to the output collection
-  auto hitsEncoding = m_hitsCellIDEncoding.get_optional();
+  auto hitsEncoding = k4FWCore::getCellIDEncoding(m_hits.objKey(), this);
   if (!hitsEncoding.has_value()) {
     error() << "Missing cellID encoding for input collection" << endmsg;
     return StatusCode::FAILURE;
   }
-  m_cellsCellIDEncoding.put(hitsEncoding.value());
+  k4FWCore::putCellIDEncoding(m_cells.objKey(), hitsEncoding.value(), this);
 
   m_decoder = dd4hep::DDSegmentation::BitFieldCoder(hitsEncoding.value());
   m_systemIndex = m_decoder.index ("system");

--- a/RecCalorimeter/src/components/CreateCaloCells.h
+++ b/RecCalorimeter/src/components/CreateCaloCells.h
@@ -3,7 +3,6 @@
 
 // k4FWCore
 #include "k4FWCore/DataHandle.h"
-#include "k4FWCore/MetaDataHandle.h"
 #include "k4Interface/ICalibrateCaloHitsTool.h"
 #include "k4Interface/ICaloReadCrosstalkMap.h"
 #include "k4Interface/ICalorimeterTool.h"
@@ -59,7 +58,6 @@ public:
 
   virtual StatusCode execute(const EventContext&) const override;
 
-
 private:
   /// Build m_caloTypes, giving calorimeter type per system ID.
   void findCaloTypes();
@@ -87,13 +85,8 @@ private:
 
   /// Handle for calo hits (input collection)
   mutable k4FWCore::DataHandle<edm4hep::SimCalorimeterHitCollection> m_hits{"hits", Gaudi::DataHandle::Reader, this};
-  /// Handle for the cellID encoding string of the input collection
-  k4FWCore::MetaDataHandle<std::string> m_hitsCellIDEncoding{m_hits, edm4hep::labels::CellIDEncoding,
-                                                             Gaudi::DataHandle::Reader};
   /// Handle for calo cells (output collection)
   mutable k4FWCore::DataHandle<edm4hep::CalorimeterHitCollection> m_cells{"cells", Gaudi::DataHandle::Writer, this};
-  k4FWCore::MetaDataHandle<std::string> m_cellsCellIDEncoding{m_cells, edm4hep::labels::CellIDEncoding,
-                                                              Gaudi::DataHandle::Writer};
   /// Name of the detector readout
   Gaudi::Property<std::string> m_readoutName{this, "readoutName", "ECalBarrelPhiEta", "Name of the detector readout"};
   /// Name of active volumes

--- a/RecCalorimeter/src/components/CreatePositionedCaloCells.cpp
+++ b/RecCalorimeter/src/components/CreatePositionedCaloCells.cpp
@@ -9,6 +9,7 @@
 
 // edm4hep
 #include "edm4hep/CalorimeterHit.h"
+#include <k4FWCore/MetadataUtils.h>
 
 DECLARE_COMPONENT(CreatePositionedCaloCells)
 
@@ -89,12 +90,12 @@ StatusCode CreatePositionedCaloCells::initialize() {
   }
 
   // Copy over the CellIDEncoding string from the input collection to the output collection
-  auto hitsEncoding = m_hitsCellIDEncoding.get_optional();
+  auto hitsEncoding = k4FWCore::getCellIDEncoding(m_hits.objKey(), this);
   if (!hitsEncoding.has_value()) {
     error() << "Missing cellID encoding for input collection" << endmsg;
     return StatusCode::FAILURE;
   }
-  m_cellsCellIDEncoding.put(hitsEncoding.value());
+  k4FWCore::putCellIDEncoding(m_cells.objKey(), hitsEncoding.value(), this);
   m_decoder = new dd4hep::DDSegmentation::BitFieldCoder(hitsEncoding.value());
 
   // these variables will be initilized in the execute() method

--- a/RecCalorimeter/src/components/CreatePositionedCaloCells.h
+++ b/RecCalorimeter/src/components/CreatePositionedCaloCells.h
@@ -1,11 +1,8 @@
 #ifndef RECCALORIMETER_CREATEPOSITIONEDCALOCELLS_H
 #define RECCALORIMETER_CREATEPOSITIONEDCALOCELLS_H
 
-#include "edm4hep/Constants.h"
-
 // k4FWCore
 #include "k4FWCore/DataHandle.h"
-#include "k4FWCore/MetaDataHandle.h"
 #include "k4Interface/ICalibrateCaloHitsTool.h"
 #include "k4Interface/ICaloReadCrosstalkMap.h"
 #include "k4Interface/ICalorimeterTool.h"
@@ -85,17 +82,11 @@ private:
 
   /// Handle for calo hits (input collection)
   mutable k4FWCore::DataHandle<edm4hep::SimCalorimeterHitCollection> m_hits{"hits", Gaudi::DataHandle::Reader, this};
-  /// Handle for the cellID encoding string of the input hit collection
-  k4FWCore::MetaDataHandle<std::string> m_hitsCellIDEncoding{m_hits, edm4hep::labels::CellIDEncoding,
-                                                             Gaudi::DataHandle::Reader};
   /// Handle for calo cells (output collection)
   mutable k4FWCore::DataHandle<edm4hep::CalorimeterHitCollection> m_cells{"cells", Gaudi::DataHandle::Writer, this};
   /// Handle for hit<->cell link (output collection)
   mutable k4FWCore::DataHandle<edm4hep::CaloHitSimCaloHitLinkCollection> m_links{"links", Gaudi::DataHandle::Writer,
                                                                                  this};
-  /// Handle for the cellID encoding of the output cell collection
-  k4FWCore::MetaDataHandle<std::string> m_cellsCellIDEncoding{m_cells, edm4hep::labels::CellIDEncoding,
-                                                              Gaudi::DataHandle::Writer};
   /// Maps of cell IDs (corresponding to DD4hep IDs) vs digitised cell energies
   mutable std::unordered_map<uint64_t, double> m_cellsMap;
   /// Maps of cell IDs (corresponding to DD4hep IDs) on transfer of signals due to crosstalk

--- a/RecFCCeeCalorimeter/src/components/AugmentClustersFCCee.cpp
+++ b/RecFCCeeCalorimeter/src/components/AugmentClustersFCCee.cpp
@@ -1,10 +1,12 @@
 #include "AugmentClustersFCCee.h"
 
 // k4FWCore
+#include "k4FWCore/MetadataUtils.h"
 #include "k4Interface/IGeoSvc.h"
 
 // edm4hep
 #include "edm4hep/ClusterCollection.h"
+#include "edm4hep/Constants.h"
 
 // DD4hep
 #include "DD4hep/Detector.h"
@@ -18,6 +20,7 @@
 #include "TMath.h"
 #include "TString.h"
 #include "TVector3.h"
+#include <edm4hep/Constants.h>
 
 DECLARE_COMPONENT(AugmentClustersFCCee)
 
@@ -115,7 +118,9 @@ StatusCode AugmentClustersFCCee::initialize() {
 
   // initialise the list of metadata for the clusters
   // append to the metadata of the input clusters (if any)
-  std::vector<std::string> showerShapeDecorations = m_inShapeParameterHandle.get({});
+  auto showerShapeDecorations = k4FWCore::getCollectionParameter<std::vector<std::string>>(
+                                    m_inClusters.objKey(), edm4hep::labels::ShapeParameterNames, this)
+                                    .value_or(std::vector<std::string>{});
   for (size_t k = 0; k < m_detectorNames.size(); k++) {
     const char* detector = m_detectorNames[k].c_str();
     for (unsigned layer = 0; layer < m_numLayers[k]; layer++) {
@@ -144,7 +149,8 @@ StatusCode AugmentClustersFCCee::initialize() {
   showerShapeDecorations.push_back("mass");   // cluster invariant mass assuming massless constituents
   showerShapeDecorations.push_back("ncells"); // number of cells in cluster with E>0
 
-  m_showerShapeHandle.put(showerShapeDecorations);
+  k4FWCore::putCollectionParameter(m_outClusters.objKey(), edm4hep::labels::ShapeParameterNames, showerShapeDecorations,
+                                   this);
 
   return StatusCode::SUCCESS;
 }

--- a/RecFCCeeCalorimeter/src/components/AugmentClustersFCCee.h
+++ b/RecFCCeeCalorimeter/src/components/AugmentClustersFCCee.h
@@ -1,11 +1,8 @@
 #ifndef RECFCCEECALORIMETER_AUGMENTCLUSTERSFCCEE_H
 #define RECFCCEECALORIMETER_AUGMENTCLUSTERSFCCEE_H
 
-#include "edm4hep/Constants.h"
-
 // Key4HEP
 #include "k4FWCore/DataHandle.h"
-#include "k4FWCore/MetaDataHandle.h"
 class IGeoSvc;
 
 // Gaudi
@@ -52,11 +49,6 @@ private:
   /// Handle for output clusters
   mutable k4FWCore::DataHandle<edm4hep::ClusterCollection> m_outClusters{"outClusters", Gaudi::DataHandle::Writer,
                                                                          this};
-  /// Handle for the cluster shape metadata to read and to write
-  k4FWCore::MetaDataHandle<std::vector<std::string>> m_inShapeParameterHandle{
-      m_inClusters, edm4hep::labels::ShapeParameterNames, Gaudi::DataHandle::Reader};
-  k4FWCore::MetaDataHandle<std::vector<std::string>> m_showerShapeHandle{
-      m_outClusters, edm4hep::labels::ShapeParameterNames, Gaudi::DataHandle::Writer};
 
   /// Pointer to the geometry service
   ServiceHandle<IGeoSvc> m_geoSvc;

--- a/RecFCCeeCalorimeter/src/components/CalibrateCaloClusters.cpp
+++ b/RecFCCeeCalorimeter/src/components/CalibrateCaloClusters.cpp
@@ -1,6 +1,7 @@
 #include "CalibrateCaloClusters.h"
 
 // Key4HEP
+#include "k4FWCore/MetadataUtils.h"
 #include "k4Interface/IGeoSvc.h"
 
 // FCC Detectors
@@ -13,6 +14,8 @@
 #include "edm4hep/CalorimeterHitCollection.h"
 #include "edm4hep/Cluster.h"
 #include "edm4hep/ClusterCollection.h"
+#include "edm4hep/Constants.h"
+
 #include <onnxruntime_cxx_api.h>
 
 #include "OnnxruntimeUtilities.h"
@@ -77,9 +80,12 @@ StatusCode CalibrateCaloClusters::initialize() {
 
   // read from the metadata the names of the shape parameters in the input clusters and append the total raw energy to
   // the output
-  std::vector<std::string> shapeParameters = m_inShapeParameterHandle.get({});
+  auto shapeParameters = k4FWCore::getCollectionParameter<std::vector<std::string>>(
+                             m_inClusters.objKey(), edm4hep::labels::ShapeParameterNames, this)
+                             .value_or(std::vector<std::string>{});
   shapeParameters.push_back("rawE");
-  m_outShapeParameterHandle.put(shapeParameters);
+
+  k4FWCore::putCollectionParameter(m_outClusters.objKey(), edm4hep::labels::ShapeParameterNames, shapeParameters, this);
 
   // check if the shape parameters contain the inputs needed for the calibration
   m_inputPositionsInShapeParameters.clear();

--- a/RecFCCeeCalorimeter/src/components/CalibrateCaloClusters.h
+++ b/RecFCCeeCalorimeter/src/components/CalibrateCaloClusters.h
@@ -1,11 +1,8 @@
 #ifndef RECFCCEECALORIMETER_CALIBRATECALOCLUSTERS_H
 #define RECFCCEECALORIMETER_CALIBRATECALOCLUSTERS_H
 
-#include "edm4hep/Constants.h"
-
 // Key4HEP
 #include "k4FWCore/DataHandle.h"
-#include "k4FWCore/MetaDataHandle.h"
 
 // Gaudi
 #include "GaudiKernel/Algorithm.h"
@@ -91,12 +88,6 @@ private:
   /// Handle for corrected (output) calorimeter clusters collection
   mutable k4FWCore::DataHandle<edm4hep::ClusterCollection> m_outClusters{"outClusters", Gaudi::DataHandle::Writer,
                                                                          this};
-
-  /// Handles for the cluster shower shape metadata to read and to write
-  k4FWCore::MetaDataHandle<std::vector<std::string>> m_inShapeParameterHandle{
-      m_inClusters, edm4hep::labels::ShapeParameterNames, Gaudi::DataHandle::Reader};
-  k4FWCore::MetaDataHandle<std::vector<std::string>> m_outShapeParameterHandle{
-      m_outClusters, edm4hep::labels::ShapeParameterNames, Gaudi::DataHandle::Writer};
 
   /// Pointer to the geometry service
   ServiceHandle<IGeoSvc> m_geoSvc;

--- a/RecFCCeeCalorimeter/src/components/CaloTopoClusterFCCee.cpp
+++ b/RecFCCeeCalorimeter/src/components/CaloTopoClusterFCCee.cpp
@@ -11,9 +11,12 @@
 // k4geo
 #include "detectorCommon/DetUtils_k4geo.h"
 
+#include "k4FWCore/MetadataUtils.h"
+
 // EDM4hep
 #include "edm4hep/CalorimeterHitCollection.h"
 #include "edm4hep/ClusterCollection.h"
+#include "edm4hep/Constants.h"
 
 // DD4hep
 #include "DD4hep/Readout.h"
@@ -88,7 +91,8 @@ StatusCode CaloTopoClusterFCCee::initialize() {
 
   // initialise the list of metadata for the clusters
   std::vector<std::string> shapeParameterNames = {"dR_over_E"};
-  m_shapeParametersHandle.put(shapeParameterNames);
+  k4FWCore::putCollectionParameter(m_clusterCollection.objKey(), edm4hep::labels::ShapeParameterNames,
+                                   shapeParameterNames, this);
 
   if (m_createClusterCellCollection) {
     std::vector<int> IDs;
@@ -101,9 +105,9 @@ StatusCode CaloTopoClusterFCCee::initialize() {
       colls.push_back(coll);
     }
 
-    if (IDs.size()==colls.size()) {
-      m_caloIDsMetaData.put(IDs);
-      m_cellsMetaData.put(colls);
+    if (IDs.size() == colls.size()) {
+      k4FWCore::putCollectionParameter(m_clusterCollection.objKey(), "inputSystemIDs", IDs, this);
+      k4FWCore::putCollectionParameter(m_clusterCollection.objKey(), "inputCellCollections", colls, this);
     } else {
       warning() << "Sizes of input cell and systemID collections of tower tool are different, no metadata written" << endmsg;
     }

--- a/RecFCCeeCalorimeter/src/components/CaloTopoClusterFCCee.h
+++ b/RecFCCeeCalorimeter/src/components/CaloTopoClusterFCCee.h
@@ -11,11 +11,8 @@
 #include "Gaudi/Algorithm.h"
 #include "GaudiKernel/ToolHandle.h"
 
-#include "edm4hep/Constants.h"
-
 // Key4HEP
 #include "k4FWCore/DataHandle.h"
-#include "k4FWCore/MetaDataHandle.h"
 #include "k4Interface/ICaloReadNeighboursMap.h"
 #include "k4Interface/IGeoSvc.h"
 #include "k4Interface/INoiseConstTool.h"
@@ -115,17 +112,9 @@ private:
   mutable k4FWCore::DataHandle<edm4hep::CalorimeterHitCollection> m_clusterCellsCollection{
       "clusterCells", Gaudi::DataHandle::Writer, this};
 
-  /// Output collection metadata handles (saving a map of ID:collection does not work)
-  k4FWCore::MetaDataHandle<std::vector<int>> m_caloIDsMetaData{m_clusterCollection, "inputSystemIDs",
-    Gaudi::DataHandle::Writer};
-  k4FWCore::MetaDataHandle<std::vector<std::string>> m_cellsMetaData{m_clusterCollection, "inputCellCollections",
-      Gaudi::DataHandle::Writer};
   Gaudi::Property<std::vector<int>> m_caloIDs{
     this, "calorimeterIDs", {}, "Corresponding list of calorimeter IDs"};
 
-  /// Handle for the cluster shape metadata to write
-  k4FWCore::MetaDataHandle<std::vector<std::string>> m_shapeParametersHandle{
-      m_clusterCollection, edm4hep::labels::ShapeParameterNames, Gaudi::DataHandle::Writer};
   /// Handle for the cells noise tool
   mutable ToolHandle<INoiseConstTool> m_noiseTool{"TopoCaloNoisyCells", this};
   /// Handle for neighbours tool

--- a/RecFCCeeCalorimeter/src/components/CreateCaloCellPositionsFCCee.cpp
+++ b/RecFCCeeCalorimeter/src/components/CreateCaloCellPositionsFCCee.cpp
@@ -1,6 +1,7 @@
 #include "CreateCaloCellPositionsFCCee.h"
 
 // k4FWCore
+#include "k4FWCore/MetadataUtils.h"
 #include "k4Interface/IGeoSvc.h"
 
 // k4geo
@@ -34,11 +35,11 @@ StatusCode CreateCaloCellPositionsFCCee::initialize() {
   }
 
   // Copy over the CellIDEncoding string from the input collection to the output collection
-  std::string hitsEncoding = m_hitsCellIDEncoding.get("");
-  if (hitsEncoding == "") {
+  auto hitsEncoding = k4FWCore::getCellIDEncoding(m_hits.objKey(), this);
+  if (!hitsEncoding.has_value()) {
     warning() << "Missing cellID encoding for input collection" << endmsg;
   }
-  m_positionedHitsCellIDEncoding.put(hitsEncoding);
+  k4FWCore::putCellIDEncoding(m_positionedHits.objKey(), hitsEncoding.value(), this);
 
   return StatusCode::SUCCESS;
 }

--- a/RecFCCeeCalorimeter/src/components/CreateCaloCellPositionsFCCee.h
+++ b/RecFCCeeCalorimeter/src/components/CreateCaloCellPositionsFCCee.h
@@ -3,7 +3,6 @@
 
 // k4FWCore
 #include "k4FWCore/DataHandle.h"
-#include "k4FWCore/MetaDataHandle.h"
 #include "k4Interface/ICellPositionsTool.h"
 
 // Gaudi
@@ -13,7 +12,6 @@
 // edm4hep
 #include "edm4hep/CalorimeterHit.h"
 #include "edm4hep/CalorimeterHitCollection.h"
-#include "edm4hep/Constants.h"
 
 #include <unordered_map>
 
@@ -51,15 +49,9 @@ private:
   ToolHandle<ICellPositionsTool> m_cellPositionsTool{};
   /// Input collection
   mutable k4FWCore::DataHandle<edm4hep::CalorimeterHitCollection> m_hits{"hits/hits", Gaudi::DataHandle::Reader, this};
-  /// Input collection metadata handle
-  k4FWCore::MetaDataHandle<std::string> m_hitsCellIDEncoding{m_hits, edm4hep::labels::CellIDEncoding,
-                                                             Gaudi::DataHandle::Reader};
   /// Output collection
   mutable k4FWCore::DataHandle<edm4hep::CalorimeterHitCollection> m_positionedHits{"hits/positionedHits",
                                                                                    Gaudi::DataHandle::Writer, this};
-  /// Output collection metadata handle
-  k4FWCore::MetaDataHandle<std::string> m_positionedHitsCellIDEncoding{
-      m_positionedHits, edm4hep::labels::CellIDEncoding, Gaudi::DataHandle::Writer};
 
   // Cache
   mutable std::unordered_map<dd4hep::DDSegmentation::CellID, edm4hep::Vector3f> m_positions_cache{};

--- a/RecFCCeeCalorimeter/src/components/CreateCaloClustersSlidingWindowFCCee.cpp
+++ b/RecFCCeeCalorimeter/src/components/CreateCaloClustersSlidingWindowFCCee.cpp
@@ -1,6 +1,8 @@
 #include "CreateCaloClustersSlidingWindowFCCee.h"
 #include "CaloTowerToolFCCee.h"
 
+#include <k4FWCore/MetadataUtils.h>
+
 // Gaudi
 #include "GaudiKernel/PhysicalConstants.h"
 
@@ -47,8 +49,8 @@ StatusCode CreateCaloClustersSlidingWindowFCCee::initialize() {
       std::vector<int> IDs = tool->getInputSystemIDs();
       std::vector<std::string> colls = tool->getInputCollections();
       if (IDs.size() == colls.size()) {
-        m_caloIDsMetaData.put(IDs);
-        m_cellsMetaData.put(colls);
+        k4FWCore::putCollectionParameter(m_clusters.objKey(), "inputSystemIDs", IDs, this);
+        k4FWCore::putCollectionParameter(m_clusters.objKey(), "inputCellCollections", colls, this);
       } else {
         warning() << "Sizes of input cell and systemID collections of tower tool are different, no metadata written"
                   << endmsg;

--- a/RecFCCeeCalorimeter/src/components/CreateCaloClustersSlidingWindowFCCee.h
+++ b/RecFCCeeCalorimeter/src/components/CreateCaloClustersSlidingWindowFCCee.h
@@ -7,7 +7,6 @@
 
 // k4FWCore
 #include "k4FWCore/DataHandle.h"
-#include "k4FWCore/MetaDataHandle.h"
 #include "k4Interface/ITowerToolThetaModule.h"
 
 // edm4hep
@@ -92,10 +91,6 @@ private:
   /// Handle for calo cluster cells (output collection)
   mutable k4FWCore::DataHandle<edm4hep::CalorimeterHitCollection> m_clusterCells{"calo/clusterCells",
                                                                                  Gaudi::DataHandle::Writer, this};
-  /// Output collection metadata handles (saving a map of ID:collection does not work)
-  k4FWCore::MetaDataHandle<std::vector<int>> m_caloIDsMetaData{m_clusters, "inputSystemIDs", Gaudi::DataHandle::Writer};
-  k4FWCore::MetaDataHandle<std::vector<std::string>> m_cellsMetaData{m_clusters, "inputCellCollections",
-                                                                     Gaudi::DataHandle::Writer};
   /// Handle for the tower building tool
   mutable ToolHandle<ITowerToolThetaModule> m_towerTool;
   /// Calorimeter towers

--- a/RecFCCeeCalorimeter/src/components/PhotonIDTool.cpp
+++ b/RecFCCeeCalorimeter/src/components/PhotonIDTool.cpp
@@ -1,8 +1,11 @@
 #include "PhotonIDTool.h"
 
+#include "k4FWCore/MetadataUtils.h"
+
 // our EDM
 #include "edm4hep/Cluster.h"
 #include "edm4hep/ClusterCollection.h"
+#include "edm4hep/Constants.h"
 
 #include <fstream>
 
@@ -38,7 +41,9 @@ StatusCode PhotonIDTool::initialize() {
   }
 
   // read from the metadata the names of the shape parameters in the input clusters
-  std::vector<std::string> shapeParameters = m_inShapeParameterHandle.get({});
+  auto shapeParameters = k4FWCore::getCollectionParameter<std::vector<std::string>>(
+                             m_inClusters.objKey(), edm4hep::labels::ShapeParameterNames, this)
+                             .value_or(std::vector<std::string>{});
   debug() << "Variables in shapeParameters of input clusters:" << endmsg;
   for (const auto& str : shapeParameters) {
     debug() << str << endmsg;
@@ -79,7 +84,7 @@ StatusCode PhotonIDTool::initialize() {
 
   // append the MVA score to the output shape parameters
   shapeParameters.push_back("photonIDscore");
-  m_outShapeParameterHandle.put(shapeParameters);
+  k4FWCore::putCollectionParameter(m_outClusters.objKey(), edm4hep::labels::ShapeParameterNames, shapeParameters, this);
 
   info() << "Initialized the photonID MVA tool" << endmsg;
   return StatusCode::SUCCESS;

--- a/RecFCCeeCalorimeter/src/components/PhotonIDTool.h
+++ b/RecFCCeeCalorimeter/src/components/PhotonIDTool.h
@@ -1,11 +1,8 @@
 #ifndef RECFCCEECALORIMETER_PHOTONIDTOOL_H
 #define RECFCCEECALORIMETER_PHOTONIDTOOL_H
 
-#include "edm4hep/Constants.h"
-
 // Key4HEP
 #include "k4FWCore/DataHandle.h"
-#include "k4FWCore/MetaDataHandle.h"
 
 // Gaudi
 #include "GaudiKernel/Algorithm.h"
@@ -79,12 +76,6 @@ private:
   /// Handle for output calorimeter clusters collection
   mutable k4FWCore::DataHandle<edm4hep::ClusterCollection> m_outClusters{"outClusters", Gaudi::DataHandle::Writer,
                                                                          this};
-
-  /// Handles for the cluster shower shape metadata to read and to write
-  k4FWCore::MetaDataHandle<std::vector<std::string>> m_inShapeParameterHandle{
-      m_inClusters, edm4hep::labels::ShapeParameterNames, Gaudi::DataHandle::Reader};
-  k4FWCore::MetaDataHandle<std::vector<std::string>> m_outShapeParameterHandle{
-      m_outClusters, edm4hep::labels::ShapeParameterNames, Gaudi::DataHandle::Writer};
 
   /// Files with the MVA model and list of inputs
   Gaudi::Property<std::string> m_mvaModelFile{this, "mvaModelFile", {}, "ONNX file with the mva model"};


### PR DESCRIPTION

BEGINRELEASENOTES
- Replace the `k4FWCore::MetadataHandle` with the utilities from `k4FWCore/MetadataUtils.h`

ENDRELEASENOTES

- [ ] Needs https://github.com/key4hep/k4FWCore/pull/391
