### PR TITLE
Remove duplication of CellID lists.

### DIFF
--- a/RecCaloCommon/include/RecCaloCommon/CalorimeterToolBase.h
+++ b/RecCaloCommon/include/RecCaloCommon/CalorimeterToolBase.h
@@ -14,10 +14,10 @@
 #include "GaudiKernel/AlgTool.h"
 #include "GaudiKernel/ServiceHandle.h"
 #include "RecCaloCommon/ICalorimeterTool.h"
+#include "RecCaloCommon/ICaloCellConstantsSvc.h"
 #include "k4Interface/IGeoSvc.h"
 #include "DD4hep/Readout.h"
 #include <vector>
-#include <mutex>
 
 
 /** @class CalorimeterToolBase RecCaloCommon/include/CalorimeterToolBase.h
@@ -72,6 +72,10 @@ protected:
   virtual StatusCode collectCells(std::vector<CellID>& cells) const = 0;
 
 
+  /// Create the list of cells and store with the constants service.
+  StatusCode makeCells();
+
+
 private:
   /// Name of the detector readout
   Gaudi::Property<std::string> m_readoutName{this, "readoutName", ""};
@@ -79,13 +83,17 @@ private:
   /// Handle to the geometry service.
   ServiceHandle<IGeoSvc> m_geoSvc { this, "GeoSvc", "GeoSvc" };
 
+  /// Handle to the cell constants service.
+  /// Used to hold the set of cell IDs.
+  ServiceHandle<k4::recCalo::ICaloCellConstantsSvc> m_constantsSvc
+  { this, "CaloCellConstantsSvc", "k4::recCalo::CaloCellConstantsSvc", "" };
+
   /// Resolved detector readout.
   dd4hep::Readout m_readout;
 
-  // The vector of cells is filled once, the first time we need it.
-  mutable std::mutex m_mutex;
-  mutable bool m_filledCells = false;
-  mutable std::vector<CellID> m_cells;
+  // Pointer to the vector of cells.  The vector itself is stored in the
+  // constants service; we create it if it's not already there.
+  const std::vector<CellID>* m_cells;
 };
 
 

--- a/RecCaloCommon/src/CalorimeterToolBase.cpp
+++ b/RecCaloCommon/src/CalorimeterToolBase.cpp
@@ -7,17 +7,18 @@
 
 #include "RecCaloCommon/CalorimeterToolBase.h"
 #include "k4Interface/IGeoSvc.h"
-#include "RecCaloCommon/k4RecCalorimeter_check.h"
+#include "k4FWCore/GaudiChecks.h"
 #include "DD4hep/Detector.h"
 #include <algorithm>
+#include <string>
 
 
 /** Standard Gaudi initialize method.
  */
 StatusCode CalorimeterToolBase::initialize()
 {
-  K4RECCALORIMETER_CHECK( AlgTool::initialize() );
-  K4RECCALORIMETER_CHECK( m_geoSvc.retrieve() );
+  K4_GAUDI_CHECK( AlgTool::initialize() );
+  K4_GAUDI_CHECK( m_geoSvc.retrieve() );
 
   // Look up the readout.
   if (!m_readoutName.empty()) {
@@ -32,6 +33,12 @@ StatusCode CalorimeterToolBase::initialize()
     m_readout = it->second;
   }
 
+  // Need to do this after m_readout is defined, since it may ask us
+  // for our id.
+  K4_GAUDI_CHECK( m_constantsSvc.retrieve() );
+
+  K4_GAUDI_CHECK( makeCells() );
+
   return StatusCode::SUCCESS;
 }
 
@@ -43,22 +50,7 @@ StatusCode CalorimeterToolBase::initialize()
  */
 auto CalorimeterToolBase::cellIDs() const -> const std::vector<CellID>&
 {
-  {
-    std::lock_guard lock (m_mutex);
-    if (!m_filledCells) {
-      if (collectCells(m_cells).isSuccess()) {
-        // Sort and make unique.
-        std::ranges::sort(m_cells);
-        const auto ret = std::ranges::unique(m_cells);
-        m_cells.erase(ret.begin(), ret.end());
-      }
-      else {
-        m_cells.clear();
-      }
-      m_filledCells = true;
-    }
-  }
-  return m_cells;
+  return *m_cells;
 }
 
 
@@ -105,4 +97,37 @@ int CalorimeterToolBase::id() const
     error() << name() << ": " << "Readout not found; can't find detector ID" << endmsg;
   }
   return m_readout.segmentation().detector()->id;
+}
+
+
+/** Create the list of cells and store with the constants service.
+ */
+StatusCode CalorimeterToolBase::makeCells()
+{
+  int detid = id();
+  std::string keyName = "cellIDs-";
+  if (detid >= 0)
+    keyName += std::to_string (detid);
+  else
+    keyName += "dummy";
+
+  m_cells = m_constantsSvc->getObj<std::vector<uint64_t> > (keyName);
+  if (m_cells) {
+    return StatusCode::SUCCESS;
+  }
+
+  std::vector<uint64_t> cells;
+  if (detid >= 0) {
+    K4_GAUDI_CHECK( collectCells(cells) );
+    // Sort and make unique.
+    std::ranges::sort(cells);
+    const auto ret = std::ranges::unique(cells);
+    cells.erase(ret.begin(), ret.end());
+  }
+
+  K4_GAUDI_CHECK( m_constantsSvc->putObj (keyName, std::move(cells)) );
+  m_cells = m_constantsSvc->getObj<std::vector<uint64_t> > (keyName);
+  K4_GAUDI_CHECK( m_cells != nullptr );
+
+  return StatusCode::SUCCESS;
 }


### PR DESCRIPTION
Store lists of calorimeter CellIDs in the cell constants service, to avoid duplicates.

BEGINRELEASENOTES
- Store lists of CellIDs in CaloCellConstantsSvc to avoid duplication.
ENDRELEASENOTES
