### PR TITLE
Add MultiIndexer

### DIFF
--- a/RecCaloCommon/CMakeLists.txt
+++ b/RecCaloCommon/CMakeLists.txt
@@ -39,4 +39,11 @@ if(BUILD_TESTING)
     LINK DD4hep::DDCore k4FWCore::k4Interface k4FWCore::k4FWCore
     TEST)
   target_include_directories(IDMapIndexer_test.exe AFTER PUBLIC include)
+
+
+  gaudi_add_executable(MultiIndexer_test.exe
+    SOURCES tests/MultiIndexer_test.cpp src/MultiIndexer.cpp
+    LINK DD4hep::DDCore k4FWCore::k4Interface k4FWCore::k4FWCore
+    TEST)
+  target_include_directories(MultiIndexer_test.exe AFTER PUBLIC include)
 endif()

--- a/RecCaloCommon/include/RecCaloCommon/MultiIndexer.h
+++ b/RecCaloCommon/include/RecCaloCommon/MultiIndexer.h
@@ -1,0 +1,166 @@
+// This file's extension implies that it's C, but it's really -*- C++ -*-.
+/**
+ * @file RecCaloCommon/MultiIndexer.h
+ * @author scott snyder <snyder@bnl.gov>
+ * @date Feb, 2026
+ * @brief Implementation of ICaloIndexer for multiple detectors.
+ */
+
+
+#ifndef RECCALOCOMMON_MULTIINDEXER_H
+#define RECCALOCOMMON_MULTIINDEXER_H
+
+
+#include "RecCaloCommon/ICaloCellConstantsSvc.h"
+#include "RecCaloCommon/ICaloIndexer.h"
+#include <vector>
+#include <stdexcept>
+
+
+namespace k4::recCalo {
+
+
+/**
+ * @brief Implementation of ICaloIndexer for multiple detectors.
+ *
+ * This is an ICaloIndexer implementation that logically joins together
+ * several detectors.  It is initialized with the ICaloIndexer objects
+ * for each individual detector, along with the number of bits used
+ * in the identifiers for the detector ID.  We reference the ICaloIndexer
+ * instances given to us, but we need to make a vector of the concatenated lists
+ * of IDs.  We store this in a given ICaloCellConstantsSvc also given
+ * at initialization.
+ */
+class MultiIndexer : public ICaloIndexer
+{
+public:
+  /// Type of an index.
+  using index_t = ICaloIndexer::index_t;
+
+  /// Flag indicating an invalid index.
+  static constexpr index_t INVALID = static_cast<index_t>(-1);
+
+
+  /**
+   * @brief Constructor.
+   * @param detIDBits Number of bits in the cell identifier used for the
+   *                  detector ID.  (We assume that this starts at the
+   *                  least significant bit.)
+   *                  We require this to be no more than 8 to avoid
+   *                  unreasonable memory allocation.s.
+   * @param indexers  Collection of indexers for each detector.
+   * @param constsSvc Used to store the concatenated vector of cell IDs.
+   */
+  MultiIndexer (size_t detIDBits,
+                std::span<const ICaloIndexer* const> indexers,
+                ICaloCellConstantsSvc& constsSvc);
+
+
+  /**
+   * @brief Return the index of an identifier.
+   * @param id The identifier to look for.
+   *
+   * Returns the index of @c id in @c cellIDs(), or @c INVALID.
+   */
+  virtual index_t index (uint64_t id) const override final;
+
+
+  /**
+   * @brief Return the set of all identifiers that we index.
+   */
+  virtual std::span<const uint64_t> cellIDs() const override final;
+
+
+  /**
+   * @brief Return the IDs of the detector(s) that we index.
+   */
+  virtual std::span<const int> detIDs() const override final;
+
+
+  /**
+   * @brief Number of bits in the cell ID used for the detector ID.
+   */
+  virtual size_t detIDBits() const override;
+
+
+  /**
+   * @brief Exceptions thrown by the ctor.
+   */
+  class MultiIndexerException : public std::runtime_error
+  {
+  public:
+    MultiIndexerException (const std::string& what);
+  };
+
+
+private:
+  /// Number of detector ID bits.
+  size_t m_detIDBits;
+
+  /// Mask to extract the detector ID from a cell ID.
+  uint64_t m_detIDMask;
+
+  /// indexer/offset pairs. indexed by detector ID.
+  /// To avoid having to do checks on the accesses, we size this vector
+  /// to the maximum possible number of detector IDs, given the number
+  /// of bits, and fill in empty entries with pointers to a dummy
+  /// indexer which always returns INVALID.
+  std::vector<std::pair<const ICaloIndexer*, size_t> > m_indexers;
+
+  /// The IDs of the detectors that we index.
+  std::vector<int> m_detIDs;
+
+  /// List of cell IDs, concatenated over all detectors.
+  /// The actual vector is held by the ICaloCellConstantsSvc.
+  std::span<const uint64_t> m_cellIDs;
+};
+
+
+/**
+ * @brief Return the index of an identifier.
+ */
+inline
+auto MultiIndexer::index (uint64_t id) const -> index_t
+{
+  auto& p = m_indexers[id & m_detIDMask];
+  index_t ndx = p.first->index (id);
+  if (ndx != INVALID) [[likely]]
+    return ndx + p.second;
+  return INVALID;
+}
+
+
+/**
+ * @brief Return the set of all identifiers that we index.
+ */
+inline
+std::span<const uint64_t> MultiIndexer::cellIDs() const
+{
+  return m_cellIDs;
+}
+
+
+/**
+ * @brief Return the IDs of the detector(s) that we index.
+ */
+inline
+std::span<const int> MultiIndexer::detIDs() const
+{
+  return m_detIDs;
+}
+
+
+/**
+ * @brief Number of bits in the cell ID used for the detector ID.
+ */
+inline
+size_t MultiIndexer::detIDBits() const
+{
+  return m_detIDBits;
+}
+
+
+} // namespace k4::recCalo
+
+
+#endif // not RECCALOCOMMON_MULTIINDEXER_H

