### PR TITLE
Remove unneeded #includes of MetaDataHandle.h.

### DIFF
--- a/RecCalorimeter/src/components/CaloTopoCluster.h
+++ b/RecCalorimeter/src/components/CaloTopoCluster.h
@@ -9,7 +9,6 @@
 
 // Key4HEP
 #include "k4FWCore/DataHandle.h"
-#include "k4FWCore/MetaDataHandle.h"
 
 // Interfaces
 #include "RecCaloCommon/ICaloReadNeighboursMap.h"

--- a/RecCalorimeter/src/components/CreateCaloCells.h
+++ b/RecCalorimeter/src/components/CreateCaloCells.h
@@ -3,7 +3,6 @@
 
 // k4FWCore
 #include "k4FWCore/DataHandle.h"
-#include "k4FWCore/MetaDataHandle.h"
 
 // Interfaces
 #include "RecCaloCommon/ICalibrateCaloHitsTool.h"

--- a/RecCalorimeter/src/components/CreatePositionedCaloCells.h
+++ b/RecCalorimeter/src/components/CreatePositionedCaloCells.h
@@ -3,7 +3,6 @@
 
 // k4FWCore
 #include "k4FWCore/DataHandle.h"
-#include "k4FWCore/MetaDataHandle.h"
 
 // Interfaces
 #include "RecCaloCommon/ICalibrateCaloHitsTool.h"

--- a/RecFCCeeCalorimeter/src/components/CaloTopoClusterFCCee.h
+++ b/RecFCCeeCalorimeter/src/components/CaloTopoClusterFCCee.h
@@ -13,7 +13,6 @@
 
 // Key4HEP
 #include "k4FWCore/DataHandle.h"
-#include "k4FWCore/MetaDataHandle.h"
 #include "RecCaloCommon/ICaloReadNeighboursMap.h"
 #include "k4Interface/IGeoSvc.h"
 #include "RecCaloCommon/INoiseConstTool.h"

--- a/RecFCCeeCalorimeter/src/components/CreateCaloCellPositionsFCCee.h
+++ b/RecFCCeeCalorimeter/src/components/CreateCaloCellPositionsFCCee.h
@@ -3,7 +3,6 @@
 
 // k4FWCore
 #include "k4FWCore/DataHandle.h"
-#include "k4FWCore/MetaDataHandle.h"
 #include "RecCaloCommon/ICellPositionsTool.h"
 
 // Gaudi

--- a/RecFCCeeCalorimeter/src/components/CreateCaloClustersSlidingWindowFCCee.h
+++ b/RecFCCeeCalorimeter/src/components/CreateCaloClustersSlidingWindowFCCee.h
@@ -7,7 +7,6 @@
 
 // k4FWCore
 #include "k4FWCore/DataHandle.h"
-#include "k4FWCore/MetaDataHandle.h"
 
 // Interface
 #include "RecCaloCommon/ITowerToolThetaModule.h"


### PR DESCRIPTION
Avoids deprecation warnings.

BEGINRELEASENOTES
- Remove unneeded includes of MetaDataHandle.h to avoid deprecation warnings.
ENDRELEASENOTES
