### PR TITLE
add tests for FCC-hh digitisation, reconstruction and positions

### DIFF
--- a/RecCalorimeter/src/components/CreateCaloCells.cpp
+++ b/RecCalorimeter/src/components/CreateCaloCells.cpp
@@ -241,8 +241,10 @@ void CreateCaloCells::findCaloTypes()
         layout = 1;
       } else if (detType.is(dd4hep::DetType::ENDCAP)) {
         layout = 2;
+      } else if (detType.is(dd4hep::DetType::FORWARD)) {
+        layout = 3;
       } else {
-        warning() << "Detector type for calorimeter " << id << " is neither BARREL nor ENDCAP" << endmsg;
+        warning() << "Detector type for calorimeter " << id << " is neither BARREL nor ENDCAP nor FORWARD" << endmsg;
       }
 
       if (static_cast<int>(m_caloTypes.size()) <= id) {

--- a/RecCalorimeter/src/components/CreatePositionedCaloCells.cpp
+++ b/RecCalorimeter/src/components/CreatePositionedCaloCells.cpp
@@ -212,6 +212,8 @@ StatusCode CreatePositionedCaloCells::execute(const EventContext&) const {
             m_layout = 1;
           } else if (detType.is(dd4hep::DetType::ENDCAP)) {
             m_layout = 2;
+          } else if (detType.is(dd4hep::DetType::FORWARD)) {
+            layout = 3;
           } else {
             warning() << "Detector type is neither BARREL nor ENDCAP" << endmsg;
           }

--- a/RecCalorimeter/src/components/CreatePositionedCaloCells.cpp
+++ b/RecCalorimeter/src/components/CreatePositionedCaloCells.cpp
@@ -213,7 +213,7 @@ StatusCode CreatePositionedCaloCells::execute(const EventContext&) const {
           } else if (detType.is(dd4hep::DetType::ENDCAP)) {
             m_layout = 2;
           } else if (detType.is(dd4hep::DetType::FORWARD)) {
-            layout = 3;
+            m_layout = 3;
           } else {
             warning() << "Detector type is neither BARREL nor ENDCAP" << endmsg;
           }

--- a/RecFCChhCalorimeter/CMakeLists.txt
+++ b/RecFCChhCalorimeter/CMakeLists.txt
@@ -27,6 +27,12 @@ install(TARGETS k4RecFCChhCalorimeterPlugins
 
 install(DIRECTORY ${CMAKE_CURRENT_LIST_DIR}/tests DESTINATION ${CMAKE_INSTALL_DATADIR}/${CMAKE_PROJECT_NAME}/RecFCChhCalorimeter)
 
+add_test(NAME FCChhBaselineSimDigiReco
+         COMMAND ${PROJECT_SOURCE_DIR}/RecFCChhCalorimeter/tests/options/FCChhBaselineSimDigiReco.sh
+         WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/Testing/Temporary
+)
+set_test_env(FCChhBaselineSimDigiReco)
+# set_tests_properties(FCChhBaselineSimDigiReco PROPERTIES FIXTURES_REQUIRED FCChhBaseline_sim_files)
 
 #gaudi_add_test(simulateFullCaloSystemForCellPositions
 #	       WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}

--- a/RecFCChhCalorimeter/CMakeLists.txt
+++ b/RecFCChhCalorimeter/CMakeLists.txt
@@ -32,16 +32,15 @@ add_test(NAME FCChhBaselineSimDigiReco
          WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/Testing/Temporary
 )
 set_test_env(FCChhBaselineSimDigiReco)
-# set_tests_properties(FCChhBaselineSimDigiReco PROPERTIES FIXTURES_REQUIRED FCChhBaseline_sim_files)
+set_tests_properties(FCChhBaselineSimDigiReco PROPERTIES FIXTURES_SETUP FCChhBaseline_digi_files)
 
-#gaudi_add_test(simulateFullCaloSystemForCellPositions
-#	       WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
-#	       FRAMEWORK ../RecCalorimeter/tests/options/runFullCaloSystem_SimAndDigitisation.py)
-#
-#gaudi_add_test(reconstructFullCaloSystemCellPositions
-#               WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
-#	       DEPENDS simulateFullCaloSystemForCellPositions
-#	       FRAMEWORK tests/options/recoPositions_fullCaloSystem.py)
+add_test(NAME FCChhBaselineCellPositions
+         COMMAND ${PROJECT_SOURCE_DIR}/RecFCChhCalorimeter/tests/options/FCChhBaselineCellPositions.sh
+         WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/Testing/Temporary
+)
+set_test_env(FCChhBaselineCellPositions)
+set_tests_properties(FCChhBaselineCellPositions PROPERTIES FIXTURES_REQUIRED FCChhBaseline_digi_files)
+
 #
 #gaudi_add_test(buildingCellNoiseMap
 #               WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}

--- a/RecFCChhCalorimeter/tests/options/FCChhBaselineCellPositions.sh
+++ b/RecFCChhCalorimeter/tests/options/FCChhBaselineCellPositions.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# Check that the Key4hep environment is set
+if [[ -z "${KEY4HEP_STACK}" ]]; then
+  echo "Error: Key4hep environment not set"
+  exit 1
+fi
+
+# run the script with the cell positioning tools
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd ) # workaround to have ctests working
+k4run $SCRIPT_DIR/recoPositions_fullCaloSystem.py --IOSvc.Input=FCChh_sim_digi_reco_e.root --IOSvc.Output=FCChh_cell_positions_e.root || exit 1
+k4run $SCRIPT_DIR/recoPositions_fullCaloSystem.py --IOSvc.Input=FCChh_sim_digi_reco_pi.root --IOSvc.Output=FCChh_cell_positions_pi.root || exit 1

--- a/RecFCChhCalorimeter/tests/options/FCChhBaselineSimDigiReco.sh
+++ b/RecFCChhCalorimeter/tests/options/FCChhBaselineSimDigiReco.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+
+# set this to 1 to use ee->Z->qq Pythia events, or 0 to use particle guns for e and pi, barrel and endcap
+# this only applies to the reconstruction. Simulation will be run on both ee->Z->qq events and on particle
+# guns, since the output files are used by other reco scripts in this package
+usePythia=0
+
+# Define the unction for downloading files
+# Attempt to download the file using wget, exit the script if wget failed
+download_file() {
+  local url="$1"
+  wget "$url" || { echo "Download failed"; exit 1; }
+}
+
+# Check that the Key4hep environment is set
+if [[ -z "${KEY4HEP_STACK}" ]]; then
+  echo "Error: Key4hep environment not set"
+  exit 1
+fi
+
+# run the SIM step (for debug do not run it if files already present. Comment the if and fi lines for production)
+if [ "$usePythia" -gt 0 ]; then
+    # Z->qq
+    # download the events to reconstruct
+    if ! test -f ./pythia_ee_z_qq_10evt.hepmc; then
+	echo "Downloading files needed for simulation"
+	download_file "https://fccsw.web.cern.ch/fccsw/filesForSimDigiReco/gen/pythia_ee_z_qq_10evt.hepmc"
+    fi
+    # run ddsim
+    if ! test -f ALLEGRO_sim_ee_z_qq.root; then
+	echo "Performing the Geant4 simulation with ddsim"
+	ddsim --inputFiles pythia_ee_z_qq_10evt.hepmc --numberOfEvents 5 --outputFile FCChh_sim_ee_z_qq.root --compactFile $K4GEO/FCChh/compact/FCChhBaseline/FCChh_DectMaster.xml || { retcode=$? ; echo "Simulation failed" ; exit $retcode ; }
+    fi
+else
+    # particle gun (for debug do not run it if files already present. Comment the if and fi lines for production)
+    if ! test -f FCChh_sim_e.root; then
+	echo "Generating events and performing the Geant4 simulation with ddsim"
+	ddsim --enableGun --gun.distribution uniform --gun.momentumMin "50*GeV" --gun.momentumMax "50*GeV" --gun.thetaMin "0.5*deg" --gun.thetaMax "1.5*deg" --gun.particle e- --numberOfEvents 2 --outputFile FCChh_sim_e.root --random.enableEventSeed --random.seed 4255 --compactFile $K4GEO/FCChh/compact/FCChhBaseline/FCChh_DectMaster.xml || exit 1
+	ddsim --enableGun --gun.distribution uniform --gun.momentumMin "20*GeV" --gun.momentumMax "20*GeV" --gun.thetaMin "80*deg" --gun.thetaMax "100*deg" --gun.particle pi+ --numberOfEvents 2 --outputFile FCChh_sim_pi.root --random.enableEventSeed --random.seed 4255 --compactFile $K4GEO/FCChh/compact/FCChhBaseline/FCChh_DectMaster.xml || exit 1
+    fi
+fi
+
+
+# get the files needed for calibration, noise, neighbor finding, etc
+# if ! test -f ./cellNoise_map_endcapTurbine_electronicsNoiseLevel.root; then  # assumes that if the last file exists, all the other as well
+#   echo "Downloading files needed for reconstruction"
+#   download_file "https://fccsw.web.cern.ch/fccsw/filesForSimDigiReco/ALLEGRO/ALLEGRO_o1_v03/capacitances_ecalBarrelFCCee_theta.root"
+#   download_file "https://fccsw.web.cern.ch/fccsw/filesForSimDigiReco/ALLEGRO/ALLEGRO_o1_v03/cellNoise_map_electronicsNoiseLevel_ecalB_thetamodulemerged.root"
+#   download_file "https://fccsw.web.cern.ch/fccsw/filesForSimDigiReco/ALLEGRO/ALLEGRO_o1_v03/cellNoise_map_electronicsNoiseLevel_ecalB_thetamodulemerged_hcalB_thetaphi.root"
+#   download_file "https://fccsw.web.cern.ch/fccsw/filesForSimDigiReco/ALLEGRO/ALLEGRO_o1_v03/cellNoise_map_electronicsNoiseLevel_ecalB_ECalBarrelModuleThetaMerged_ecalE_ECalEndcapTurbine_hcalB_HCalBarrelReadout_hcalE_HCalEndcapReadout.root"
+#   download_file "https://fccsw.web.cern.ch/fccsw/filesForSimDigiReco/ALLEGRO/ALLEGRO_o1_v03/elecNoise_ecalBarrelFCCee_theta.root"
+#   download_file "https://fccsw.web.cern.ch/fccsw/filesForSimDigiReco/ALLEGRO/ALLEGRO_o1_v03/lgbm_calibration-CaloClusters.onnx"
+#   download_file "https://fccsw.web.cern.ch/fccsw/filesForSimDigiReco/ALLEGRO/ALLEGRO_o1_v03/lgbm_calibration-CaloTopoClusters.onnx"
+#   download_file "https://fccsw.web.cern.ch/fccsw/filesForSimDigiReco/ALLEGRO/ALLEGRO_o1_v03/neighbours_map_ecalB_thetamodulemerged.root"
+#   download_file "https://fccsw.web.cern.ch/fccsw/filesForSimDigiReco/ALLEGRO/ALLEGRO_o1_v03/neighbours_map_ecalE_turbine.root"
+#   download_file "https://fccsw.web.cern.ch/fccsw/filesForSimDigiReco/ALLEGRO/ALLEGRO_o1_v03/neighbours_map_ecalB_thetamodulemerged_ecalE_turbine_hcalB_hcalEndcap_phitheta.root"
+#   download_file "https://fccsw.web.cern.ch/fccsw/filesForSimDigiReco/ALLEGRO/ALLEGRO_o1_v03/cellNoise_map_endcapTurbine_electronicsNoiseLevel.root"
+
+  # add here the lines to get the files for the photon ID
+# fi
+
+# run the RECO step
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd ) # workaround to have ctests working
+if [ "$usePythia" -gt 0 ]; then
+    k4run $SCRIPT_DIR/runFullCaloSystem_Digitisation.py
+else
+    #   k4run $SCRIPT_DIR/runFullCaloSystem_Digitisation.py --IOSvc.Input=FCChh_sim_e.root --IOSvc.Output=FCChh_sim_digi_reco_e.root || exit 1
+    k4run $SCRIPT_DIR/runFullCaloSystem_Digitisation.py --IOSvc.Input=FCChh_sim_pi.root --IOSvc.Output=FCChh_sim_digi_reco_pi.root || exit 1
+fi