--- a/RecCaloCommon/src/MultiIndexer.cpp
+++ b/RecCaloCommon/src/MultiIndexer.cpp
@@ -1,0 +1,131 @@
+/**
+ * @file RecCaloCommon/src/MultiIndexer.cpp
+ * @author scott snyder <snyder@bnl.gov>
+ * @date Feb, 2026
+ * @brief Implementation of ICaloIndexer for multiple detectors.
+ */
+
+
+#include "RecCaloCommon/MultiIndexer.h"
+#include <string>
+#include <format>
+
+
+namespace k4::recCalo {
+
+
+/**
+ * @brief For reporting errors from the constructor.
+ */
+MultiIndexer::MultiIndexerException::MultiIndexerException (const std::string& what)
+  : std::runtime_error ("MultiIndexerException: " + what)
+{
+}
+
+
+/**
+ * @brief Dummy indexer that always returns INVALID.
+ */
+class DummyIndexer : public ICaloIndexer
+{
+  virtual index_t index (uint64_t /*id*/) const override final
+  { return ICaloIndexer::INVALID; }
+  virtual std::span<const uint64_t> cellIDs() const override final
+  { return std::span<const uint64_t>(); }
+  virtual std::span<const int> detIDs() const override final
+  { return std::span<const int>(); }
+  virtual size_t detIDBits() const override final { return 4; }
+};
+
+
+/**
+ * @brief Constructor.
+ */
+MultiIndexer::MultiIndexer (size_t detIDBits,
+                            std::span<const ICaloIndexer* const> indexers,
+                            ICaloCellConstantsSvc& constsSvc)
+  : m_detIDBits (detIDBits)
+{
+  // Check that the number of detector ID bits is reasonable.
+  if (detIDBits < 1 || detIDBits > 8) {
+    throw MultiIndexerException (std::format ("detIDBits {} out of range; should be between 1 and 8",
+                                              detIDBits));
+  }
+
+  // Mask for extracting detector ID.
+  m_detIDMask = (static_cast<uint64_t>(1) << detIDBits) - 1;
+
+  // Resize the indexer vector to the number of possible detector IDs,
+  // and fill it with pointers to a dummy indexer that always
+  // returns INVALID.
+  static const DummyIndexer dummyIndexer;
+  m_indexers.resize (m_detIDMask+1, std::make_pair (&dummyIndexer, 0));
+
+  std::string keyName = "cellIDs";
+  size_t totcells = 0;
+
+  // Loop over indexers.
+  for (const ICaloIndexer* indexer : indexers) {
+    // Check that the detector ID from this indexer is OK.
+    std::span<const int> detIDs = indexer->detIDs();
+    if (detIDs.size() != 1) {
+      throw MultiIndexerException (std::format ("bad indexer returns detIDs of size {}",
+                                                detIDs.size()));
+    }
+    if (detIDs[0] > static_cast<int>(m_detIDMask)) {
+      throw MultiIndexerException (std::format ("bad indexer returns out-of-range detID {}",
+                                                detIDs[0]));
+    }
+
+    // Remember this ID.
+    m_detIDs.push_back (detIDs[0]);
+
+    // Fill in the indexer and offset.
+    m_indexers[detIDs[0]].first = indexer;
+    m_indexers[detIDs[0]].second = totcells;
+
+    // Append the ID to the key, and count the total number of cells.
+    keyName += "-" + std::to_string(detIDs[0]);
+    totcells += indexer->cellIDs().size();
+  }
+
+  // Now we get the list of cellIDs.
+  // Don't need to do anything if it would be empty.
+  if (totcells == 0) return;
+
+  // See if we've already made this combination.
+  const std::vector<uint64_t>* cellsptr =
+    constsSvc.getObj<std::vector<uint64_t> > (keyName);
+  if (!cellsptr) {
+    // Nope.  Concatenate the cell ID lists from each indexer.
+    std::vector<uint64_t> cells;
+    cells.reserve (totcells);
+    for (const ICaloIndexer* indexer : indexers) {
+#if __cpp_lib_containers_ranges // c++23
+      cells.append_range (indexer->cellIDs());
+#else
+      std::span<const uint64_t> ids = indexer->cellIDs();
+      cells.insert (cells.end(), ids.begin(), ids.end());
+#endif
+    }
+
+    // And store in the constants service.
+    constsSvc.putObj (keyName, std::move (cells));
+    cellsptr = constsSvc.getObj<std::vector<uint64_t> > (keyName);
+  }
+
+  // Some validity checking.
+  if (!cellsptr) {
+    throw MultiIndexerException (std::format ("cannot get cells vector"));
+  }
+  if (cellsptr->size() != totcells) {
+    throw MultiIndexerException (std::format ("cells vector size mismatch.  Got {}; expected {}",
+                                              cellsptr->size(), totcells));
+  }
+
+  // Save the span over cells.
+  m_cellIDs = *cellsptr;
+}
+
+
+} // namespace k4::recCalo

