### PR TITLE
Add code for making noise map for turbine ECal endcap

### DIFF
--- a/RecFCCeeCalorimeter/src/components/NoiseCaloCellsTurbineEndcapFromFileTool.cpp
+++ b/RecFCCeeCalorimeter/src/components/NoiseCaloCellsTurbineEndcapFromFileTool.cpp
@@ -1,0 +1,238 @@
+#include "NoiseCaloCellsTurbineEndcapFromFileTool.h"
+#include "RecCaloCommon/k4RecCalorimeter_check.h"
+
+// k4geo
+#include "detectorCommon/DetUtils_k4geo.h"
+
+// k4FWCore
+#include "k4Interface/IGeoSvc.h"
+
+// DD4hep
+#include "DD4hep/Detector.h"
+
+// ROOT
+#include "TFile.h"
+#include "TH2F.h"
+#include "TMath.h"
+#include "TSystem.h"
+
+DECLARE_COMPONENT(NoiseCaloCellsTurbineEndcapFromFileTool)
+
+StatusCode NoiseCaloCellsTurbineEndcapFromFileTool::initialize() {
+  K4RECCALORIMETER_CHECK( m_geoSvc.retrieve() );
+  K4RECCALORIMETER_CHECK( m_cellPositionsTool.retrieve() );
+  K4RECCALORIMETER_CHECK( m_randSvc = service<IRndmGenSvc> ("RndmGenSvc", false) );
+  K4RECCALORIMETER_CHECK( m_gauss.initialize(m_randSvc, Rndm::Gauss(0., 1.)) );
+
+  // open and check file, read the histograms with noise constants
+  K4RECCALORIMETER_CHECK( initNoiseFromFile() );
+
+  // Get decoder and index of layer field
+  // put in try... block
+  m_decoder = m_geoSvc->getDetector()->readout(m_readoutName).idSpec().decoder();
+  m_index_activeField = m_decoder->index(m_activeFieldName);
+
+  debug() << "Filter noise threshold: " << m_filterThreshold << "*sigma" << endmsg;
+
+  K4RECCALORIMETER_CHECK( AlgTool::initialize() );
+
+  return StatusCode::SUCCESS;
+}
+
+template <class C>
+void NoiseCaloCellsTurbineEndcapFromFileTool::addRandomCellNoiseT(C& aCells) const {
+  for (auto& p : aCells) {
+    p.second += getNoiseOffsetPerCell(p.first);
+    p.second += (getNoiseRMSPerCell(p.first) * m_gauss.shoot());
+  }
+}
+
+void NoiseCaloCellsTurbineEndcapFromFileTool::addRandomCellNoise(std::unordered_map<uint64_t, double>& aCells) const {
+  addRandomCellNoiseT(aCells);
+}
+
+void NoiseCaloCellsTurbineEndcapFromFileTool::addRandomCellNoise(std::vector<std::pair<uint64_t, double> >& aCells) const {
+  addRandomCellNoiseT (aCells);
+}
+
+template <typename C>
+void NoiseCaloCellsTurbineEndcapFromFileTool::filterCellNoiseT(C& aCells) const {
+  // Erase a cell if it has energy below a threshold from the vector
+  if (m_useAbsInFilter) {
+    std::erase_if(aCells,
+                  [&](auto& p) { return std::abs(p.second-getNoiseOffsetPerCell(p.first)) < m_filterThreshold * getNoiseRMSPerCell(p.first); });
+  }
+  else {
+    std::erase_if(aCells,
+                  [&](auto& p) { return p.second < getNoiseOffsetPerCell(p.first) + m_filterThreshold * getNoiseRMSPerCell(p.first); });
+  }
+}
+
+void NoiseCaloCellsTurbineEndcapFromFileTool::filterCellNoise(std::unordered_map<uint64_t, double>& aCells) const {
+  filterCellNoiseT (aCells);
+}
+
+void NoiseCaloCellsTurbineEndcapFromFileTool::filterCellNoise(std::vector<std::pair<uint64_t, double> >& aCells) const {
+  filterCellNoiseT (aCells);
+}
+
+StatusCode NoiseCaloCellsTurbineEndcapFromFileTool::initNoiseFromFile() {
+  // Check if file exists
+  if (m_noiseFileName.empty()) {
+    error() << "Name of the file with the noise values not provided!" << endmsg;
+    return StatusCode::FAILURE;
+  }
+  if (gSystem->AccessPathName(m_noiseFileName.value().c_str())) {
+    error() << "Provided file with the noise values not found!" << endmsg;
+    error() << "File path: " << m_noiseFileName.value() << endmsg;
+    return StatusCode::FAILURE;
+  }
+  std::unique_ptr<TFile> noiseFile(TFile::Open(m_noiseFileName.value().c_str(), "READ"));
+  if (noiseFile->IsZombie()) {
+    error() << "Unable to open the file with the noise values!" << endmsg;
+    error() << "File path: " << m_noiseFileName.value() << endmsg;
+    return StatusCode::FAILURE;
+  } else {
+    info() << "Using the following file with noise values: " << m_noiseFileName.value() << endmsg;
+  }
+  
+  std::string elecNoiseRMSWheelHistoName, pileupNoiseRMSWheelHistoName;
+  std::string elecNoiseOffsetWheelHistoName, pileupNoiseOffsetWheelHistoName;
+  // Read the histograms with electronics noise and pileup from the file
+  for (unsigned iWheel = 0; iWheel < m_numWheels; iWheel++) {
+    elecNoiseRMSWheelHistoName = m_elecNoiseRMSHistoName +std::to_string(iWheel);
+    debug() << "Getting histogram with a name " <<  elecNoiseRMSWheelHistoName << endmsg;
+    m_histoElecNoiseRMS.push_back(* dynamic_cast<TH2F*>(noiseFile->Get(elecNoiseRMSWheelHistoName.c_str())));
+    if (m_histoElecNoiseRMS.at(iWheel).GetNbinsX() < 1) {
+      error() << "Histogram  " << elecNoiseRMSWheelHistoName 
+	      << " has 0 bins! check the file with noise and the name of the histogram!" << endmsg;
+      return StatusCode::FAILURE;
+    }
+    if (m_setNoiseOffset) {
+      elecNoiseOffsetWheelHistoName = m_elecNoiseOffsetHistoName +std::to_string(iWheel);
+      debug() << "Getting histogram with a name " << elecNoiseOffsetWheelHistoName  << endmsg;
+      m_histoElecNoiseOffset.push_back(*dynamic_cast<TH2F*>(noiseFile->Get(elecNoiseOffsetWheelHistoName.c_str())));
+      if (m_histoElecNoiseOffset.at(iWheel).GetNbinsX() < 1) {
+	error() << "Histogram  " <<  elecNoiseOffsetWheelHistoName
+		<< " has 0 bins! check the file with noise and the name of the histogram!" << endmsg;
+	return StatusCode::FAILURE;
+      }
+    }
+    if (m_addPileup) {
+      pileupNoiseRMSWheelHistoName = m_pileupNoiseRMSHistoName +std::to_string(iWheel);
+      debug() << "Getting histogram with a name " <<  pileupNoiseRMSWheelHistoName << endmsg;
+      m_histoPileupNoiseRMS.push_back(* dynamic_cast<TH2F*>(noiseFile->Get(pileupNoiseRMSWheelHistoName.c_str())));
+      if (m_histoPileupNoiseRMS.at(iWheel).GetNbinsX() < 1) {
+	error() << "Histogram  " << pileupNoiseRMSWheelHistoName 
+		<< " has 0 bins! check the file with noise and the name of the histogram!" << endmsg;
+	return StatusCode::FAILURE;
+      }
+      if (m_setNoiseOffset) {
+	pileupNoiseOffsetWheelHistoName = m_pileupNoiseOffsetHistoName +std::to_string(iWheel);
+	debug() << "Getting histogram with a name " << pileupNoiseOffsetWheelHistoName  << endmsg;
+	m_histoPileupNoiseOffset.push_back(*dynamic_cast<TH2F*>(noiseFile->Get(pileupNoiseOffsetWheelHistoName.c_str())));
+	if (m_histoPileupNoiseOffset.at(iWheel).GetNbinsX() < 1) {
+	  error() << "Histogram  " <<  pileupNoiseOffsetWheelHistoName
+		  << " has 0 bins! check the file with noise and the name of the histogram!" << endmsg;
+	  return StatusCode::FAILURE;
+	}
+      }
+    }
+  }
+  noiseFile->Close();
+
+  return StatusCode::SUCCESS;
+}
+
+double NoiseCaloCellsTurbineEndcapFromFileTool::getNoiseRMSPerCell(uint64_t aCellId) const {
+
+  double elecNoiseRMS = 0.;
+  double pileupNoiseRMS = 0.;
+
+  unsigned iWheel = m_decoder->get(aCellId, "wheel");
+  unsigned iRho = m_decoder->get(aCellId, "rho");
+  unsigned iZ = m_decoder->get(aCellId, "z");
+
+  // All histograms have same binning, all bins with same size
+  // Using the histogram in the first layer to get the bin size
+  if (m_histoElecNoiseRMS.size() >  0) {
+     // Check that there are not more wheels than the constants are provided for
+    if (iWheel < m_histoElecNoiseRMS.size()) {      
+      elecNoiseRMS = m_histoElecNoiseRMS.at(iWheel).GetBinContent(iZ+1, iRho+1);
+      debug() << "Here with noise RMS = " << elecNoiseRMS << endmsg;
+      if (m_addPileup) {
+	pileupNoiseRMS = m_histoPileupNoiseRMS.at(iWheel).GetBinContent(iZ+1, iRho+1);
+      }
+    } else {
+      error() << "More wheels than we have noise for!!!!! " << endmsg;
+    }
+  
+  } else {
+    error() << "No histograms with RMS noise constants!!!!! " << endmsg;
+  }
+
+  // Total noise: electronics noise + pileup
+  double totalNoiseRMS = 0;
+  if (m_addPileup) {
+    totalNoiseRMS = sqrt(elecNoiseRMS * elecNoiseRMS + pileupNoiseRMS * pileupNoiseRMS) * m_scaleFactor;
+  } else { // avoid useless math operations if no pileup
+    totalNoiseRMS = elecNoiseRMS * m_scaleFactor;
+  }
+  if (totalNoiseRMS < 1e-6) {
+    warning() << "Zero noise RMS:  iZ, iRho " << iZ << "," << iRho  << " noise RMS " << totalNoiseRMS
+              << endmsg;
+  }
+  
+  return totalNoiseRMS;
+}
+
+double NoiseCaloCellsTurbineEndcapFromFileTool::getNoiseOffsetPerCell(uint64_t aCellId) const {
+
+  if (!m_setNoiseOffset)
+    return 0.;
+
+  double elecNoiseOffset = 0.;
+  double pileupNoiseOffset = 0.;
+  
+  unsigned iWheel = m_decoder->get(aCellId, "wheel");
+  unsigned iRho = m_decoder->get(aCellId, "rho");
+  unsigned iZ = m_decoder->get(aCellId, "z");
+  
+  // All histograms have same binning, all bins with same size
+  // Using the histogram in the first layer to get the bin size
+  if (m_histoElecNoiseOffset.size() >  0) {
+    // Check that there are not more wheels than the constants are provided for
+    if (iWheel < m_histoElecNoiseOffset.size()) {
+      elecNoiseOffset = m_histoElecNoiseOffset.at(iWheel).GetBinContent(iZ+1, iRho+1);
+      if (m_addPileup) {
+	pileupNoiseOffset = m_histoPileupNoiseOffset.at(iWheel).GetBinContent(iZ+1, iRho+1);
+      }
+    } else {
+      error() << "More wheels than we have noise for!!!!! " << endmsg;
+    }
+    
+  } else {
+    error() << "No histograms with Offset noise constants!!!!! " << endmsg;
+  }
+  
+  // Total noise: electronics noise + pileup
+  double totalNoiseOffset = 0;
+  if (m_addPileup) {
+    totalNoiseOffset = sqrt(elecNoiseOffset * elecNoiseOffset + pileupNoiseOffset * pileupNoiseOffset) * m_scaleFactor;
+  } else { // avoid useless math operations if no pileup
+    totalNoiseOffset = elecNoiseOffset * m_scaleFactor;
+  }
+  
+  if (totalNoiseOffset < 1e-6) {
+    warning() << "Zero noise Offset:  iZ, iRho " << iZ << "," << iRho << " noise Offset " << totalNoiseOffset
+              << endmsg;
+  }
+  
+  return totalNoiseOffset;
+}
+
+std::pair<double, double> NoiseCaloCellsTurbineEndcapFromFileTool::getNoisePerCell(uint64_t aCellId) const
+{
+  return std::make_pair (getNoiseRMSPerCell(aCellId),
+                         getNoiseOffsetPerCell(aCellId));
+}