--- a/RecFCChhCalorimeter/tests/options/FCChhBaselineSimDigiReco.sh
+++ b/RecFCChhCalorimeter/tests/options/FCChhBaselineSimDigiReco.sh
@@ -5,7 +5,7 @@
 # guns, since the output files are used by other reco scripts in this package
 usePythia=0
 
-# Define the unction for downloading files
+# Define the function for downloading files
 # Attempt to download the file using wget, exit the script if wget failed
 download_file() {
   local url="$1"
@@ -40,30 +40,23 @@ else
     fi
 fi
 
-
-# get the files needed for calibration, noise, neighbor finding, etc
-# if ! test -f ./cellNoise_map_endcapTurbine_electronicsNoiseLevel.root; then  # assumes that if the last file exists, all the other as well
-#   echo "Downloading files needed for reconstruction"
-#   download_file "https://fccsw.web.cern.ch/fccsw/filesForSimDigiReco/ALLEGRO/ALLEGRO_o1_v03/capacitances_ecalBarrelFCCee_theta.root"
-#   download_file "https://fccsw.web.cern.ch/fccsw/filesForSimDigiReco/ALLEGRO/ALLEGRO_o1_v03/cellNoise_map_electronicsNoiseLevel_ecalB_thetamodulemerged.root"
-#   download_file "https://fccsw.web.cern.ch/fccsw/filesForSimDigiReco/ALLEGRO/ALLEGRO_o1_v03/cellNoise_map_electronicsNoiseLevel_ecalB_thetamodulemerged_hcalB_thetaphi.root"
-#   download_file "https://fccsw.web.cern.ch/fccsw/filesForSimDigiReco/ALLEGRO/ALLEGRO_o1_v03/cellNoise_map_electronicsNoiseLevel_ecalB_ECalBarrelModuleThetaMerged_ecalE_ECalEndcapTurbine_hcalB_HCalBarrelReadout_hcalE_HCalEndcapReadout.root"
-#   download_file "https://fccsw.web.cern.ch/fccsw/filesForSimDigiReco/ALLEGRO/ALLEGRO_o1_v03/elecNoise_ecalBarrelFCCee_theta.root"
-#   download_file "https://fccsw.web.cern.ch/fccsw/filesForSimDigiReco/ALLEGRO/ALLEGRO_o1_v03/lgbm_calibration-CaloClusters.onnx"
-#   download_file "https://fccsw.web.cern.ch/fccsw/filesForSimDigiReco/ALLEGRO/ALLEGRO_o1_v03/lgbm_calibration-CaloTopoClusters.onnx"
-#   download_file "https://fccsw.web.cern.ch/fccsw/filesForSimDigiReco/ALLEGRO/ALLEGRO_o1_v03/neighbours_map_ecalB_thetamodulemerged.root"
-#   download_file "https://fccsw.web.cern.ch/fccsw/filesForSimDigiReco/ALLEGRO/ALLEGRO_o1_v03/neighbours_map_ecalE_turbine.root"
-#   download_file "https://fccsw.web.cern.ch/fccsw/filesForSimDigiReco/ALLEGRO/ALLEGRO_o1_v03/neighbours_map_ecalB_thetamodulemerged_ecalE_turbine_hcalB_hcalEndcap_phitheta.root"
-#   download_file "https://fccsw.web.cern.ch/fccsw/filesForSimDigiReco/ALLEGRO/ALLEGRO_o1_v03/cellNoise_map_endcapTurbine_electronicsNoiseLevel.root"
-
-  # add here the lines to get the files for the photon ID
-# fi
-
-# run the RECO step
+# run the DIGI step
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd ) # workaround to have ctests working
 if [ "$usePythia" -gt 0 ]; then