--- a/RecCaloCommon/tests/MultiIndexer_test.cpp
+++ b/RecCaloCommon/tests/MultiIndexer_test.cpp
@@ -1,0 +1,148 @@
+/**
+ * @file RecCaloCommon/tests/MultiIndexer_test.cpp
+ * @author scott snyder <snyder@bnl.gov>
+ * @date Feb, 2026
+ * @brief Unit test for MultiIndexer.
+ */
+
+#undef NDEBUG
+#include "RecCaloCommon/MultiIndexer.h"
+#include "RecCaloCommon/IDMapIndexer.h"
+#include "RecCaloCommon/ICaloCellConstantsSvc.h"
+#include "DD4hep/IDDescriptor.h"
+#include <vector>
+#include <algorithm>
+
+
+using mapkey_t = uint64_t; // libc defines key_t...
+using mapkey_span = std::span<const mapkey_t>;
+
+
+// Helpers to make lists of IDS.
+#include "make_ecalb_ids.icc"
+#include "make_hcalb_ids.icc"
+
+
+class DummyCellConstantsSvc : public k4::recCalo::ICaloCellConstantsSvc
+{
+public:
+  virtual const std::any* getAnyObj (const std::string& key) const override;
+  virtual bool putAnyObj (const std::string& key, std::any&& obj) override;
+
+  virtual std::vector<std::string> getInterfaceNames() const override { return std::vector<std::string>(); }
+  virtual unsigned long addRef() const override { return 0; }
+  virtual unsigned long release() const override { return 0; }
+  virtual unsigned long refCount() const override { return 0; }
+  virtual void const* i_cast( const InterfaceID& ) const override { return nullptr; }
+  virtual unsigned long decRef() const override { return 0; }
+  virtual StatusCode queryInterface(const InterfaceID&, void**) override { return StatusCode::FAILURE; }
+
+
+private:
+  std::map<std::string, std::any> m_objs;
+};
+
+
+const std::any* DummyCellConstantsSvc::getAnyObj (const std::string& key) const
+{
+  auto it = m_objs.find (key);
+  if (it != m_objs.end()) return &it->second;
+  return nullptr;
+}
+
+
+bool DummyCellConstantsSvc::putAnyObj (const std::string& key, std::any&& obj)
+{
+  return m_objs.try_emplace (key, std::move(obj)).second;
+}
+
+
+//************************************************************************
+
+
+void test1 (mapkey_span ecalb_ids, mapkey_span hcalb_ids)
+{
+  using Indexer_t = k4::recCalo::IDMapIndexer<3>;
+  using IDMap_t = Indexer_t::IDMap_t;
+  using FieldDesc_t = Indexer_t::FieldDesc_t;
+
+  dd4hep::IDDescriptor ecalb_desc ("desc", ecalb_descstr);
+  std::vector<FieldDesc_t> ecalb_fielddescs
+    {
+      IDMap_t::makeDesc (*ecalb_desc.field ("layer")),
+      IDMap_t::makeDesc (*ecalb_desc.field ("theta")),
+      IDMap_t::makeDesc (*ecalb_desc.field ("module")),
+    };
+
+  dd4hep::IDDescriptor hcalb_desc ("desc", hcalb_descstr);
+  std::vector<FieldDesc_t> hcalb_fielddescs
+    {
+      IDMap_t::makeDesc (*hcalb_desc.field ("layer")),
+      IDMap_t::makeDesc (*hcalb_desc.field ("theta")),
+      IDMap_t::makeDesc (*hcalb_desc.field ("phi")),
+    };
+
+  Indexer_t ecalb_map (4, 4, ecalb_fielddescs, ecalb_ids);
+  Indexer_t hcalb_map (8, 4, hcalb_fielddescs, hcalb_ids);
+
+  DummyCellConstantsSvc constsSvc;
+  std::vector<const k4::recCalo::ICaloIndexer*> indexers { &ecalb_map, &hcalb_map };
+  k4::recCalo::MultiIndexer map (4, indexers, constsSvc);
+  assert (map.detIDs().size() == 2);
+  assert (map.detIDs()[0] == 4);
+  assert (map.detIDs()[1] == 8);
+  assert (map.detIDBits() == 4);
+
+  std::span<const uint64_t> cell_ids = map.cellIDs();
+  assert (cell_ids.size() == ecalb_ids.size() + hcalb_ids.size());
+  assert (std::equal (ecalb_ids.begin(), ecalb_ids.end(), cell_ids.begin()));
+  assert (std::equal (hcalb_ids.begin(), hcalb_ids.end(), cell_ids.begin() + ecalb_ids.size()));
+
+  size_t ncell = cell_ids.size();
+  for (size_t i = 0; i < ncell; i++) {
+    assert (map.index(cell_ids[i]) == i);
+  }
+  assert (map.index (0) == Indexer_t::INVALID);
+
+
+  //***************************************************
+  // Testing for errors during construction.
+  using MultiIndexerException = k4::recCalo::MultiIndexer::MultiIndexerException;
+
+#define EXPECT_EXCEPTION(EXP, CODE) do {        \
+  bool caught = false;                          \
+  try {                                         \
+    CODE;                                       \
+  }                                             \
+  catch (const MultiIndexerException& exc) {    \
+    if (std::string (exc.what()) == EXP) {      \
+      caught = true;                            \
+    }                                           \
+    else {                                      \
+      std::cerr << exc.what() << "\n";          \
+    }                                           \
+  }                                             \
+  assert (caught);                              \
+} while(0)
+
+  EXPECT_EXCEPTION( "MultiIndexerException: detIDBits 40 out of range; should be between 1 and 8",
+                    k4::recCalo::MultiIndexer map2 (40, indexers, constsSvc) );
+
+  std::vector<const k4::recCalo::ICaloIndexer*> indexers3 { &map };
+  EXPECT_EXCEPTION( "MultiIndexerException: bad indexer returns detIDs of size 2",
+                    k4::recCalo::MultiIndexer map3 (4, indexers3, constsSvc) );
+
+  Indexer_t ecalb_map4 (40, 10, ecalb_fielddescs, ecalb_ids);
+  std::vector<const k4::recCalo::ICaloIndexer*> indexers4 { &ecalb_map4 };
+  EXPECT_EXCEPTION( "MultiIndexerException: bad indexer returns out-of-range detID 40",
+                    k4::recCalo::MultiIndexer map4 (4, indexers4, constsSvc) );
+}
+
+
+int main()
+{
+  std::vector<mapkey_t> ecalb_ids = make_ecalb_ids();
+  std::vector<mapkey_t> hcalb_ids = make_hcalb_ids();
+  test1 (ecalb_ids, hcalb_ids);
+  return 0;
+}

