### PR TITLE
ICalorimeterTool updates.

### DIFF
--- a/RecCaloCommon/include/RecCaloCommon/CalorimeterToolBase.h
+++ b/RecCaloCommon/include/RecCaloCommon/CalorimeterToolBase.h
@@ -39,27 +39,25 @@ public:
    * The result is sorted and unique.
    * Returns an empty vector on error.
    */
-  virtual const std::vector<CellID>& cellIDs() const final;
+  virtual const std::vector<CellID>& cellIDs() const final override;
 
   /** Prepare a map of all existing cells in current geometry.
    *   @param[out] aCells map of existing cells (and deposited energy, set to 0)
    *   return Status code.
    */
-  virtual StatusCode prepareEmptyCells(std::unordered_map<CellID, double>& aCells) const final;
-  virtual StatusCode prepareEmptyCells(std::unordered_map<CellID, double>& aCells) final override
-  { const auto* cthis = this;  return cthis->prepareEmptyCells(aCells); }
+  virtual StatusCode prepareEmptyCells(std::unordered_map<CellID, double>& aCells) const final override;
 
   /** Return the segmentation associated with this geometry.
    */
-  virtual const dd4hep::DDSegmentation::Segmentation* segmentation() const final;
+  virtual const dd4hep::DDSegmentation::Segmentation* segmentation() const final override;
 
   /** Return the name specified for the readout.
    */
-  virtual const std::string& readoutName() const final;
+  virtual const std::string& readoutName() const final override;
 
   /** Return the subdetector ID.
    */
-  virtual int id() const final;
+  virtual int id() const final override;
 
 
 protected:

--- a/RecCaloCommon/include/RecCaloCommon/ICalorimeterTool.h
+++ b/RecCaloCommon/include/RecCaloCommon/ICalorimeterTool.h
@@ -27,6 +27,13 @@
 #include "GaudiKernel/IAlgTool.h"
 
 #include <memory>
+#include <unordered_map>
+#include <vector>
+
+
+namespace dd4hep::DDSegmentation {
+  class Segmentation;
+} // namespace dd4hep::DDSegmentation
 
 
 namespace k4::recCalo {
@@ -44,11 +51,27 @@ public:
 
   DeclareInterfaceID(ICalorimeterTool, 1, 0);
 
+  /** Fill vector with all existing cells for this geometry.
+   */
+  virtual const std::vector<CellID>& cellIDs() const = 0;
+
   /** Prepare a map of all existing cells in current geometry.
    *   @param[out] aCells map of existing cells (and deposited energy, set to 0)
    *   return Status code.
    */
-  virtual StatusCode prepareEmptyCells(std::unordered_map<CellID, double>& aCells) = 0;
+  virtual StatusCode prepareEmptyCells(std::unordered_map<CellID, double>& aCells) const = 0;
+
+  /** Return the segmentation associated with this geometry.
+   */
+  virtual const dd4hep::DDSegmentation::Segmentation* segmentation() const = 0;
+
+  /** Return the name specified for the readout.
+   */
+  virtual const std::string& readoutName() const = 0;
+
+  /** Return the subdetector ID.
+   */
+  virtual int id() const = 0;
 
   /** Return a new indexer object for this subdetector.
    *


### PR DESCRIPTION
Remove non-const methods of ICalorimeterTool and (re)-add override keywords in CalorimeterToolBase.
Add cellIDs/segmentation/readoutName/id methods to ICalorimeterTool (implementations are already in CalorimeterToolBase).

BEGINRELEASENOTES
- Remove non-const methods from ICalorimeterTool and add cellIDs/segmentation/readoutName/id methods.
ENDRELEASENOTES