-    k4run $SCRIPT_DIR/runFullCaloSystem_Digitisation.py
+    k4run $SCRIPT_DIR/runFullCaloSystem_Digitisation.py || exit 1
 else
-    #   k4run $SCRIPT_DIR/runFullCaloSystem_Digitisation.py --IOSvc.Input=FCChh_sim_e.root --IOSvc.Output=FCChh_sim_digi_reco_e.root || exit 1
-    k4run $SCRIPT_DIR/runFullCaloSystem_Digitisation.py --IOSvc.Input=FCChh_sim_pi.root --IOSvc.Output=FCChh_sim_digi_reco_pi.root || exit 1
+    if ! test -f FCChh_sim_digi_e.root; then
+	k4run $SCRIPT_DIR/runFullCaloSystem_Digitisation.py --IOSvc.Input=FCChh_sim_e.root --IOSvc.Output=FCChh_sim_digi_e.root || exit 1
+	k4run $SCRIPT_DIR/runFullCaloSystem_Digitisation.py --IOSvc.Input=FCChh_sim_pi.root --IOSvc.Output=FCChh_sim_digi_pi.root || exit 1
+    fi
+fi
+
+# run the RECO step
+if [ "$usePythia" -gt 0 ]; then
+    k4run $SCRIPT_DIR/runFullCaloSystem_ReconstructionSW_noNoise.py || exit 1
+else
+    if ! test -f FCChh_sim_digi_reco_e.root; then
+	k4run $SCRIPT_DIR/runFullCaloSystem_ReconstructionSW_noNoise.py --IOSvc.Input=FCChh_sim_digi_e.root --IOSvc.Output=FCChh_sim_digi_reco_e.root || exit 1
+	k4run $SCRIPT_DIR/runFullCaloSystem_ReconstructionSW_noNoise.py --IOSvc.Input=FCChh_sim_digi_pi.root --IOSvc.Output=FCChh_sim_digi_reco_pi.root || exit 1
+    fi
 fi

--- a/RecFCChhCalorimeter/tests/options/recoPositions_fullCaloSystem.py
+++ b/RecFCChhCalorimeter/tests/options/recoPositions_fullCaloSystem.py
@@ -1,6 +1,69 @@
-from Gaudi.Configuration import *
+# Number of events
+Nevts = 3
+# input/output files
+inputfile = "output_fullCalo_SimDigi_e_50GeV_"+str(Nevts)+"events.root"
+outputfile = "digi_cellPositions_50GeVelectrons.root"
 
-from Configurables import ApplicationMgr, k4DataSvc, PodioOutput
+#
+# ALGORITHMS AND SERVICES SETUP
+#
+TopAlg = []  # alg sequence
+ExtSvc = []  # list of external services
+
+from Gaudi.Configuration import INFO, WARNING, DEBUG
+
+# Event counter
+from Configurables import EventCounter
+eventCounter = EventCounter("EventCounter",
+                            OutputLevel=INFO,
+                            Frequency=1)
+TopAlg += [eventCounter]
+
+# CPU information
+from Configurables import AuditorSvc, ChronoAuditor
+chra = ChronoAuditor()
+audsvc = AuditorSvc()
+audsvc.Auditors = [chra]
+ExtSvc += [audsvc]
+
+# Detector geometry
+# prefix all xmls with path_to_detector
+# if K4GEO is empty, this should use relative path to working directory
+from Configurables import GeoSvc
+import os
+geoservice = GeoSvc("GeoSvc",
+                    OutputLevel=WARNING
+                    )
+
+path_to_detector = os.environ.get("K4GEO", "") + "/FCChh/compact/FCChhBaseline/"
+detectors_to_use = [
+    'FCChh_DectMaster.xml'
+]
+geoservice.detectors = [
+    os.path.join(path_to_detector, _det) for _det in detectors_to_use
+]
+
+#detectors_to_use=['file:Detector/DetFCChhBaseline1/compact/FCChh_DectEmptyMaster.xml',
+#                  # Tracker disabled to save cpu time
+#                  #'file:Detector/DetFCChhTrackerTkLayout/compact/Tracker.xml',
+#                  'file:Detector/DetFCChhECalInclined/compact/FCChh_ECalBarrel_withCryostat.xml',
+#                  'file:Detector/DetFCChhHCalTile/compact/FCChh_HCalBarrel_TileCal.xml',
+#                  'file:Detector/DetFCChhHCalTile/compact/FCChh_HCalExtendedBarrel_TileCal.xml',
+#                  'file:Detector/DetFCChhCalDiscs/compact/Endcaps_coneCryo.xml',
+#                  'file:Detector/DetFCChhCalDiscs/compact/Forward_coneCryo.xml',
+#                  ]
+# geoservice.detector = detectors_to_use
+ExtSvc += [geoservice]
+
+# Input/Output handling
+from k4FWCore import IOSvc
+from Configurables import EventDataSvc
+io_svc = IOSvc("IOSvc")
+io_svc.Input = inputfile
+io_svc.Output = outputfile
+ExtSvc += [EventDataSvc("EventDataSvc")]
+
+# Configure tools for calo reconstruction
 
 # ECAL readouts
 ecalBarrelReadoutName = "ECalBarrelEta"
@@ -15,48 +78,29 @@ hcalFwdReadoutName = "HFwdPhiEtaReco"
 # Number of events
 num_events = 3
 