--- a/RecCaloCommon/tests/make_hcalb_ids.icc
+++ b/RecCaloCommon/tests/make_hcalb_ids.icc
@@ -1,0 +1,59 @@
+/**
+ * @file RecCaloCommon/tests/make_hcalb_ids.cpp
+ * @author scott snyder <snyder@bnl.gov>
+ * @date Feb, 2026
+ * @brief Helper to make a list of IDs for testing.
+ *        Hardcoded to match the set of Allegro HCal barrel IDs as of this writing.
+ */
+
+
+const unsigned int hcalb_numLayers = 13;
+const char* const hcalb_descstr = "system:4,layer:5,row:9,theta:9,phi:10";
+
+
+std::vector<mapkey_t> make_hcalb_ids()
+{
+  std::vector<mapkey_t> ids;
+  ids.reserve (210944);
+  dd4hep::IDDescriptor desc ("desc", hcalb_descstr);
+  auto decoder = desc.decoder();
+
+  static const unsigned nphi = 256;
+  static const std::pair<unsigned, unsigned> thetas[hcalb_numLayers] = {
+    { 1, 70 }, // 0
+    { 1, 70 }, // 1
+    { 2, 69 }, // 2
+    { 2, 69 }, // 3
+    { 3, 68 }, // 4
+    { 3, 68 }, // 5
+    { 4, 67 }, // 6
+    { 5, 66 }, // 7
+    { 5, 66 }, // 8
+    { 6, 65 }, // 9
+    { 7, 64 }, // 10
+    { 8, 63 }, // 11
+    { 9, 62 }, // 11
+  };
+
+  size_t phi_index = decoder->index ("phi");
+  size_t theta_index  = decoder->index ("theta");
+
+  for (unsigned int ilayer = 0; ilayer < hcalb_numLayers; ilayer++) {
+    mapkey_t id = 0;
+    decoder->set (id, "system", 8);
+    decoder->set (id, "layer", ilayer);
+    decoder->set (id, "row", 0);
+    decoder->set (id, theta_index, 0);
+    decoder->set (id, phi_index, 0);
+
+    for (unsigned int theta = thetas[ilayer].first; theta <= thetas[ilayer].second; ++theta) {
+      decoder->set (id, theta_index, theta);
+      for (unsigned int iphi = 0; iphi < nphi; ++iphi) {
+        decoder->set (id, phi_index, iphi);
+        ids.push_back (id);
+      }
+    }
+  }
+  std::ranges::sort (ids);
+  return ids;
+}


### PR DESCRIPTION
An ICaloIndexer implementation that combines indexers across several detectors.

BEGINRELEASENOTES
- Add MultiIndexer class, to combine indexers across several detectors.
ENDRELEASENOTES