--- a/RecFCCeeCalorimeter/src/components/NoiseCaloCellsTurbineEndcapFromFileTool.cpp
+++ b/RecFCCeeCalorimeter/src/components/NoiseCaloCellsTurbineEndcapFromFileTool.cpp
@@ -19,13 +19,13 @@
 DECLARE_COMPONENT(NoiseCaloCellsTurbineEndcapFromFileTool)
 
 StatusCode NoiseCaloCellsTurbineEndcapFromFileTool::initialize() {
-  K4RECCALORIMETER_CHECK( m_geoSvc.retrieve() );
-  K4RECCALORIMETER_CHECK( m_cellPositionsTool.retrieve() );
-  K4RECCALORIMETER_CHECK( m_randSvc = service<IRndmGenSvc> ("RndmGenSvc", false) );
-  K4RECCALORIMETER_CHECK( m_gauss.initialize(m_randSvc, Rndm::Gauss(0., 1.)) );
+  K4RECCALORIMETER_CHECK(m_geoSvc.retrieve());
+  K4RECCALORIMETER_CHECK(m_cellPositionsTool.retrieve());
+  K4RECCALORIMETER_CHECK(m_randSvc = service<IRndmGenSvc>("RndmGenSvc", false));
+  K4RECCALORIMETER_CHECK(m_gauss.initialize(m_randSvc, Rndm::Gauss(0., 1.)));
 
   // open and check file, read the histograms with noise constants
-  K4RECCALORIMETER_CHECK( initNoiseFromFile() );
+  K4RECCALORIMETER_CHECK(initNoiseFromFile());
 
   // Get decoder and index of layer field
   // put in try... block
@@ -34,7 +34,7 @@ StatusCode NoiseCaloCellsTurbineEndcapFromFileTool::initialize() {
 
   debug() << "Filter noise threshold: " << m_filterThreshold << "*sigma" << endmsg;
 
-  K4RECCALORIMETER_CHECK( AlgTool::initialize() );
+  K4RECCALORIMETER_CHECK(AlgTool::initialize());
 
   return StatusCode::SUCCESS;
 }
@@ -51,29 +51,31 @@ void NoiseCaloCellsTurbineEndcapFromFileTool::addRandomCellNoise(std::unordered_
   addRandomCellNoiseT(aCells);
 }
 
-void NoiseCaloCellsTurbineEndcapFromFileTool::addRandomCellNoise(std::vector<std::pair<uint64_t, double> >& aCells) const {
-  addRandomCellNoiseT (aCells);
+void NoiseCaloCellsTurbineEndcapFromFileTool::addRandomCellNoise(
+    std::vector<std::pair<uint64_t, double>>& aCells) const {
+  addRandomCellNoiseT(aCells);
 }
 
 template <typename C>
 void NoiseCaloCellsTurbineEndcapFromFileTool::filterCellNoiseT(C& aCells) const {
   // Erase a cell if it has energy below a threshold from the vector
   if (m_useAbsInFilter) {
-    std::erase_if(aCells,
-                  [&](auto& p) { return std::abs(p.second-getNoiseOffsetPerCell(p.first)) < m_filterThreshold * getNoiseRMSPerCell(p.first); });
-  }
-  else {
-    std::erase_if(aCells,
-                  [&](auto& p) { return p.second < getNoiseOffsetPerCell(p.first) + m_filterThreshold * getNoiseRMSPerCell(p.first); });
+    std::erase_if(aCells, [&](auto& p) {
+      return std::abs(p.second - getNoiseOffsetPerCell(p.first)) < m_filterThreshold * getNoiseRMSPerCell(p.first);
+    });
+  } else {
+    std::erase_if(aCells, [&](auto& p) {
+      return p.second < getNoiseOffsetPerCell(p.first) + m_filterThreshold * getNoiseRMSPerCell(p.first);
+    });
   }
 }
 
 void NoiseCaloCellsTurbineEndcapFromFileTool::filterCellNoise(std::unordered_map<uint64_t, double>& aCells) const {
-  filterCellNoiseT (aCells);
+  filterCellNoiseT(aCells);
 }
 
-void NoiseCaloCellsTurbineEndcapFromFileTool::filterCellNoise(std::vector<std::pair<uint64_t, double> >& aCells) const {
-  filterCellNoiseT (aCells);
+void NoiseCaloCellsTurbineEndcapFromFileTool::filterCellNoise(std::vector<std::pair<uint64_t, double>>& aCells) const {
+  filterCellNoiseT(aCells);
 }
 
 StatusCode NoiseCaloCellsTurbineEndcapFromFileTool::initNoiseFromFile() {
@@ -95,47 +97,48 @@ StatusCode NoiseCaloCellsTurbineEndcapFromFileTool::initNoiseFromFile() {
   } else {
     info() << "Using the following file with noise values: " << m_noiseFileName.value() << endmsg;
   }
-  
+
   std::string elecNoiseRMSWheelHistoName, pileupNoiseRMSWheelHistoName;
   std::string elecNoiseOffsetWheelHistoName, pileupNoiseOffsetWheelHistoName;
   // Read the histograms with electronics noise and pileup from the file
   for (unsigned iWheel = 0; iWheel < m_numWheels; iWheel++) {
-    elecNoiseRMSWheelHistoName = m_elecNoiseRMSHistoName +std::to_string(iWheel);
-    debug() << "Getting histogram with a name " <<  elecNoiseRMSWheelHistoName << endmsg;
-    m_histoElecNoiseRMS.push_back(* dynamic_cast<TH2F*>(noiseFile->Get(elecNoiseRMSWheelHistoName.c_str())));
+    elecNoiseRMSWheelHistoName = m_elecNoiseRMSHistoName + std::to_string(iWheel);
+    debug() << "Getting histogram with a name " << elecNoiseRMSWheelHistoName << endmsg;
+    m_histoElecNoiseRMS.push_back(*dynamic_cast<TH2F*>(noiseFile->Get(elecNoiseRMSWheelHistoName.c_str())));
     if (m_histoElecNoiseRMS.at(iWheel).GetNbinsX() < 1) {
-      error() << "Histogram  " << elecNoiseRMSWheelHistoName 
-	      << " has 0 bins! check the file with noise and the name of the histogram!" << endmsg;
+      error() << "Histogram  " << elecNoiseRMSWheelHistoName
+              << " has 0 bins! check the file with noise and the name of the histogram!" << endmsg;
       return StatusCode::FAILURE;
     }
     if (m_setNoiseOffset) {
-      elecNoiseOffsetWheelHistoName = m_elecNoiseOffsetHistoName +std::to_string(iWheel);
-      debug() << "Getting histogram with a name " << elecNoiseOffsetWheelHistoName  << endmsg;
+      elecNoiseOffsetWheelHistoName = m_elecNoiseOffsetHistoName + std::to_string(iWheel);
+      debug() << "Getting histogram with a name " << elecNoiseOffsetWheelHistoName << endmsg;
       m_histoElecNoiseOffset.push_back(*dynamic_cast<TH2F*>(noiseFile->Get(elecNoiseOffsetWheelHistoName.c_str())));
       if (m_histoElecNoiseOffset.at(iWheel).GetNbinsX() < 1) {
-	error() << "Histogram  " <<  elecNoiseOffsetWheelHistoName
-		<< " has 0 bins! check the file with noise and the name of the histogram!" << endmsg;
-	return StatusCode::FAILURE;
+        error() << "Histogram  " << elecNoiseOffsetWheelHistoName
+                << " has 0 bins! check the file with noise and the name of the histogram!" << endmsg;
+        return StatusCode::FAILURE;
       }
     }
     if (m_addPileup) {
-      pileupNoiseRMSWheelHistoName = m_pileupNoiseRMSHistoName +std::to_string(iWheel);
-      debug() << "Getting histogram with a name " <<  pileupNoiseRMSWheelHistoName << endmsg;
-      m_histoPileupNoiseRMS.push_back(* dynamic_cast<TH2F*>(noiseFile->Get(pileupNoiseRMSWheelHistoName.c_str())));
+      pileupNoiseRMSWheelHistoName = m_pileupNoiseRMSHistoName + std::to_string(iWheel);
+      debug() << "Getting histogram with a name " << pileupNoiseRMSWheelHistoName << endmsg;
+      m_histoPileupNoiseRMS.push_back(*dynamic_cast<TH2F*>(noiseFile->Get(pileupNoiseRMSWheelHistoName.c_str())));
       if (m_histoPileupNoiseRMS.at(iWheel).GetNbinsX() < 1) {
-	error() << "Histogram  " << pileupNoiseRMSWheelHistoName 
-		<< " has 0 bins! check the file with noise and the name of the histogram!" << endmsg;
-	return StatusCode::FAILURE;
+        error() << "Histogram  " << pileupNoiseRMSWheelHistoName
+                << " has 0 bins! check the file with noise and the name of the histogram!" << endmsg;
+        return StatusCode::FAILURE;
       }
       if (m_setNoiseOffset) {
-	pileupNoiseOffsetWheelHistoName = m_pileupNoiseOffsetHistoName +std::to_string(iWheel);
-	debug() << "Getting histogram with a name " << pileupNoiseOffsetWheelHistoName  << endmsg;
-	m_histoPileupNoiseOffset.push_back(*dynamic_cast<TH2F*>(noiseFile->Get(pileupNoiseOffsetWheelHistoName.c_str())));
-	if (m_histoPileupNoiseOffset.at(iWheel).GetNbinsX() < 1) {
-	  error() << "Histogram  " <<  pileupNoiseOffsetWheelHistoName
-		  << " has 0 bins! check the file with noise and the name of the histogram!" << endmsg;
-	  return StatusCode::FAILURE;
-	}
+        pileupNoiseOffsetWheelHistoName = m_pileupNoiseOffsetHistoName + std::to_string(iWheel);
+        debug() << "Getting histogram with a name " << pileupNoiseOffsetWheelHistoName << endmsg;
+        m_histoPileupNoiseOffset.push_back(
+            *dynamic_cast<TH2F*>(noiseFile->Get(pileupNoiseOffsetWheelHistoName.c_str())));
+        if (m_histoPileupNoiseOffset.at(iWheel).GetNbinsX() < 1) {
+          error() << "Histogram  " << pileupNoiseOffsetWheelHistoName
+                  << " has 0 bins! check the file with noise and the name of the histogram!" << endmsg;
+          return StatusCode::FAILURE;
+        }
       }
     }
   }
@@ -155,18 +158,18 @@ double NoiseCaloCellsTurbineEndcapFromFileTool::getNoiseRMSPerCell(uint64_t aCel
 
   // All histograms have same binning, all bins with same size
   // Using the histogram in the first layer to get the bin size
-  if (m_histoElecNoiseRMS.size() >  0) {
-     // Check that there are not more wheels than the constants are provided for
-    if (iWheel < m_histoElecNoiseRMS.size()) {      
-      elecNoiseRMS = m_histoElecNoiseRMS.at(iWheel).GetBinContent(iZ+1, iRho+1);
+  if (m_histoElecNoiseRMS.size() > 0) {
+    // Check that there are not more wheels than the constants are provided for
+    if (iWheel < m_histoElecNoiseRMS.size()) {
+      elecNoiseRMS = m_histoElecNoiseRMS.at(iWheel).GetBinContent(iZ + 1, iRho + 1);
       debug() << "Here with noise RMS = " << elecNoiseRMS << endmsg;
       if (m_addPileup) {
-	pileupNoiseRMS = m_histoPileupNoiseRMS.at(iWheel).GetBinContent(iZ+1, iRho+1);
+        pileupNoiseRMS = m_histoPileupNoiseRMS.at(iWheel).GetBinContent(iZ + 1, iRho + 1);
       }
     } else {
       error() << "More wheels than we have noise for!!!!! " << endmsg;
     }
-  
+
   } else {
     error() << "No histograms with RMS noise constants!!!!! " << endmsg;
   }
@@ -179,10 +182,9 @@ double NoiseCaloCellsTurbineEndcapFromFileTool::getNoiseRMSPerCell(uint64_t aCel
     totalNoiseRMS = elecNoiseRMS * m_scaleFactor;
   }
   if (totalNoiseRMS < 1e-6) {
-    warning() << "Zero noise RMS:  iZ, iRho " << iZ << "," << iRho  << " noise RMS " << totalNoiseRMS
-              << endmsg;
+    warning() << "Zero noise RMS:  iZ, iRho " << iZ << "," << iRho << " noise RMS " << totalNoiseRMS << endmsg;
   }
-  
+
   return totalNoiseRMS;
 }
 
@@ -193,28 +195,28 @@ double NoiseCaloCellsTurbineEndcapFromFileTool::getNoiseOffsetPerCell(uint64_t a
 
   double elecNoiseOffset = 0.;
   double pileupNoiseOffset = 0.;
-  
+
   unsigned iWheel = m_decoder->get(aCellId, "wheel");
   unsigned iRho = m_decoder->get(aCellId, "rho");
   unsigned iZ = m_decoder->get(aCellId, "z");
-  
+
   // All histograms have same binning, all bins with same size
   // Using the histogram in the first layer to get the bin size
-  if (m_histoElecNoiseOffset.size() >  0) {
+  if (m_histoElecNoiseOffset.size() > 0) {
     // Check that there are not more wheels than the constants are provided for
     if (iWheel < m_histoElecNoiseOffset.size()) {
-      elecNoiseOffset = m_histoElecNoiseOffset.at(iWheel).GetBinContent(iZ+1, iRho+1);
+      elecNoiseOffset = m_histoElecNoiseOffset.at(iWheel).GetBinContent(iZ + 1, iRho + 1);
       if (m_addPileup) {
-	pileupNoiseOffset = m_histoPileupNoiseOffset.at(iWheel).GetBinContent(iZ+1, iRho+1);
+        pileupNoiseOffset = m_histoPileupNoiseOffset.at(iWheel).GetBinContent(iZ + 1, iRho + 1);
       }
     } else {
       error() << "More wheels than we have noise for!!!!! " << endmsg;
     }
-    
+
   } else {
     error() << "No histograms with Offset noise constants!!!!! " << endmsg;
   }
-  
+
   // Total noise: electronics noise + pileup
   double totalNoiseOffset = 0;
   if (m_addPileup) {
@@ -222,17 +224,14 @@ double NoiseCaloCellsTurbineEndcapFromFileTool::getNoiseOffsetPerCell(uint64_t a
   } else { // avoid useless math operations if no pileup
     totalNoiseOffset = elecNoiseOffset * m_scaleFactor;
   }
-  
+
   if (totalNoiseOffset < 1e-6) {
-    warning() << "Zero noise Offset:  iZ, iRho " << iZ << "," << iRho << " noise Offset " << totalNoiseOffset
-              << endmsg;
+    warning() << "Zero noise Offset:  iZ, iRho " << iZ << "," << iRho << " noise Offset " << totalNoiseOffset << endmsg;
   }
-  
+
   return totalNoiseOffset;
 }
 
-std::pair<double, double> NoiseCaloCellsTurbineEndcapFromFileTool::getNoisePerCell(uint64_t aCellId) const
-{
-  return std::make_pair (getNoiseRMSPerCell(aCellId),
-                         getNoiseOffsetPerCell(aCellId));
+std::pair<double, double> NoiseCaloCellsTurbineEndcapFromFileTool::getNoisePerCell(uint64_t aCellId) const {
+  return std::make_pair(getNoiseRMSPerCell(aCellId), getNoiseOffsetPerCell(aCellId));
 }

--- a/RecFCCeeCalorimeter/src/components/NoiseCaloCellsTurbineEndcapFromFileTool.h
+++ b/RecFCCeeCalorimeter/src/components/NoiseCaloCellsTurbineEndcapFromFileTool.h
@@ -10,9 +10,9 @@
 // #include "detectorSegmentations/FCCSWGridPhiEta_k4geo.h"
 
 // k4FWCore
-#include "k4Interface/ICellPositionsTool.h"
-#include "k4Interface/INoiseCaloCellsTool.h"
-#include "k4Interface/INoiseConstTool.h"
+#include "RecCaloCommon/ICellPositionsTool.h"
+#include "RecCaloCommon/INoiseCaloCellsTool.h"
+#include "RecCaloCommon/INoiseConstTool.h"
 
 class IGeoSvc;
 
@@ -32,7 +32,7 @@ class TH1F;
  *
  */
 
-class NoiseCaloCellsTurbineEndcapFromFileTool : public extends<AlgTool, INoiseCaloCellsTool, INoiseConstTool> {
+class NoiseCaloCellsTurbineEndcapFromFileTool : public extends<AlgTool, k4::recCalo::INoiseCaloCellsTool, k4::recCalo::INoiseConstTool> {
 public:
   using base_class::base_class;
   virtual ~NoiseCaloCellsTurbineEndcapFromFileTool() = default;
@@ -70,7 +70,7 @@ private:
   void filterCellNoiseT(C& aCells) const;
 
   /// Handle for tool to get cell positions
-  ToolHandle<ICellPositionsTool> m_cellPositionsTool{this, "cellPositionsTool", "CellPositionsDummyTool",
+  ToolHandle<k4::recCalo::ICellPositionsTool> m_cellPositionsTool{this, "cellPositionsTool", "CellPositionsDummyTool",
                                                      "Handle for tool to retrieve cell positions"};
 
   /// Add pileup contribution to the electronics noise? (only if read from file)

--- a/RecFCCeeCalorimeter/src/components/NoiseCaloCellsTurbineEndcapFromFileTool.h
+++ b/RecFCCeeCalorimeter/src/components/NoiseCaloCellsTurbineEndcapFromFileTool.h
@@ -1,0 +1,137 @@
+#ifndef RECFCCEECALORIMETER_NOISECALOCELLSTURBINEENDCAPFROMFILETOOL_H
+#define RECFCCEECALORIMETER_NOISECALOCELLSTURBINEENDCAPFROMFILETOOL_H
+
+// from Gaudi
+#include "GaudiKernel/AlgTool.h"
+#include "GaudiKernel/IRndmGenSvc.h"
+#include "GaudiKernel/RndmGenerators.h"
+
+// k4geo
+// #include "detectorSegmentations/FCCSWGridPhiEta_k4geo.h"
+
+// k4FWCore
+#include "k4Interface/ICellPositionsTool.h"
+#include "k4Interface/INoiseCaloCellsTool.h"
+#include "k4Interface/INoiseConstTool.h"
+
+class IGeoSvc;
+
+// Root
+class TH1F;
+
+/** @class NoiseCaloCellsTurbineEndcapFromFileTool
+ *
+ *  Tool for calorimeter noise
+ *  Access noise constants from TH1F histogram (noise vs. calibration layer)
+ *  createRandomCellNoise: Create random CaloHits (gaussian distribution) for the vector of cells
+ *  filterCellNoise: remove cells with energy below threshold*sigma from the vector of cells
+ * 
+ *
+ *  @author Erich Varnes
+ *  @date   2026-03
+ *
+ */
+
+class NoiseCaloCellsTurbineEndcapFromFileTool : public extends<AlgTool, INoiseCaloCellsTool,  INoiseConstTool> {
+public:
+  using base_class::base_class;
+  virtual ~NoiseCaloCellsTurbineEndcapFromFileTool() = default;
+  virtual StatusCode initialize() override final;
+
+  /** @brief Create random CaloHits (gaussian distribution) for the vector of cells (aCells).
+   * Vector of cells must contain all cells in the calorimeter with their cellIDs.
+   */
+  virtual void addRandomCellNoise(std::unordered_map<uint64_t, double>& aCells) const override final;
+
+  /** @brief Create random CaloHits (gaussian distribution) for the vector of cells (aCells).
+   * Vector of cells must contain all cells in the calorimeter with their cellIDs.
+   */
+  virtual void addRandomCellNoise(std::vector<std::pair<uint64_t, double> >& aCells) const override final;
+
+  /** @brief Remove cells with energy below threshold*sigma from the vector of cells
+   */
+  virtual void filterCellNoise(std::unordered_map<uint64_t, double>& aCells) const override final;
+
+  /** @brief Remove cells with energy below threshold*sigma from the vector of cells
+   */
+  virtual void filterCellNoise(std::vector<std::pair<uint64_t, double> >& aCells)    const final;
+
+  /// Open file and read noise histograms in the memory
+  StatusCode initNoiseFromFile();
+  /// Find the appropriate noise RMS from the histogram
+  virtual double getNoiseRMSPerCell(uint64_t aCellID) const override final;
+  virtual double getNoiseOffsetPerCell(uint64_t aCellID) const override final;
+  virtual std::pair<double, double> getNoisePerCell(uint64_t aCellID) const override final;
+private:
+  template <typename C>
+  void addRandomCellNoiseT (C& aCells) const;
+  template <typename C>
+  void filterCellNoiseT (C& aCells) const;
+
+  /// Handle for tool to get cell positions
+  ToolHandle<ICellPositionsTool> m_cellPositionsTool{this, "cellPositionsTool", "CellPositionsDummyTool", "Handle for tool to retrieve cell positions"};
+
+  /// Add pileup contribution to the electronics noise? (only if read from file)
+  Gaudi::Property<bool> m_addPileup{this, "addPileup", true,
+                                    "Add pileup contribution to the electronics noise? (only if read from file)"};
+  /// Read noise offset from histograms in files or not (if false, offset is set to 0)
+  Gaudi::Property<bool> m_setNoiseOffset{this, "setNoiseOffset", false, "Set a noise offset per cell"};
+  /// Name of the file with noise constants
+  Gaudi::Property<std::string> m_noiseFileName{this, "noiseFileName", "", "Name of the file with noise constants"};
+  /// Factor to apply to the noise values to get them in GeV if e.g. they were produced in MeV
+  Gaudi::Property<float> m_scaleFactor{this, "scaleFactor", 1, "Factor to apply to the noise values"};
+  /// Name of the detector readout (only needed to retrieve the decoder)
+  Gaudi::Property<std::string> m_readoutName{this, "readoutName", "ECalEndcapTurbine",
+                                             "Name of the detector readout"};
+  /// Name of active layers for sampling calorimeter
+  Gaudi::Property<std::string> m_activeFieldName{this, "activeFieldName", "layer",
+                                                 "Name of active layers for sampling calorimeter"};
+  /// Name of pileup noise RMS histogram
+  Gaudi::Property<std::string> m_pileupNoiseRMSHistoName{this, "pileupNoiseRMSHistoName", "h_pileup_layer",
+                                                         "Name of pileup noise RMS histogram"};
+  /// Name of electronics noise RMS histogram
+  Gaudi::Property<std::string> m_elecNoiseRMSHistoName{this, "elecNoiseRMSHistoName", "h_elecNoise_layer",
+                                                       "Name of electronics noise RMS histogram"};
+  /// Name of electronics noise offset histogram
+  Gaudi::Property<std::string> m_elecNoiseOffsetHistoName{this, "elecNoiseOffsetHistoName", "h_mean_pileup_layer",
+                                                          "Name of electronics noise offset histogram"};
+  /// Name of pileup noise offset histogram
+  Gaudi::Property<std::string> m_pileupNoiseOffsetHistoName{this, "pileupNoiseOffsetHistoName", "h_pileup_layer",
+                                                            "Name of pileup noise offset histogram"};
+
+  /// Energy threshold (cells with Ecell < filterThreshold*m_cellNoise removed)
+  Gaudi::Property<double> m_filterThreshold{
+      this, "filterNoiseThreshold", 3,
+      "Energy threshold (cells with Ecell < offset + filterThreshold*m_cellNoise removed)"};
+  /// Change the cell filter condition to remove only cells with abs(Ecell) < offset + filterThreshold*m_cellNoise
+  /// removed) This avoids to keep only 'one side'  of the noise fluctuations and prevents biasing cluster energy
+  /// towards higher energies
+  Gaudi::Property<bool> m_useAbsInFilter{
+      this, "useAbsInFilter", false,
+      "If set, cell filtering condition becomes: drop cell if abs(Ecell-offset) < filterThreshold*m_cellNoise"};
+  /// Number of radial layers
+  Gaudi::Property<uint> m_numWheels{this, "numWheels", 3, "Number of wheels"};
+
+  /// Histogram with pileup noise RMS (histograms binned in rho and z, array index -- wheel ) 
+  std::vector<TH2F> m_histoPileupNoiseRMS;
+  /// Histograms with electronics noise RMS (histograms binned in rho and z, array index -- wheel )
+  std::vector<TH2F> m_histoElecNoiseRMS;
+  /// Histograms with pileup offset (histograms binned in rho and z, array index -- wheel )
+  std::vector<TH2F>  m_histoPileupNoiseOffset;
+  /// Histograms with electronics noise offset (histograms binned in rho and z, array index -- wheel )
+  std::vector<TH2F>  m_histoElecNoiseOffset;
+
+  /// Random Number Service
+  SmartIF<IRndmGenSvc> m_randSvc;
+  /// Gaussian random number generator used for the generation of random noise hits
+  Rndm::Numbers m_gauss;
+
+  /// Pointer to the geometry service
+  ServiceHandle<IGeoSvc> m_geoSvc { this, "GeoSvc", "GeoSvc" };
+
+  /// Decoder for ECal layers
+  dd4hep::DDSegmentation::BitFieldCoder* m_decoder;
+  int m_index_activeField;
+};
+
+#endif /* RECFCCEECALORIMETER_NOISECALOCELLSTURBINEENDCAPFROMFILETOOL_H */

--- a/RecFCCeeCalorimeter/src/components/NoiseCaloCellsTurbineEndcapFromFileTool.h
+++ b/RecFCCeeCalorimeter/src/components/NoiseCaloCellsTurbineEndcapFromFileTool.h
@@ -25,14 +25,14 @@ class TH1F;
  *  Access noise constants from TH1F histogram (noise vs. calibration layer)
  *  createRandomCellNoise: Create random CaloHits (gaussian distribution) for the vector of cells
  *  filterCellNoise: remove cells with energy below threshold*sigma from the vector of cells
- * 
+ *
  *
  *  @author Erich Varnes
  *  @date   2026-03
  *
  */
 
-class NoiseCaloCellsTurbineEndcapFromFileTool : public extends<AlgTool, INoiseCaloCellsTool,  INoiseConstTool> {
+class NoiseCaloCellsTurbineEndcapFromFileTool : public extends<AlgTool, INoiseCaloCellsTool, INoiseConstTool> {
 public:
   using base_class::base_class;
   virtual ~NoiseCaloCellsTurbineEndcapFromFileTool() = default;
@@ -46,7 +46,7 @@ public:
   /** @brief Create random CaloHits (gaussian distribution) for the vector of cells (aCells).
    * Vector of cells must contain all cells in the calorimeter with their cellIDs.
    */
-  virtual void addRandomCellNoise(std::vector<std::pair<uint64_t, double> >& aCells) const override final;
+  virtual void addRandomCellNoise(std::vector<std::pair<uint64_t, double>>& aCells) const override final;
 
   /** @brief Remove cells with energy below threshold*sigma from the vector of cells
    */
@@ -54,7 +54,7 @@ public:
 
   /** @brief Remove cells with energy below threshold*sigma from the vector of cells
    */
-  virtual void filterCellNoise(std::vector<std::pair<uint64_t, double> >& aCells)    const final;
+  virtual void filterCellNoise(std::vector<std::pair<uint64_t, double>>& aCells) const final;
 
   /// Open file and read noise histograms in the memory
   StatusCode initNoiseFromFile();
@@ -62,14 +62,16 @@ public:
   virtual double getNoiseRMSPerCell(uint64_t aCellID) const override final;
   virtual double getNoiseOffsetPerCell(uint64_t aCellID) const override final;
   virtual std::pair<double, double> getNoisePerCell(uint64_t aCellID) const override final;
+
 private:
   template <typename C>
-  void addRandomCellNoiseT (C& aCells) const;
+  void addRandomCellNoiseT(C& aCells) const;
   template <typename C>
-  void filterCellNoiseT (C& aCells) const;
+  void filterCellNoiseT(C& aCells) const;
 
   /// Handle for tool to get cell positions
-  ToolHandle<ICellPositionsTool> m_cellPositionsTool{this, "cellPositionsTool", "CellPositionsDummyTool", "Handle for tool to retrieve cell positions"};
+  ToolHandle<ICellPositionsTool> m_cellPositionsTool{this, "cellPositionsTool", "CellPositionsDummyTool",
+                                                     "Handle for tool to retrieve cell positions"};
 
   /// Add pileup contribution to the electronics noise? (only if read from file)
   Gaudi::Property<bool> m_addPileup{this, "addPileup", true,
@@ -81,8 +83,7 @@ private:
   /// Factor to apply to the noise values to get them in GeV if e.g. they were produced in MeV
   Gaudi::Property<float> m_scaleFactor{this, "scaleFactor", 1, "Factor to apply to the noise values"};
   /// Name of the detector readout (only needed to retrieve the decoder)
-  Gaudi::Property<std::string> m_readoutName{this, "readoutName", "ECalEndcapTurbine",
-                                             "Name of the detector readout"};
+  Gaudi::Property<std::string> m_readoutName{this, "readoutName", "ECalEndcapTurbine", "Name of the detector readout"};
   /// Name of active layers for sampling calorimeter
   Gaudi::Property<std::string> m_activeFieldName{this, "activeFieldName", "layer",
                                                  "Name of active layers for sampling calorimeter"};
@@ -112,14 +113,14 @@ private:
   /// Number of radial layers
   Gaudi::Property<uint> m_numWheels{this, "numWheels", 3, "Number of wheels"};
 
-  /// Histogram with pileup noise RMS (histograms binned in rho and z, array index -- wheel ) 
+  /// Histogram with pileup noise RMS (histograms binned in rho and z, array index -- wheel )
   std::vector<TH2F> m_histoPileupNoiseRMS;
   /// Histograms with electronics noise RMS (histograms binned in rho and z, array index -- wheel )
   std::vector<TH2F> m_histoElecNoiseRMS;
   /// Histograms with pileup offset (histograms binned in rho and z, array index -- wheel )
-  std::vector<TH2F>  m_histoPileupNoiseOffset;
+  std::vector<TH2F> m_histoPileupNoiseOffset;
   /// Histograms with electronics noise offset (histograms binned in rho and z, array index -- wheel )
-  std::vector<TH2F>  m_histoElecNoiseOffset;
+  std::vector<TH2F> m_histoElecNoiseOffset;
 
   /// Random Number Service
   SmartIF<IRndmGenSvc> m_randSvc;
@@ -127,7 +128,7 @@ private:
   Rndm::Numbers m_gauss;
 
   /// Pointer to the geometry service
-  ServiceHandle<IGeoSvc> m_geoSvc { this, "GeoSvc", "GeoSvc" };
+  ServiceHandle<IGeoSvc> m_geoSvc{this, "GeoSvc", "GeoSvc"};
 
   /// Decoder for ECal layers
   dd4hep::DDSegmentation::BitFieldCoder* m_decoder;


### PR DESCRIPTION

BEGINRELEASENOTES

This PR adds code for creating the noise map for the turbine ECal endcap. This is modeled closely on the code used to make the barrel noise map.
 
ENDRELEASENOTES