-podioevent = k4DataSvc("EventDataSvc", input="output_fullCalo_SimAndDigi_e50GeV_"+str(num_events)+"events.root")
-
-# reads HepMC text file and write the HepMC::GenEvent to the data service
-from Configurables import PodioInput
-podioinput = PodioInput("PodioReader", collections = ["ECalBarrelCells", "HCalBarrelCells", "HCalExtBarrelCells", "ECalEndcapCells", "HCalEndcapCells", "ECalFwdCells", "HCalFwdCells"], OutputLevel = DEBUG)
-
-from Configurables import GeoSvc
-detectors_to_use=['file:Detector/DetFCChhBaseline1/compact/FCChh_DectEmptyMaster.xml',
-                  # Tracker disabled to save cpu time
-                  #'file:Detector/DetFCChhTrackerTkLayout/compact/Tracker.xml',
-                  'file:Detector/DetFCChhECalInclined/compact/FCChh_ECalBarrel_withCryostat.xml',
-                  'file:Detector/DetFCChhHCalTile/compact/FCChh_HCalBarrel_TileCal.xml',
-                  'file:Detector/DetFCChhHCalTile/compact/FCChh_HCalExtendedBarrel_TileCal.xml',
-                  'file:Detector/DetFCChhCalDiscs/compact/Endcaps_coneCryo.xml',
-                  'file:Detector/DetFCChhCalDiscs/compact/Forward_coneCryo.xml',
-                  ]
-
-geoservice = GeoSvc("GeoSvc", detectors = detectors_to_use, OutputLevel = WARNING)
-
-#Configure tools for calo cell positions
+# Configure tools for calo cell positions
 from Configurables import CellPositionsECalBarrelTool, CellPositionsHCalBarrelNoSegTool, CellPositionsCaloDiscsTool, CellPositionsTailCatcherTool 
 ECalBcells = CellPositionsECalBarrelTool("CellPositionsECalBarrel", 
                                          readoutName = ecalBarrelReadoutNamePhiEta, 
                                          OutputLevel = INFO)
 EMECcells = CellPositionsCaloDiscsTool("CellPositionsEMEC", 
-                                    readoutName = ecalEndcapReadoutName, 
-                                    OutputLevel = INFO)
-ECalFwdcells = CellPositionsCaloDiscsTool("CellPositionsECalFwd", 
-                                        readoutName = ecalFwdReadoutName, 
-                                        OutputLevel = INFO)
-HCalBcells = CellPositionsHCalBarrelNoSegTool("CellPositionsHCalBarrel", 
-                                    readoutName = hcalBarrelReadoutName, 
-                                    OutputLevel = INFO)
-HCalExtBcells = CellPositionsHCalBarrelNoSegTool("CellPositionsHCalExtBarrel", 
-                                       readoutName = hcalExtBarrelReadoutName, 
+                                       readoutName = ecalEndcapReadoutName, 
                                        OutputLevel = INFO)
+ECalFwdcells = CellPositionsCaloDiscsTool("CellPositionsECalFwd", 
+                                          readoutName = ecalFwdReadoutName, 
+                                          OutputLevel = INFO)
+HCalBcells = CellPositionsHCalBarrelNoSegTool("CellPositionsHCalBarrel", 
+                                              readoutName = hcalBarrelReadoutName, 
+                                              OutputLevel = INFO)
+HCalExtBcells = CellPositionsHCalBarrelNoSegTool("CellPositionsHCalExtBarrel", 
+                                                 readoutName = hcalExtBarrelReadoutName, 
+                                                 OutputLevel = INFO)
 HECcells = CellPositionsCaloDiscsTool("CellPositionsHEC", 
-                                   readoutName = hcalEndcapReadoutName, 
-                                   OutputLevel = INFO)
+                                      readoutName = hcalEndcapReadoutName, 
+                                      OutputLevel = INFO)
 HCalFwdcells = CellPositionsCaloDiscsTool("CellPositionsHCalFwd", 
-                                        readoutName = hcalFwdReadoutName, 
-                                        OutputLevel = INFO)
+                                          readoutName = hcalFwdReadoutName, 
+                                          OutputLevel = INFO)
 
 # cell positions
 from Configurables import CreateCellPositions
@@ -71,10 +115,10 @@ positionsHcalBarrel = CreateCellPositions("positionsHcalBarrel",
                                           positionedHits = "HCalBarrelCellPositions", 
                                           OutputLevel = INFO)
 positionsHcalExtBarrel = CreateCellPositions("positionsHcalExtBarrel", 
-                                          positionsTool=HCalExtBcells, 
-                                          hits = "HCalExtBarrelCells", 
-                                          positionedHits = "HCalExtBarrelCellPositions", 
-                                          OutputLevel = INFO)
+                                             positionsTool=HCalExtBcells, 
+                                             hits = "HCalExtBarrelCells", 
+                                             positionedHits = "HCalExtBarrelCellPositions", 
+                                             OutputLevel = INFO)
 positionsEcalEndcap = CreateCellPositions("positionsEcalEndcap", 
                                           positionsTool=EMECcells, 
                                           hits = "ECalEndcapCells", 
@@ -86,47 +130,40 @@ positionsHcalEndcap = CreateCellPositions("positionsHcalEndcap",
                                           positionedHits = "HCalEndcapCellPositions", 
                                           OutputLevel = INFO)
 positionsEcalFwd = CreateCellPositions("positionsEcalFwd", 
-                                          positionsTool=ECalFwdcells, 
-                                          hits = "ECalFwdCells", 
-                                          positionedHits = "ECalFwdCellPositions", 
-                                          OutputLevel = INFO)
+                                       positionsTool=ECalFwdcells, 
+                                       hits = "ECalFwdCells", 
+                                       positionedHits = "ECalFwdCellPositions", 
+                                       OutputLevel = INFO)
 positionsHcalFwd = CreateCellPositions("positionsHcalFwd", 
-                                          positionsTool=HCalFwdcells, 
-                                          hits = "HCalFwdCells", 
-                                          positionedHits = "HCalFwdCellPositions", 
-                                          OutputLevel = INFO)
+                                       positionsTool=HCalFwdcells, 
+                                       hits = "HCalFwdCells", 
+                                       positionedHits = "HCalFwdCellPositions", 
+                                       OutputLevel = INFO)
 
-out = PodioOutput("out", OutputLevel=DEBUG)
-out.filename = "digi_cellPositions_50GeVelectrons.root"
-out.outputCommands = ["keep *","drop ECalBarrelCells","drop ECalEndcapCells","drop ECalFwdCells","drop HCalBarrelCells", "drop HCalExtBarrelCells", "drop HCalEndcapCells", "drop HCalFwdCells"]
+TopAlg += [    
+    positionsEcalBarrel,
+    positionsEcalEndcap,
+    positionsEcalFwd, 
+    positionsHcalBarrel, 
+    positionsHcalExtBarrel,
+    positionsHcalEndcap, 
+    positionsHcalFwd,
+]
 
-#CPU information
-from Configurables import AuditorSvc, ChronoAuditor
-chra = ChronoAuditor()
-audsvc = AuditorSvc()
-audsvc.Auditors = [chra]
-podioinput.AuditExecute = True
-positionsEcalBarrel.AuditExecute = True
-positionsEcalEndcap.AuditExecute = True
-positionsEcalFwd.AuditExecute = True
-positionsHcalBarrel.AuditExecute = True
-positionsHcalExtBarrel.AuditExecute = True
-positionsHcalEndcap.AuditExecute = True
-positionsHcalFwd.AuditExecute = True
-out.AuditExecute = True
+io_svc.outputCommands = ["keep *","drop ECalBarrelCells","drop ECalEndcapCells","drop ECalFwdCells","drop HCalBarrelCells", "drop HCalExtBarrelCells", "drop HCalEndcapCells", "drop HCalFwdCells"]
 
-ApplicationMgr(
-TopAlg = [    podioinput,
-              positionsEcalBarrel,
-              positionsEcalEndcap,
-              positionsEcalFwd, 
-              positionsHcalBarrel, 
-              positionsHcalExtBarrel,
-              positionsHcalEndcap, 
-              positionsHcalFwd,
-              out
-              ],
-    EvtSel = 'NONE',
-    EvtMax = 1,
-    ExtSvc = [geoservice, podioevent, audsvc],
+
+# configure the application
+print(TopAlg)
+print(ExtSvc)
+from k4FWCore import ApplicationMgr
+applicationMgr = ApplicationMgr(
+    TopAlg=TopAlg,
+    EvtSel='NONE',
+    EvtMax=Nevts,
+    ExtSvc=ExtSvc,
+    StopOnSignal=True,
 )
+
+for algo in applicationMgr.TopAlg:
+    algo.AuditExecute = True

--- a/RecFCChhCalorimeter/tests/options/runFullCaloSystem_Digitisation.py
+++ b/RecFCChhCalorimeter/tests/options/runFullCaloSystem_Digitisation.py
@@ -1,0 +1,278 @@
+import os
+
+from GaudiKernel.SystemOfUnits import MeV,GeV
+
+# simulations setup
+Nevts = 3
+inputfile = "FCChh_sim_e_50GeV.root"
+outputfile = "output_fullCalo_SimAndDigi_e_50GeV_"+str(Nevts)+"events.root"
+
+from Gaudi.Configuration import INFO
+
+# ECAL readouts
+ecalBarrelReadoutName = "ECalBarrelEta"
+ecalBarrelReadoutNamePhiEta = "ECalBarrelPhiEta"
+ecalEndcapReadoutName = "EMECPhiEta"
+ecalFwdReadoutName = "EMFwdPhiEta"
+# HCAL readouts
+hcalReadoutName = "HCalBarrelReadout"
+extHcalReadoutName = "HCalExtBarrelReadout"
+hcalEndcapReadoutName = "HECPhiEta"
+hcalFwdReadoutName = "HFwdPhiEta"
+# layers to be merged in endcaps & forward calo
+ecalEndcapNumberOfLayersToMerge = [26]*5+[27]
+ecalFwdNumberOfLayersToMerge = [7]*5+[8]
+hcalEndcapNumberOfLayersToMerge = [13]+[14]*5
+hcalFwdNumberOfLayersToMerge = [8]+[9]*5
+identifierName = "layer"
+volumeName = "layer"
+
+#
+# ALGORITHMS AND SERVICES SETUP
+#
+TopAlg = []  # alg sequence
+ExtSvc = []  # list of external services
+
+# Event counter
+from Configurables import EventCounter
+eventCounter = EventCounter("EventCounter",
+                            OutputLevel=INFO,
+                            Frequency=1)
+TopAlg += [eventCounter]
+
+# CPU information
+from Configurables import AuditorSvc, ChronoAuditor
+chra = ChronoAuditor()
+audsvc = AuditorSvc()
+audsvc.Auditors = [chra]
+ExtSvc += [audsvc]
+
+# Detector geometry
+# prefix all xmls with path_to_detector
+# if K4GEO is empty, this should use relative path to working directory
+from Configurables import GeoSvc
+import os
+geoservice = GeoSvc("GeoSvc",
+                    OutputLevel=INFO
+                    # OutputLevel=DEBUG  # set to DEBUG to print dd4hep::DEBUG messages in k4geo C++ drivers
+                    )
+
+path_to_detector = os.environ.get("K4GEO", "") + "/FCChh//compact/FCChhBaseline/"
+detectors_to_use = [
+    'FCChh_DectMaster.xml'
+]
+geoservice.detectors = [
+    os.path.join(path_to_detector, _det) for _det in detectors_to_use
+]
+ExtSvc += [geoservice]
+
+# Input/Output handling
+from k4FWCore import IOSvc
+from Configurables import EventDataSvc
+io_svc = IOSvc("IOSvc")
+io_svc.Input = inputfile
+io_svc.Output = outputfile
+ExtSvc += [EventDataSvc("EventDataSvc")]
+
+# Configure tools for calo reconstruction
+# EM scale calibration
+from Configurables import CalibrateCaloHitsTool
+calibHcells = CalibrateCaloHitsTool("CalibrateHCal", invSamplingFraction="41.66")
+
+from Configurables import CalibrateInLayersTool
+calibEcalBarrel = CalibrateInLayersTool("CalibrateECalBarrel",
+                                   # sampling fraction obtained using SamplingFractionInLayers from DetStudies package
+                                   samplingFraction = [0.36571381189697705] * 1 + [0.09779064189677973] * 1 + [0.12564152224404024] * 1 + [0.14350599973146283] * 1 + [0.1557126972314961] * 1 + [0.16444759076233928] * 1 + [0.17097165096847836] * 1 + [0.17684775359805122] * 1 + [0.18181154293837265] * 1 + [0.18544247938196395] * 1 + [0.18922747431624687] * 1 + [0.21187001375505543] * 1,
+                                   readoutName = ecalBarrelReadoutName,
+                                   layerFieldName = "layer")
+
+calibEcalEndcap = CalibrateCaloHitsTool("CalibrateECalEndcap", invSamplingFraction="13.89")
+calibEcalFwd = CalibrateCaloHitsTool("CalibrateECalFwd", invSamplingFraction="303.03")
+calibHcalEndcap = CalibrateCaloHitsTool("CalibrateHCalEndcap", invSamplingFraction="33.62")
+calibHcalFwd = CalibrateCaloHitsTool("CalibrateHCalFwd", invSamplingFraction="1207.7")
+
+# Create cells in ECal barrel
+# 1. step - merge hits into cells with default Eta segmentation
+# 2. step - rewrite the cellId using the Phi-Eta segmentation
+from Configurables import CreateCaloCells
+createEcalBarrelCellsStep1 = CreateCaloCells("CreateECalBarrelCellsStep1",
+                                             doCellCalibration=True,
+                                             calibTool = calibEcalBarrel,
+                                             addCellNoise=False,
+                                             filterCellNoise=False,
+                                             OutputLevel=INFO,
+                                             hits=ecalBarrelReadoutName,
+                                             cells="ECalBarrelCellsStep1")
+TopAlg += [createEcalBarrelCellsStep1]
+
+# Ecal barrel cell positions
+# does not work
+# from Configurables import CreateVolumeCaloPositions
+# positionsEcalBarrel = CreateVolumeCaloPositions("positionsBarrelEcal", OutputLevel = INFO)
+# positionsEcalBarrel.hits.Path = "ECalBarrelCellsStep1"
+# positionsEcalBarrel.positionedHits.Path = "ECalBarrelPositions"
+# TopAlg += [positionsEcalBarrel]
+
+# Use Phi-Eta segmentation in ECal barrel
+from Configurables import RedoSegmentation
+resegmentEcalBarrel = RedoSegmentation("ReSegmentationEcal",
+                                       # old bitfield (readout)
+                                       oldReadoutName = ecalBarrelReadoutName,
+                                       # specify which fields are going to be altered (deleted/rewritten)
+                                       oldSegmentationIds = ["module"],
+                                       # new bitfield (readout), with new segmentation
+                                       newReadoutName = ecalBarrelReadoutNamePhiEta,
+                                       OutputLevel = INFO,
+                                       # inhits = "ECalBarrelPositions",
+                                       inhits = "ECalBarrelCellsStep1",
+                                       outhits = "ECalBarrelCellsStep2")
+TopAlg += [resegmentEcalBarrel]
+
+createEcalBarrelCells = CreateCaloCells("CreateECalBarrelCells",
+                                        doCellCalibration=False,
+                                        addCellNoise=False,
+                                        filterCellNoise=False,
+                                        OutputLevel=INFO,
+                                        hits="ECalBarrelCellsStep2",
+                                        cells="ECalBarrelCells")
+TopAlg += [createEcalBarrelCells]
+
+# Create Ecal cells in endcaps
+# 1. step - merge layer IDs
+# 2. step - create cells
+from Configurables import MergeLayers
+mergelayersEcalEndcap = MergeLayers("MergeLayersEcalEndcap",
+                                    # take the bitfield description from the geometry service
+                                    readout = ecalEndcapReadoutName,
+                                    # cells in which field should be merged
+                                    identifier = identifierName,
+                                    volumeName = volumeName,
+                                    # how many cells to merge
+                                    merge = ecalEndcapNumberOfLayersToMerge,
+                                    OutputLevel = INFO)
+mergelayersEcalEndcap.inhits.Path = ecalEndcapReadoutName
+mergelayersEcalEndcap.outhits.Path = "mergedECalEndcapHits"
+TopAlg += [mergelayersEcalEndcap]
+              
+createEcalEndcapCells = CreateCaloCells("CreateEcalEndcapCaloCells",
+                                        doCellCalibration=True,
+                                        calibTool=calibEcalEndcap,
+                                        addCellNoise=False,
+                                        filterCellNoise=False,
+                                        OutputLevel=INFO)
+createEcalEndcapCells.hits.Path="mergedECalEndcapHits"
+createEcalEndcapCells.cells.Path="ECalEndcapCells"
+TopAlg += [createEcalEndcapCells]
+
+# Create Ecal cells in forward
+mergelayersEcalFwd = MergeLayers("MergeLayersEcalFwd",
+                                 # take the bitfield description from the geometry service
+                                 readout = ecalFwdReadoutName,
+                                 # cells in which field should be merged
+                                 identifier = identifierName,
+                                 volumeName = volumeName,
+                                 # how many cells to merge
+                                 merge = ecalFwdNumberOfLayersToMerge,
+                                 OutputLevel = INFO)
+mergelayersEcalFwd.inhits.Path = ecalFwdReadoutName
+mergelayersEcalFwd.outhits.Path = "mergedECalFwdHits"
+TopAlg += [mergelayersEcalFwd]
+
+createEcalFwdCells = CreateCaloCells("CreateEcalFwdCaloCells",
+                                     doCellCalibration=True,
+                                     calibTool=calibEcalFwd,
+                                     addCellNoise=False,
+                                     filterCellNoise=False,
+                                     OutputLevel=INFO)
+createEcalFwdCells.hits.Path="mergedECalFwdHits"
+createEcalFwdCells.cells.Path="ECalFwdCells"
+TopAlg += [createEcalFwdCells]
+
+# Create cells in HCal
+# 1. step - merge hits into cells with the default readout
+createHcalCells = CreateCaloCells("CreateHCaloCells",
+                                  doCellCalibration=True,
+                                  calibTool=calibHcells,
+                                  addCellNoise = False,
+                                  filterCellNoise = False,
+                                  OutputLevel = INFO,
+                                  hits=hcalReadoutName,
+                                  cells="HCalBarrelCells")
+TopAlg += [createHcalCells]
+
+# Hcal extended barrel cells
+createExtHcalCells = CreateCaloCells("CreateExtHcalCaloCells",
+                                     doCellCalibration=True,
+                                     calibTool=calibHcells,
+                                     addCellNoise = False,
+                                     filterCellNoise = False,
+                                     OutputLevel = INFO,
+                                     hits=extHcalReadoutName,
+                                     cells="HCalExtBarrelCells")
+TopAlg += [createExtHcalCells]
+
+# Create Hcal cells in endcaps
+mergelayersHcalEndcap = MergeLayers("MergeLayersHcalEndcap",
+                                    # take the bitfield description from the geometry service
+                                    readout = hcalEndcapReadoutName,
+                                    # cells in which field should be merged
+                                    identifier = identifierName,
+                                    volumeName = volumeName,
+                                    # how many cells to merge
+                                    merge = hcalEndcapNumberOfLayersToMerge,
+                                    OutputLevel = INFO)
+mergelayersHcalEndcap.inhits.Path = hcalEndcapReadoutName
+mergelayersHcalEndcap.outhits.Path = "mergedHCalEndcapHits"
+TopAlg += [mergelayersHcalEndcap]
+
+createHcalEndcapCells = CreateCaloCells("CreateHcalEndcapCaloCells",
+                                        doCellCalibration=True,
+                                        calibTool=calibHcalEndcap,
+                                        addCellNoise=False,
+                                        filterCellNoise=False,
+                                        OutputLevel=INFO)
+createHcalEndcapCells.hits.Path="mergedHCalEndcapHits"
+createHcalEndcapCells.cells.Path="HCalEndcapCells"
+TopAlg += [createHcalEndcapCells]
+
+# Create Hcal cells in forward
+mergelayersHcalFwd = MergeLayers("MergeLayersHcalFwd",
+                                 # take the bitfield description from the geometry service
+                                 readout = hcalFwdReadoutName,
+                                 # cells in which field should be merged
+                                 identifier = identifierName,
+                                 volumeName = volumeName,
+                                 # how many cells to merge
+                                 merge = hcalFwdNumberOfLayersToMerge,
+                                 OutputLevel = INFO)
+mergelayersHcalFwd.inhits.Path = hcalFwdReadoutName
+mergelayersHcalFwd.outhits.Path = "mergedHCalFwdHits"
+TopAlg += [mergelayersHcalFwd]
+
+createHcalFwdCells = CreateCaloCells("CreateHcalFwdCaloCells",
+                                     doCellCalibration=True,
+                                     calibTool=calibHcalFwd,
+                                     addCellNoise=False, filterCellNoise=False,
+                                     OutputLevel=INFO)
+createHcalFwdCells.hits.Path="mergedHCalFwdHits"
+createHcalFwdCells.cells.Path="HCalFwdCells"
+TopAlg += [createHcalFwdCells]
+
+# Configure output
+io_svc.outputCommands = ["drop *", "keep ECalBarrelCells", "keep ECalEndcapCells", "keep ECalFwdCells", "keep HCalBarrelCells", "keep HCalExtBarrelCells", "keep HCalEndcapCells", "keep HCalFwdCells", "keep GenParticles","keep GenVertices"]
+io_svc.Output = outputfile
+
+# configure the application
+print(TopAlg)
+print(ExtSvc)
+from k4FWCore import ApplicationMgr
+applicationMgr = ApplicationMgr(
+    TopAlg=TopAlg,
+    EvtSel='NONE',
+    EvtMax=Nevts,
+    ExtSvc=ExtSvc,
+    StopOnSignal=True,
+)
+
+for algo in applicationMgr.TopAlg:
+    algo.AuditExecute = True

--- a/RecFCChhCalorimeter/tests/options/runFullCaloSystem_Digitisation.py
+++ b/RecFCChhCalorimeter/tests/options/runFullCaloSystem_Digitisation.py
@@ -1,13 +1,7 @@
-import os
-
-from GaudiKernel.SystemOfUnits import MeV,GeV
-
 # simulations setup
 Nevts = 3
 inputfile = "FCChh_sim_e_50GeV.root"
 outputfile = "output_fullCalo_SimAndDigi_e_50GeV_"+str(Nevts)+"events.root"
-
-from Gaudi.Configuration import INFO
 
 # ECAL readouts
 ecalBarrelReadoutName = "ECalBarrelEta"
@@ -33,6 +27,8 @@ volumeName = "layer"
 TopAlg = []  # alg sequence
 ExtSvc = []  # list of external services
 
+from Gaudi.Configuration import INFO, DEBUG
+
 # Event counter
 from Configurables import EventCounter
 eventCounter = EventCounter("EventCounter",
@@ -57,7 +53,7 @@ geoservice = GeoSvc("GeoSvc",
                     # OutputLevel=DEBUG  # set to DEBUG to print dd4hep::DEBUG messages in k4geo C++ drivers
                     )
 
-path_to_detector = os.environ.get("K4GEO", "") + "/FCChh//compact/FCChhBaseline/"
+path_to_detector = os.environ.get("K4GEO", "") + "/FCChh/compact/FCChhBaseline/"
 detectors_to_use = [
     'FCChh_DectMaster.xml'
 ]
@@ -102,11 +98,13 @@ createEcalBarrelCellsStep1 = CreateCaloCells("CreateECalBarrelCellsStep1",
                                              filterCellNoise=False,
                                              OutputLevel=INFO,
                                              hits=ecalBarrelReadoutName,
-                                             cells="ECalBarrelCellsStep1")
+                                             cells="ECalBarrelCellsStep1",
+                                             addPosition=True)
 TopAlg += [createEcalBarrelCellsStep1]
 
 # Ecal barrel cell positions
-# does not work
+# does not work - should not needed since only x-y position is needed, which is correctly
+# calculated by CreateCaloCells with addPosition=True
 # from Configurables import CreateVolumeCaloPositions
 # positionsEcalBarrel = CreateVolumeCaloPositions("positionsBarrelEcal", OutputLevel = INFO)
 # positionsEcalBarrel.hits.Path = "ECalBarrelCellsStep1"

--- a/RecFCChhCalorimeter/tests/options/runFullCaloSystem_ReconstructionSW_noNoise.py
+++ b/RecFCChhCalorimeter/tests/options/runFullCaloSystem_ReconstructionSW_noNoise.py
@@ -1,0 +1,203 @@
+# Setup
+# Names of cells collections
+ecalBarrelCellsName = "ECalBarrelCells"
+ecalEndcapCellsName = "ECalEndcapCells"
+ecalFwdCellsName = "ECalFwdCells"
+hcalBarrelCellsName = "HCalBarrelCells"
+hcalExtBarrelCellsName = "HCalExtBarrelCells"
+hcalEndcapCellsName = "HCalEndcapCells"
+hcalFwdCellsName = "HCalFwdCells"
+# Readouts
+ecalBarrelReadoutName = "ECalBarrelPhiEta"
+ecalEndcapReadoutName = "EMECPhiEtaReco"
+ecalFwdReadoutName = "EMFwdPhiEta"
+hcalBarrelReadoutName = "HCalBarrelReadout"
+hcalExtBarrelReadoutName = "HCalExtBarrelReadout"
+hcalBarrelReadoutPhiEtaName = "BarHCal_Readout_phieta"
+hcalExtBarrelReadoutPhiEtaName = "ExtBarHCal_Readout_phieta"
+hcalEndcapReadoutName = "HECPhiEtaReco"
+hcalFwdReadoutName = "HFwdPhiEta"
+
+# Number of events
+Nevts = 3
+# input/output files
+inputfile = "output_fullCalo_SimDigi_e_50GeV_"+str(Nevts)+"events.root"
+outputfile = "output_fullCalo_SimDigiReco_e_50GeV_"+str(Nevts)+"events.root"
+
+#
+# ALGORITHMS AND SERVICES SETUP
+#
+TopAlg = []  # alg sequence
+ExtSvc = []  # list of external services
+
+from Gaudi.Configuration import INFO, DEBUG
+
+# Event counter
+from Configurables import EventCounter
+eventCounter = EventCounter("EventCounter",
+                            OutputLevel=INFO,
+                            Frequency=1)
+TopAlg += [eventCounter]
+
+# CPU information
+from Configurables import AuditorSvc, ChronoAuditor
+chra = ChronoAuditor()
+audsvc = AuditorSvc()
+audsvc.Auditors = [chra]
+ExtSvc += [audsvc]
+
+# Detector geometry
+# prefix all xmls with path_to_detector
+# if K4GEO is empty, this should use relative path to working directory
+from Configurables import GeoSvc
+import os
+geoservice = GeoSvc("GeoSvc",
+                    OutputLevel=INFO
+                    # OutputLevel=DEBUG  # set to DEBUG to print dd4hep::DEBUG messages in k4geo C++ drivers
+                    )
+
+path_to_detector = os.environ.get("K4GEO", "") + "/FCChh/compact/FCChhBaseline/"
+detectors_to_use = [
+    'FCChh_DectMaster.xml'
+]
+geoservice.detectors = [
+    os.path.join(path_to_detector, _det) for _det in detectors_to_use
+]
+ExtSvc += [geoservice]
+
+# Input/Output handling
+from k4FWCore import IOSvc
+from Configurables import EventDataSvc
+io_svc = IOSvc("IOSvc")
+io_svc.Input = inputfile
+io_svc.Output = outputfile
+ExtSvc += [EventDataSvc("EventDataSvc")]
+
+# Configure tools for calo reconstruction
+
+##############################################################################################################
+#######                                       REWRITE HCAL BITFIELD                              #############
+##############################################################################################################
+from Configurables import RewriteBitfield
+# Use Phi-Eta segmentation in Hcal barrel
+rewriteHcal = RewriteBitfield("RewriteHCal",
+                                # old bitfield (readout)
+                                oldReadoutName = "HCalBarrelReadout",
+                                # specify which fields are going to be deleted 
+                                removeIds = ["row"],
+                                # new bitfield (readout), with new segmentation
+                                newReadoutName = "BarHCal_Readout_phieta",
+                                debugPrint = 10,
+                                OutputLevel= INFO)
+# clusters are needed, with deposit position and cellID in bits
+rewriteHcal.inhits.Path = "HCalBarrelCells"
+rewriteHcal.outhits.Path = "newHCalBarrelCells"
+TopAlg += [rewriteHcal]
+
+rewriteExtHcal = RewriteBitfield("RewriteExtHcal",
+                                 # old bitfield (readout)
+                                 oldReadoutName = hcalExtBarrelReadoutName,
+                                 # specify which fields are going to be altered (deleted/rewritten)
+                                 removeIds = ["row"],
+                                 # new bitfield (readout), with new segmentation
+                                 newReadoutName = hcalExtBarrelReadoutPhiEtaName,
+                                 debugPrint = 10,
+                                 OutputLevel = INFO,
+                                 inhits = "HCalExtBarrelCells",
+                                 outhits = "newHCalExtBarrelCells")
+TopAlg += [rewriteExtHcal]
+
+##############################################################################################################
+#######                                       REWRITE ENDCAP BITFIELD                            #############
+##############################################################################################################
+
+from Configurables import RewriteBitfield
+rewriteECalEC = RewriteBitfield("RewriteECalEC",
+                                # old bitfield (readout)
+                                oldReadoutName = "EMECPhiEta",
+                                # specify which fields are going to be deleted
+                                removeIds = ["sublayer"],
+                                # clusters are needed, with deposit position and cellID in bits
+                                newReadoutName = ecalEndcapReadoutName,
+                                debugPrint = 10,
+                                OutputLevel = INFO)
+rewriteECalEC.inhits.Path = "ECalEndcapCells"
+rewriteECalEC.outhits.Path = "newECalEndcapCells"
+TopAlg += [rewriteECalEC]
+
+rewriteHCalEC = RewriteBitfield("RewriteHCalEC",
+                                # old bitfield (readout)
+                                oldReadoutName = "HECPhiEta",
+                                # specify which fields are going to be deleted
+                                removeIds = ["sublayer"],
+                                # new bitfield (readout), with new segmentation
+                                newReadoutName = hcalEndcapReadoutName,
+                                debugPrint = 10,
+                                OutputLevel = INFO)
+# clusters are needed, with deposit position and cellID in bits
+rewriteHCalEC.inhits.Path = "HCalEndcapCells"
+rewriteHCalEC.outhits.Path = "newHCalEndcapCells"
+TopAlg += [rewriteHCalEC]
+
+#Create calo clusters
+from Configurables import CreateCaloClustersSlidingWindow, CaloTowerTool
+from GaudiKernel.PhysicalConstants import pi
+
+towers = CaloTowerTool("towers",
+                               deltaEtaTower = 0.01, deltaPhiTower = 2*pi/704.,
+                               ecalBarrelReadoutName = ecalBarrelReadoutName,
+                               ecalEndcapReadoutName = ecalEndcapReadoutName,
+                               ecalFwdReadoutName = ecalFwdReadoutName,
+                               hcalBarrelReadoutName = hcalBarrelReadoutPhiEtaName,
+                               hcalExtBarrelReadoutName = hcalExtBarrelReadoutPhiEtaName,
+                               hcalEndcapReadoutName = hcalEndcapReadoutName,
+                               hcalFwdReadoutName = hcalFwdReadoutName,
+                               OutputLevel = DEBUG)
+towers.ecalBarrelCells.Path = ecalBarrelCellsName
+towers.ecalEndcapCells.Path = "newECalEndcapCells"
+towers.ecalFwdCells.Path = ecalFwdCellsName
+towers.hcalBarrelCells.Path = "newHCalBarrelCells"
+towers.hcalExtBarrelCells.Path ="newHCalExtBarrelCells"
+towers.hcalEndcapCells.Path = "newHCalEndcapCells"
+towers.hcalFwdCells.Path = hcalFwdCellsName
+
+# Cluster variables
+windE = 9
+windP = 17
+posE = 5
+posP = 11
+dupE = 7
+dupP = 13
+finE = 9
+finP = 17
+threshold = 12
+
+createClusters = CreateCaloClustersSlidingWindow("CreateClusters",
+                                                 towerTool = towers,
+                                                 nEtaWindow = windE, nPhiWindow = windP,
+                                                 nEtaPosition = posE, nPhiPosition = posP,
+                                                 nEtaDuplicates = dupE, nPhiDuplicates = dupP,
+                                                 nEtaFinal = finE, nPhiFinal = finP,
+                                                 energyThreshold = threshold,
+                                                 ellipse = True,
+                                                 OutputLevel = DEBUG)
+createClusters.clusters.Path = "CaloClusters"
+createClusters.clusterCells.Path = "CaloClusterCells"
+TopAlg += [createClusters]
+
+io_svc.outputCommands = ["keep *"]
+
+# configure the application
+print(TopAlg)
+print(ExtSvc)
+from k4FWCore import ApplicationMgr
+applicationMgr = ApplicationMgr(
+    TopAlg=TopAlg,
+    EvtSel='NONE',
+    EvtMax=Nevts,
+    ExtSvc=ExtSvc,
+    StopOnSignal=True,
+)
+
+for algo in applicationMgr.TopAlg:
+    algo.AuditExecute = True

--- a/RecFCChhCalorimeter/tests/options/runFullCaloSystem_ReconstructionSW_noNoise.py
+++ b/RecFCChhCalorimeter/tests/options/runFullCaloSystem_ReconstructionSW_noNoise.py
@@ -139,7 +139,7 @@ rewriteHCalEC.inhits.Path = "HCalEndcapCells"
 rewriteHCalEC.outhits.Path = "newHCalEndcapCells"
 TopAlg += [rewriteHCalEC]
 
-#Create calo clusters
+# Create calo clusters
 from Configurables import CreateCaloClustersSlidingWindow, CaloTowerTool
 from GaudiKernel.PhysicalConstants import pi
 


### PR DESCRIPTION

BEGINRELEASENOTES
- Remove warning in cell digitisers for cells from FORWARD calorimeters 
- Add working scripts and CI tests for FCC-hh digitisation, reconstruction and positions
ENDRELEASENOTES

Essentially an attempt to migrate to the new I/O and to k4geo/k4RecCalorimeter legacy tests that were commented after the migration from FCCSW / FCCDetectors

* https://github.com/HEP-FCC/k4RecCalorimeter/blob/main/RecCalorimeter/tests/options/runFullCaloSystem_SimAndDigitisation.py
* https://github.com/HEP-FCC/k4RecCalorimeter/blob/main/RecCalorimeter/tests/options/runFullCaloSystem_ReconstructionSW_noNoise.py
* https://github.com/HEP-FCC/k4RecCalorimeter/blob/main/RecFCChhCalorimeter/tests/options/recoPositions_fullCaloSystem.py


Notes:
- clusters from 20 GeV pions in barrel are reconstructed
- clusters from 50 GeV electrons in forward are not reconstructed (but cell energies are OK, sum of energies ~50 GeV)

Depends on 
- https://github.com/key4hep/k4SimGeant4/pull/93
- https://github.com/key4hep/k4geo/pull/586
