### PR TITLE
Upstream muon collider calo digis.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,6 +65,7 @@ add_subdirectory(RecCaloCommon)
 add_subdirectory(RecCalorimeter)
 add_subdirectory(RecFCChhCalorimeter)
 add_subdirectory(RecFCCeeCalorimeter)
+add_subdirectory(RecCaloDigi)
 
 
 install(EXPORT ${PROJECT_NAME}Targets

--- a/RecCaloDigi/CMakeLists.txt
+++ b/RecCaloDigi/CMakeLists.txt
@@ -1,0 +1,58 @@
+################################################################################
+# Package: RecCaloDigi
+################################################################################
+
+gaudi_add_library(RecCaloDigi
+  SOURCES
+    src/CalorimeterHitType.cc
+    src/RealisticCaloDigi.cc
+    src/RealisticCaloReco.cc
+  LINK
+    Gaudi::GaudiKernel
+    EDM4HEP::edm4hep
+    k4FWCore::k4FWCore
+    k4FWCore::k4Interface
+    DD4hep::DDCore
+    DD4hep::DDRec
+    ROOT::Core
+    ROOT::Hist
+    CLHEP::Random
+)
+
+target_include_directories(RecCaloDigi PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>
+  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+)
+
+# Concrete algorithm plugins — loaded at runtime by Gaudi
+gaudi_add_module(k4RecCaloDigiPlugins
+  SOURCES
+    src/FilterDoubleLayerHits.cc
+    src/RealisticCaloDigiScinPpd.cc
+    src/RealisticCaloDigiSilicon.cc
+    src/RealisticCaloRecoScinPpd.cc
+    src/RealisticCaloRecoSilicon.cc
+  LINK
+    RecCaloDigi
+    Gaudi::GaudiKernel
+    EDM4HEP::edm4hep
+    k4FWCore::k4FWCore
+    k4FWCore::k4Interface
+    DD4hep::DDCore
+    DD4hep::DDRec
+    ROOT::Core
+    ROOT::Hist
+    CLHEP::Random
+)
+
+target_include_directories(k4RecCaloDigiPlugins PRIVATE
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>
+)
+
+install(TARGETS RecCaloDigi k4RecCaloDigiPlugins
+  EXPORT k4RecCalorimeterTargets
+  RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}" COMPONENT bin
+  LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}" COMPONENT shlib
+                                                COMPONENT dev
+  PUBLIC_HEADER DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
+)

--- a/RecCaloDigi/include/CalorimeterHitType.h
+++ b/RecCaloDigi/include/CalorimeterHitType.h
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2020-2024 Key4hep-Project.
+ *
+ * This file is part of Key4hep.
+ * See https://key4hep.github.io/key4hep-doc/ for further info.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef CalorimeterHitType_h
+#define CalorimeterHitType_h 1
+
+#include <iostream>
+
+/** Helper class for decoding/encoding lcio::CalorimeterHit types for the ILD
+ *  detector. The encoding is: caloType + 10 * caloID + 1000 * layout + 10000 * layerNum <br>
+ *  (see enums: CaloType, CaloID and Layout for possible values).<br>
+ *  Example usage: <br>
+ *  <pre>
+ *     lcio::CalorimeterHit* cHit = .... ;
+ *
+ *     // set the type (e.g. in digitization )
+ *     cHit->setType( CHT( CHT::em ,  CHT::ecal , CHT::plug , 12 ) ) ;
+ *
+ *     ...
+ *
+ *     CHT cht = cHit->getType() ;
+ *
+ *     //   sum energies for electromagentic, hadronic and tailcatcher:
+ *     if( cht.is( CHT::em ) )
+ *          e_em +=  cHit->getEnergy() ;
+ *     else
+ *       if ( cht.is(CHT::had ) )
+ *          e_had += cHit->getEnergy() ;
+ *       else
+ *          e_muon += cHit->getEnergy() ;
+ *
+ *     // use only EcalPlug hits:
+ *     if( cht.is( CHT::ecal) && cht.is( CHT::plug) )
+ *
+ *     // get the layer number (e.g. for calibration or clustering)
+ *     unsigned l = cht.layer() ;
+ *     // or directly :
+ *     unsigned l = CHT(  cHit->getType() ).layer()  ;
+ *
+ *     // detailed print:
+ *     std::cout <<  CHT(  cHit->getType() ) << std::endl ;
+ *
+ *  </pre>
+ *
+ *  F.Gaede, DESY, 12/2008
+ */
+
+class CHT {
+public:
+  /** calorimeter types */
+  enum CaloType { em = 0, had = 1, muon = 2 };
+
+  /** calo ids - specific to ILD */
+  enum CaloID { unknown = 0, ecal = 1, hcal = 2, yoke = 3, lcal = 4, lhcal = 5, bcal = 6 };
+
+  /** calo layout / subdetector  */
+  enum Layout { any = 0, barrel = 1, endcap = 2, plug = 3, ring = 4 };
+
+  /** C'tor for initialization from CalorimeterHit::getType()  */
+  CHT(int type) : m_type(type) {}
+
+  /** C'tor  for encoding the calo type inforamtion  */
+  CHT(CaloType c, CaloID n, Layout l, unsigned lay)
+      : m_type(c * fCaloType + n * fCaloID + l * fLayout + lay * fLayer) {}
+
+  /** calorimeter type: CHT::em , CHT::had, CHT::muon */
+  CaloType caloType() const { return (CaloType)(m_type % fCaloID); }
+
+  /** calo ID - see enum CaloID for allowed values */
+  CaloID caloID() const { return (CaloID)((m_type % fLayout) / fCaloID); }
+
+  /** calo layout - see enum layout for allowed values */
+  Layout layout() const { return (Layout)((m_type % fLayer) / fLayout); }
+
+  /** calo layer of hit  */
+  unsigned layer() const { return unsigned(m_type) / fLayer; }
+
+  bool is(CaloType t) const { return caloType() == t; }
+
+  bool is(CaloID n) const { return caloID() == n; }
+
+  bool is(Layout l) const { return layout() == l; }
+
+  /** automatic conversion to int */
+  operator int() const { return m_type; }
+
+  /** explicit conversion to int */
+  int toInt() const { return m_type; }
+
+protected:
+  int m_type;
+
+  static const int fCaloType = 1;
+  static const int fCaloID   = 10;
+  static const int fLayout   = 1000;
+  static const int fLayer    = 10000;
+};
+
+/** detailed string for calo type */
+std::ostream& operator<<(std::ostream& os, const CHT& cht);
+
+/** Return Layout based on the collection name, e.g. if name contains tolower("endcap") CHT::endcap is returned. In case no known layout
+    is found, CHT::any is returned.*/
+CHT::Layout layoutFromString(const std::string& name);
+
+/** Return caloID based on the collection name, e.g. if name contains tolower("HCal") CHT::hcal is returned. In case no known type
+    is found, CHT::unknown is returned.*/
+CHT::CaloID caloIDFromString(const std::string& name);
+
+/** Return caloType from string, e.g. if name contains tolower("Had") CHT::had is returned. In case no known type
+    is found, CHT::em is returned.*/
+CHT::CaloType caloTypeFromString(const std::string& name);
+
+#endif

--- a/RecCaloDigi/include/FilterDoubleLayerHits.h
+++ b/RecCaloDigi/include/FilterDoubleLayerHits.h
@@ -1,0 +1,95 @@
+#ifndef FilterDoubleLayerHits_h
+#define FilterDoubleLayerHits_h 1
+
+#include <k4FWCore/Transformer.h>
+#include "k4Interface/IGeoSvc.h"
+#include <GaudiKernel/ITHistSvc.h>
+
+#include "DDRec/SurfaceManager.h"
+#include <edm4hep/TrackerHitPlaneCollection.h>
+#include <edm4hep/TrackerHitPlane.h>
+
+#include <string>
+
+#include <TH1.h>
+
+
+
+/** Utility processor that removes tracker hits in double layers if they don't have
+ *  a corresponding close-by hit in the other sublayer.
+ *  Pairs of considered layers are configurable and extracted from the cellID word.
+ *  Works for all four lcio hit classes.
+ *
+ *  @parameter InputCollection name of the hit collection with (Sim)TrackerHits/(Sim)CalorimeterHits
+ *  @parameter OutputCollections ( ColName  StartLayer EndLayer )
+ *
+ * @author N. Bartosik, INFN Torino, S. Ferraro
+ * @date  17 June 2020
+ * @version $Id: $
+ */
+
+struct FilterDoubleLayerHits : public k4FWCore::Transformer<edm4hep::TrackerHitPlaneCollection(
+  const edm4hep::TrackerHitPlaneCollection &)> {
+
+protected:
+
+  static const size_t NHITS_MAX = 10000000;
+
+  struct SensorPosition{
+    unsigned int layer;
+    unsigned int side;
+    unsigned int ladder;
+    unsigned int module;
+
+    bool operator<(const SensorPosition& rhs) const {
+      return std::tie(layer, side, ladder, module) < std::tie(rhs.layer, rhs.side, rhs.ladder, rhs.module);
+    }
+  };
+
+  /// Double layer cut struct
+  struct DoubleLayerCut{
+    unsigned int layer0 ;
+    unsigned int layer1 ;
+    double dPhi_max ;
+    double dTheta_max ;
+  };
+
+
+ public:
+  FilterDoubleLayerHits(const std::string& name, ISvcLocator* svcLoc) ;
+
+  /** Called at the begin of the job before anything is read.
+   * Use to initialize the processor, e.g. book histograms.
+   */
+  virtual StatusCode initialize() ;
+
+  /** Called for every event - the working horse.
+   */
+  edm4hep::TrackerHitPlaneCollection operator()(const edm4hep::TrackerHitPlaneCollection& inputTrackerHitCollection) const override;
+
+  /** Called after data processing for clean up.
+   */
+  virtual StatusCode finalize();
+
+
+ protected:
+  dd4hep::rec::Vector2D globalToLocal(long int cellID, const dd4hep::rec::Vector3D& posGlobal, dd4hep::rec::ISurface** surf) const;
+
+  Gaudi::Property<std::string> m_subDetName{this, "SubDetectorName", "Vertex", "Name of sub detector"};
+  Gaudi::Property<bool> m_fillHistos{this, "FillHistograms", false, "Whether to fill diagnostic histograms"};
+  Gaudi::Property<double> m_dtMax{this, "DeltaTimeMax", -1.0, "Maximum time difference between hits in a doublet [ns]"};
+  Gaudi::Property<std::string> m_encodingStringVariable{this, "EncodingStringParameterName", "GlobalTrackerReadoutID", "The name of the DD4hep constant that contains the Encoding string for tracking detectors"};
+  Gaudi::Property<std::vector<std::string>> m_dlCutConfigs{this, "DoubleLayerCuts" , {"0", "1", "0.5", "0.05"}, "Layer IDs and angular cuts [mrad] to be applied: <layer 0> <layer 1> <dPhi> <dTheta>"};
+
+  ////Double layer cuts configuration
+  std::vector<DoubleLayerCut> m_dlCuts {};
+  ////Surface map for getting local hit positions at sensor surface
+  const dd4hep::rec::SurfaceMap* m_map {nullptr};
+  ////Monitoring histograms
+  std::map<std::string, TH1*> m_histos {};
+  // GeoSvc
+  SmartIF<IGeoSvc>   m_geoSvc;
+  SmartIF<ITHistSvc> m_histSvc;
+} ;
+
+#endif

--- a/RecCaloDigi/include/RealisticCaloDigi.h
+++ b/RecCaloDigi/include/RealisticCaloDigi.h
@@ -1,0 +1,118 @@
+#ifndef REALISTICCALODIGI_H
+#define REALISTICCALODIGI_H 1
+
+#include <k4FWCore/Transformer.h>
+#include <edm4hep/SimCalorimeterHit.h>
+#include <edm4hep/SimCalorimeterHitCollection.h>
+#include <edm4hep/CalorimeterHitCollection.h>
+#include <edm4hep/EventHeaderCollection.h>
+#include <edm4hep/CaloHitSimCaloHitLinkCollection.h>
+
+#include "k4Interface/IGeoSvc.h"
+#include "k4Interface/IUniqueIDGenSvc.h"
+
+#include "TRandom2.h"
+
+#include <string>
+#include <tuple>
+#include <vector>
+#include <functional>
+#include <optional>
+
+
+/** === RealisticCaloDigi Processor === <br>
+    Digitisation of calorimeter hits
+    e.g. timing, dead cells, miscalibrations
+    this is virtual class, technology-blind
+    technology-specific classes can inherit from this one
+    D. Jeans 02/2016, rewrite of parts of ILDCaloDigi, DDCaloDigi
+    R. Ete 11/2020, rewrite of charge integration and extension of timing treatment
+ */
+
+struct RealisticCaloDigi : k4FWCore::MultiTransformer<
+    std::tuple<edm4hep::CalorimeterHitCollection, 
+    edm4hep::CaloHitSimCaloHitLinkCollection>(
+      const edm4hep::SimCalorimeterHitCollection&,
+      const edm4hep::EventHeaderCollection&)> {
+  public:
+    RealisticCaloDigi(const std::string& name, ISvcLocator* svcLoc);
+    /** Called at the begin of the job before anything is read.
+    * Use to initialize the processor, e.g. book histograms.
+    */
+    StatusCode initialize();
+  
+    /** Called for every run.
+     */
+    std::tuple<edm4hep::CalorimeterHitCollection, 
+               edm4hep::CaloHitSimCaloHitLinkCollection> operator()(
+              const edm4hep::SimCalorimeterHitCollection& inputSim,
+              const edm4hep::EventHeaderCollection& headers) const; 
+  
+    /** Called after data processing for clean up.
+     */
+    StatusCode finalize();
+
+
+  protected:
+  
+    // energy scales we know about
+    enum { MIP, GEVDEP, NPE };
+    // integration result types
+    using integr_res = std::pair<float,float>;
+    using integr_res_opt = std::optional<integr_res>;
+    using integr_function = std::function<integr_res_opt(const edm4hep::SimCalorimeterHit*)>;
+
+   virtual float EnergyDigi(float energy, float event_correl_miscalib) const;
+   virtual integr_res_opt Integrate( const edm4hep::SimCalorimeterHit * hit ) const;
+   
+   integr_res_opt StandardIntegration( const edm4hep::SimCalorimeterHit * hit ) const ;
+   integr_res_opt ROCIntegration( const edm4hep::SimCalorimeterHit * hit ) const ;
+   float SmearTime(float time) const;
+
+   // virtual methods to be be overloaded in tech-specific derived classes
+   virtual int    getMyUnit() const = 0 ;
+   virtual float digitiseDetectorEnergy(float energy) const = 0 ;
+   virtual float convertEnergy( float energy, int inScale ) const = 0; // convert energy from input to output scale
+
+   // timing
+   Gaudi::Property<int> m_time_apply{this, "timingCut", 0, "Use hit times"};
+   Gaudi::Property<int> m_time_correctForPropagation{this, "timingCorrectForPropagation", 0, "Correct hit times for propagation: radial distance/c"};
+   Gaudi::Property<float> m_time_windowMin{this, "timingWindowMin", -10.0f, "Time Window minimum time in ns"};
+   Gaudi::Property<float> m_time_windowMax{this, "timingWindowMax", 100.0f, "Time Window maximum time in ns"};
+   Gaudi::Property<std::string> m_integration_method{this, "integrationMethod", "Standard", "Energy integration and time calculation method. Options: Standard, ROC"};
+   Gaudi::Property<float> m_fast_shaper{this, "fastShaper", 0.f, "Fast shaper value. Unit in ns"};
+   Gaudi::Property<float> m_slow_shaper{this, "slowShaper", 0.f, "Slow shaper value. Unit in ns"};
+   Gaudi::Property<float> m_time_resol{this, "timingResolution", 0.f, "Time resolution to apply (gaussian smearing). Unit in ns"};
+   // additional digi effects
+   Gaudi::Property<float> m_calib_mip{this, "calibration_mip", 1.0e-4f, "Average G4 deposited energy by MIP for calibration"};
+   Gaudi::Property<float> m_misCalib_uncorrel{this, "miscalibration_uncorrel", 0.0f, "Uncorrelated random Gaussian miscalibration (as a fraction: 1.0 = 100%)"};
+   Gaudi::Property<float> m_misCalib_correl{this, "miscalibration_correl", 0.0f, "Correlated random Gaussian miscalibration (as a fraction: 1.0 = 100%)"};
+   Gaudi::Property<float> m_deadCell_fraction{this, "deadCell_fraction", 0.0f, "Random dead cell fraction (as a fraction: 0->1)"};
+   // simple model of electronics properties
+   Gaudi::Property<float> m_elec_noiseMip{this, "elec_noise_mip", 0.0f, "Typical electronics noise (in MIP units)"};
+   Gaudi::Property<float> m_elec_rangeMip{this, "elec_range_mip", 2500.0f, "Maximum of dynamic range of electronics (in MIPs)"};
+   // code for layer info for cellID decoder
+   Gaudi::Property<std::string> m_encodingStringVariable{this, "EncodingStringParameterName", "GlobalTrackerReadoutID", "The name of the DD4hep constant that contains the Encoding string for tracking detectors"};
+   // energy threshold
+   Gaudi::Property<float> m_threshold_value{this, "threshold", 0.5f, "Threshold for Hit"};
+   Gaudi::Property<std::string> m_threshold_unit{this, "thresholdUnit", std::string("MIP"), "Unit for threshold. Can be \"GeV\", \"MIP\" or \"px\". MIP and px need properly set calibration constants"};
+   // id parameters
+   Gaudi::Property<std::string> m_calo_type {this, "CaloType", "em", "Calorimeter Type: em, had, mu"};
+   Gaudi::Property<std::string> m_calo_id {this, "CaloID", "ecal", "Calorimeter ID: ecal, hcal, yoke, lcal, lhcal, bcal"};
+   Gaudi::Property<std::string> m_calo_layout {this, "CaloLayout", "barrel", "Calorimeter Layout: barrel, endcap, ring, plug"};
+   
+
+   int m_threshold_iunit{};  
+   inline static thread_local TRandom2 m_engine;
+   SmartIF<IGeoSvc>                    m_geoSvc;
+   SmartIF<IUniqueIDGenSvc>            m_uidSvc;
+ 
+
+   integr_function m_integr_function{};
+
+} ;
+
+#endif
+
+
+

--- a/RecCaloDigi/include/RealisticCaloDigiScinPpd.h
+++ b/RecCaloDigi/include/RealisticCaloDigiScinPpd.h
@@ -1,0 +1,31 @@
+#ifndef DIGITIZER_DDCCALODIGISCINT_H
+#define DIGITIZER_DDCCALODIGISCINT_H 1
+
+#include "RealisticCaloDigi.h"
+
+
+/** === RealisticCaloDigiScinPpd Processor === <br>
+    realistic digitisation of scint+PPD (SiPM, MPPC) calorimeter hits
+    D.Jeans 02/2016.
+*/
+
+struct RealisticCaloDigiScinPpd : public RealisticCaloDigi {
+  
+ public:
+  RealisticCaloDigiScinPpd(const std::string& name, ISvcLocator* svcLoc);
+
+ protected:
+  int getMyUnit() const {return NPE;}
+  float digitiseDetectorEnergy(float energy) const ; // apply scin+PPD specific effects
+  float convertEnergy( float energy, int inputUnit ) const; // convert energy from input to output scale
+
+  Gaudi::Property<float> m_PPD_pe_per_mip{this, "ppd_mipPe", 10.0f, "# Photo-electrons per MIP (scintillator): used to Poisson smear #PEs if >0"};
+  Gaudi::Property<int> m_PPD_n_pixels{this, "ppd_npix", 10000, "Total number of MPPC/SiPM pixels for implementation of saturation effect"};
+  Gaudi::Property<float> m_misCalibNpix{this, "ppd_npix_uncert", 0.05f, "Fractional uncertainty of effective total number of MPPC/SiPM pixels"};
+  Gaudi::Property<float> m_pixSpread{this, "ppd_pix_spread", 0.05f, "Variation of PPD pixel signal (as a fraction: 0.01=1%)"};
+} ;
+
+#endif
+
+
+

--- a/RecCaloDigi/include/RealisticCaloDigiSilicon.h
+++ b/RecCaloDigi/include/RealisticCaloDigiSilicon.h
@@ -1,0 +1,27 @@
+#ifndef DIGITIZER_REALISTICCALODIGISILICON_H
+#define DIGITIZER_REALISTICCALODIGISILICON_H 1
+
+#include "RealisticCaloDigi.h"
+
+/** === RealisticCaloDigiSilicon Processor === <br>
+    realistic digitisation of silicon calorimeter hits
+    D.Jeans 02/2016.
+*/
+
+struct RealisticCaloDigiSilicon : public RealisticCaloDigi {
+  
+ public:
+  RealisticCaloDigiSilicon(const std::string& name, ISvcLocator* svcLoc) ;
+
+ protected:
+  int getMyUnit() const {return MIP;}
+  float convertEnergy( float energy, int inputUnit )const; // convert energy from input to output (MIP) scale 
+  float digitiseDetectorEnergy(float energy)const;         // apply silicon-specific realistic digitisation
+  
+  Gaudi::Property<float> m_ehEnergy{this, "silicon_pairEnergy" , 3.6f, "energy required to create e-h pair in silicon (in eV)"};
+} ;
+
+#endif
+
+
+

--- a/RecCaloDigi/include/RealisticCaloReco.h
+++ b/RecCaloDigi/include/RealisticCaloReco.h
@@ -1,0 +1,72 @@
+#ifndef DIGITIZER_REALISTICCALORECO_H
+#define DIGITIZER_REALISTICCALORECO_H 1
+
+#include <k4FWCore/Transformer.h>
+
+#include <edm4hep/CalorimeterHit.h>
+#include <edm4hep/CalorimeterHitCollection.h>
+#include <edm4hep/CaloHitSimCaloHitLinkCollection.h>
+
+#include "CalorimeterHitType.h"
+#include "k4Interface/IGeoSvc.h"
+
+#include <string>
+#include <vector>
+
+
+/** === RealisticCaloReco Processor === <br>
+    realistic reconstruction of calorimeter hits
+    e.g. apply sampling fraction correction
+    virtual class, technology indenpendent
+    D.Jeans 02/2016.
+
+    24 March 2016: removed gap corrections - to be put into separate processor
+    changed relations: now keep relation between reconstructed and simulated hits.
+*/
+
+
+struct RealisticCaloReco : k4FWCore::MultiTransformer<std::tuple<
+    edm4hep::CalorimeterHitCollection, 
+    edm4hep::CaloHitSimCaloHitLinkCollection>(
+      const edm4hep::CaloHitSimCaloHitLinkCollection&)> {
+  
+ public:
+    RealisticCaloReco(const std::string& name, ISvcLocator* svcLoc);
+    /** Called at the begin of the job before anything is read.
+    * Use to initialize the processor, e.g. book histograms.
+    */
+    StatusCode initialize();
+  
+    /** Called for every run.
+     */
+    std::tuple<edm4hep::CalorimeterHitCollection, 
+               edm4hep::CaloHitSimCaloHitLinkCollection> operator()(
+              const edm4hep::CaloHitSimCaloHitLinkCollection& inputLinks) const; 
+  
+    /** Called after data processing for clean up.
+     */
+    StatusCode finalize();
+
+
+
+ protected:
+
+  float getLayerCalib( int ilayer ) const;
+  virtual float reconstructEnergy(const edm4hep::CalorimeterHit* hit, int layer) const = 0;  // to be overloaded, technology-specific
+
+  // parameters
+  // Grouping of calo layers
+  Gaudi::Property<std::vector<int>> m_calLayers{this, "calibration_layergroups", {}, "Grouping of calo layers"};
+  // Calibration coefficients for layers groups
+  Gaudi::Property<std::vector<float>> m_calibrCoeff{this, "calibration_factorsMipGev", {}, "Calibration coefficients (MIP->shower GeV) of layers groups"};
+  // Cell ID layer string
+  Gaudi::Property<std::string> m_encodingStringVariable{this, "EncodingStringParameterName", "GlobalTrackerReadoutID", "The name of the DD4hep constant that contains the Encoding string for tracking detectors"};
+
+  SmartIF<IGeoSvc> m_geoSvc;
+
+} ;
+
+#endif
+
+
+

--- a/RecCaloDigi/include/RealisticCaloRecoScinPpd.h
+++ b/RecCaloDigi/include/RealisticCaloRecoScinPpd.h
@@ -1,0 +1,23 @@
+#ifndef REALISTICCALORECOSCINPPD_H
+#define REALISTICCALORECOSCINPPD_H 1
+
+#include "RealisticCaloReco.h"
+
+/** === RealisticCaloRecoSilicon Processor === <br>
+    realistic reconstruction of scint+PPD calorimeter hits
+    D.Jeans 02/2016.
+*/
+
+struct RealisticCaloRecoScinPpd final : RealisticCaloReco {
+ public:
+  RealisticCaloRecoScinPpd(const std::string& name, ISvcLocator* svcLoc);
+
+ protected:
+  float reconstructEnergy(const edm4hep::CalorimeterHit* hit, int layer) const override;
+
+  Gaudi::Property<float> m_PPD_pe_per_mip{this, "ppd_mipPe", 10.0f, "# Photo-electrons per MIP (scintillator): used to Poisson smear #PEs if >0"};
+  Gaudi::Property<int> m_PPD_n_pixels{this, "ppd_npix", 10000, "Total number of MPPC/SiPM pixels for implementation of saturation effect"};
+ 
+} ;
+
+#endif 

--- a/RecCaloDigi/include/RealisticCaloRecoSilicon.h
+++ b/RecCaloDigi/include/RealisticCaloRecoSilicon.h
@@ -1,0 +1,23 @@
+#ifndef REALISTICCALORECOSILICON_H
+#define REALISTICCALORECOSILICON_H 1
+
+#include "RealisticCaloReco.h"
+
+/** === RealisticCaloRecoSilicon Processor === <br>
+    realistic reconstruction of silicon calorimeter hits
+    D.Jeans 02/2016.
+
+    24 March 2016: removed gap corrections - to be put into separate processor
+
+*/
+
+struct RealisticCaloRecoSilicon final : RealisticCaloReco {
+
+ public:
+  RealisticCaloRecoSilicon(const std::string& name, ISvcLocator* svcLoc);
+
+ protected:
+  float reconstructEnergy(const edm4hep::CalorimeterHit* hit, int layer) const override;
+} ;
+
+#endif 

--- a/RecCaloDigi/src/CalorimeterHitType.cc
+++ b/RecCaloDigi/src/CalorimeterHitType.cc
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) 2020-2024 Key4hep-Project.
+ *
+ * This file is part of Key4hep.
+ * See https://key4hep.github.io/key4hep-doc/ for further info.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "CalorimeterHitType.h"
+
+#include <algorithm>
+
+/** detailed string for calo type */
+std::ostream& operator<<(std::ostream& os, const CHT& cht) {
+  os << " calo hit type: ";
+
+  switch (cht.caloType()) {
+    case CHT::em:
+      os << " em,   ";
+      break;
+    case CHT::had:
+      os << " had,  ";
+      break;
+    case CHT::muon:
+      os << " muon, ";
+      break;
+    default:
+      os << "  -  ,";
+  }
+  switch (cht.caloID()) {
+    case CHT::ecal:
+      os << "ecal,  ";
+      break;
+    case CHT::hcal:
+      os << "hcal,  ";
+      break;
+    case CHT::yoke:
+      os << "yoke,  ";
+      break;
+    case CHT::lcal:
+      os << "lcal,  ";
+      break;
+    case CHT::lhcal:
+      os << "lhcal, ";
+      break;
+    case CHT::bcal:
+      os << "bcal,  ";
+      break;
+    default:
+      os << "  -  ,";
+  }
+  switch (cht.layout()) {
+    case CHT::any:
+      os << "any,    ";
+      break;
+    case CHT::ring:
+      os << "ring,   ";
+      break;
+    case CHT::endcap:
+      os << "endcap, ";
+      break;
+    case CHT::barrel:
+      os << "barrel, ";
+      break;
+    case CHT::plug:
+      os << "plug,   ";
+      break;
+    default:
+      os << "  -  ,";
+  }
+  os << " layer: " << cht.layer();
+
+  return os;
+}
+
+/** Helper functions that should go to Marlinutil/CalorimeterHitTypes.hh */
+
+CHT::Layout layoutFromString(const std::string& name) {
+  std::string str(name);
+  std::transform(str.begin(), str.end(), str.begin(), ::tolower);
+
+  if (str.find("ring") != std::string::npos)
+    return CHT::ring;
+  if (str.find("plug") != std::string::npos)
+    return CHT::plug;
+  if (str.find("endcap") != std::string::npos)
+    return CHT::endcap;
+  if (str.find("barrel") != std::string::npos)
+    return CHT::barrel;
+
+  std::cout << " not found :" << str << " in " << name << std::endl;
+  return CHT::any;
+}
+
+CHT::CaloID caloIDFromString(const std::string& name) {
+  std::string str(name);
+  std::transform(str.begin(), str.end(), str.begin(), ::tolower);
+
+  if (str.find("ecal") != std::string::npos)
+    return CHT::ecal;
+  if (str.find("hcal") != std::string::npos)
+    return CHT::hcal;
+  if (str.find("yoke") != std::string::npos)
+    return CHT::yoke;
+  if (str.find("lcal") != std::string::npos)
+    return CHT::lcal;
+  if (str.find("lhcal") != std::string::npos)
+    return CHT::lhcal;
+  if (str.find("bcal") != std::string::npos)
+    return CHT::bcal;
+
+  return CHT::unknown;
+}
+
+CHT::CaloType caloTypeFromString(const std::string& name) {
+  std::string str(name);
+  std::transform(str.begin(), str.end(), str.begin(), ::tolower);
+
+  if (str.find("em") != std::string::npos)
+    return CHT::em;
+  if (str.find("had") != std::string::npos)
+    return CHT::had;
+  if (str.find("muon") != std::string::npos)
+    return CHT::muon;
+
+  // jl: this should probably also have a separate "unknown" or "any" value?
+  return CHT::em;
+}

--- a/RecCaloDigi/src/FilterDoubleLayerHits.cc
+++ b/RecCaloDigi/src/FilterDoubleLayerHits.cc
@@ -1,0 +1,293 @@
+#include "FilterDoubleLayerHits.h"
+#include <iostream>
+#include <cstdlib>
+#include <string.h>
+
+#include <edm4hep/TrackerHitPlane.h>
+#include <GaudiKernel/GaudiException.h>
+
+#include <DDSegmentation/BitFieldCoder.h>
+
+#include "DD4hep/DD4hepUnits.h"
+
+#include <TH1F.h>
+#include <TH2F.h>
+
+DECLARE_COMPONENT(FilterDoubleLayerHits)
+
+FilterDoubleLayerHits::FilterDoubleLayerHits(const std::string& name, ISvcLocator* svcLoc) : Transformer(name, svcLoc,
+    KeyValues("InputCollection", {"VXDTrackerHitPlanes"}),
+    KeyValues("OutputCollection", {"VXDTrackerHitPlanes_DLFiltered"})) {}
+
+
+dd4hep::rec::Vector2D FilterDoubleLayerHits::globalToLocal(long int cellID, const dd4hep::rec::Vector3D& posGlobal, dd4hep::rec::ISurface** surfptr=nullptr) const{
+  dd4hep::rec::ISurface* surf;
+  // Using directly the provided surface object if available
+  if (surfptr && *surfptr) {
+    surf = *surfptr;
+  } else {
+    // Finding the surface corresponding to the cellID
+    dd4hep::rec::SurfaceMap::const_iterator surfIt = m_map->find( cellID );
+    if( surfIt == m_map->end() ){
+      throw GaudiException(" FilterDoubleLayerHits::processEvent(): no surface found for cellID: " + cellID, "Fail", StatusCode::FAILURE);
+    }
+    surf = surfIt->second;
+    // Saving the surface object outside the function to be reused for the same cellID
+    if (surfptr) *surfptr = surf;
+  }
+  // Converting global position to local in [cm]
+  dd4hep::rec::Vector2D posLocal = surf->globalToLocal(  dd4hep::mm * posGlobal );
+
+  return dd4hep::rec::Vector2D( posLocal.u() / dd4hep::mm, posLocal.v() / dd4hep::mm );
+}
+
+
+StatusCode FilterDoubleLayerHits::initialize() {
+  m_geoSvc = serviceLocator()->service("GeoSvc");
+  if (!m_geoSvc) {
+    error() << "Unable to retrieve the GeoSvc" << endmsg;
+    return StatusCode::FAILURE;
+  }
+  // Get Histogram and Data Services
+	SmartIF<ITHistSvc> histSvc;
+	histSvc = serviceLocator()->service("THistSvc");
+
+  debug() << "   init called  " << endmsg;
+
+  // Extracting double-layer cut configurations
+  m_dlCuts.resize( m_dlCutConfigs.size() / 4 ) ;
+
+  unsigned i=0,index=0 ;
+  while( i < m_dlCutConfigs.size() ){
+    m_dlCuts[index].layer0      = std::atoi( m_dlCutConfigs[ i++ ].c_str() ) ;
+    m_dlCuts[index].layer1      = std::atoi( m_dlCutConfigs[ i++ ].c_str() ) ;
+    m_dlCuts[index].dPhi_max    = std::atof( m_dlCutConfigs[ i++ ].c_str() ) / 1e3 ;  // converting mrad -> rad
+    m_dlCuts[index].dTheta_max  = std::atof( m_dlCutConfigs[ i++ ].c_str() ) / 1e3 ;  // converting mrad -> rad
+    ++index ;
+  }
+
+  // Get the surface map from the SurfaceManager
+  dd4hep::Detector& theDetector = *(m_geoSvc->getDetector());
+  dd4hep::rec::SurfaceManager& surfMan = *theDetector.extension<dd4hep::rec::SurfaceManager>();
+  dd4hep::DetElement det = theDetector.detector( m_subDetName );
+
+  m_map = surfMan.map( det.name() );
+
+  if( !m_map ) {
+    throw GaudiException( " Could not find surface map for detector: " + m_subDetName + " in SurfaceManager", "Fail", StatusCode::FAILURE);
+  }
+
+  // Booking diagnostic histograms for each configured cut
+  char hname[100];
+  for(size_t iCut=0, nCuts=m_dlCuts.size() ; iCut<nCuts ; ++iCut){
+    const DoubleLayerCut& cut = m_dlCuts.at(iCut);
+    if (m_fillHistos) {
+      // Properties of the closest hits across 2 sublayers
+      sprintf(hname, "h_dU_layers_%d_%d", cut.layer0, cut.layer1);
+      m_histos[ std::string(hname) ] = new TH1F( hname , ";#DeltaU [mm]; Hit pairs", 2000, -5, 5 );
+      sprintf(hname, "h2_dU_dPhi_layers_%d_%d", cut.layer0, cut.layer1);
+      m_histos[ std::string(hname) ] = new TH2F( hname , ";#DeltaU [mm]; #Delta#phi [mrad]", 500, -5, 5, 500, 0, 50);
+      sprintf(hname, "h_dTheta_layers_%d_%d", cut.layer0, cut.layer1);
+      m_histos[ std::string(hname) ] = new TH1F( hname , ";#Delta#Theta [mrad]; Hit pairs", 3000, -30, 30 );
+      sprintf(hname, "h_dPhi_layers_%d_%d", cut.layer0, cut.layer1);
+      m_histos[ std::string(hname) ] = new TH1F( hname , ";|#Delta#phi| [mrad]; Hit pairs", 1000, 0, 50 );
+      sprintf(hname, "h_dt_layers_%d_%d", cut.layer0, cut.layer1);
+      m_histos[ std::string(hname) ] = new TH1F( hname , ";|#Deltat| [ns]; Hit pairs", 2000, -10, 10 );
+      // Hit properties for each individual layer
+      std::vector<unsigned int> layers{cut.layer0, cut.layer1};
+      for (auto layer : layers) {
+        sprintf(hname, "h2_posUV_rejected_layer_%d", layer);
+        m_histos[ std::string(hname) ] = new TH2F( hname , ";U [mm]; V [mm]", 500, -100, 100, 1000, -200, 200 );
+      }
+    }
+
+    for (const auto& [name, histo] : m_histos) {
+        (void)m_histSvc->regHist("/histos/" + name, histo);
+    }
+
+    // Printing the configured cut
+    debug() <<  iCut << ". layers: " << cut.layer0 << " >> " << cut.layer1 << ";  dPhi: "
+    << cut.dPhi_max << " rad;  dTheta: " << cut.dTheta_max << " rad" << endmsg;
+  }
+
+  return StatusCode::SUCCESS;
+
+}
+
+
+edm4hep::TrackerHitPlaneCollection FilterDoubleLayerHits::operator()(const edm4hep::TrackerHitPlaneCollection& inputTrackerHitCollection) const{
+  std::string initString;
+  initString = m_geoSvc->constantAsString(m_encodingStringVariable.value());
+  dd4hep::DDSegmentation::BitFieldCoder bitFieldCoder(initString);  // check!
+
+  //---- create the output collection
+  edm4hep::TrackerHitPlaneCollection outCol;
+  outCol.setSubsetCollection();
+
+  // Set acceptance flags for all hits to FALSE
+  const size_t nHit = inputTrackerHitCollection.size(); 
+  bool hitAccepted[NHITS_MAX]; ////Array of flags for hits to be accepted
+  memset(&hitAccepted, false, nHit);
+
+  ////Map of vectors of hits grouped by position in the detector
+  std::map<SensorPosition, std::vector<size_t> > hitsGrouped{};
+
+  // Splitting hits by sensor ids for faster association
+  for (size_t iHit = 0; iHit < nHit ; iHit++) {
+
+    edm4hep::TrackerHitPlane h = inputTrackerHitCollection.at( iHit );
+
+    unsigned int layerID  = bitFieldCoder.get(h.getCellID(), "layer");
+    unsigned int sideID   = bitFieldCoder.get(h.getCellID(), "side");
+    unsigned int ladderID = bitFieldCoder.get(h.getCellID(), "module");
+    unsigned int moduleID = bitFieldCoder.get(h.getCellID(), "sensor");
+
+    SensorPosition sensPos = {layerID, sideID, ladderID, moduleID};
+    if (hitsGrouped.find(sensPos) == hitsGrouped.end()) {
+      hitsGrouped[sensPos] = std::vector<size_t>();
+      hitsGrouped[sensPos].reserve(nHit);
+    }
+    hitsGrouped[sensPos].push_back(iHit);
+  }
+
+  //---- loop over hits
+  for (size_t iHit = 0; iHit < nHit ; iHit++) {
+
+    // Skipping hits that are already accepted
+    if (hitAccepted[iHit]) continue;
+
+    edm4hep::TrackerHitPlane h = inputTrackerHitCollection.at( iHit );
+
+    unsigned int layerID  = bitFieldCoder.get(h.getCellID(), "layer");
+    unsigned int sideID   = bitFieldCoder.get(h.getCellID(), "side");
+    unsigned int ladderID = bitFieldCoder.get(h.getCellID(), "module");
+    unsigned int moduleID = bitFieldCoder.get(h.getCellID(), "sensor");
+    debug() << " Checking 1st hit " << iHit << " / " << nHit << " at layer: " << layerID << "  ladder: " << ladderID << "  module: " << moduleID <<  endmsg ;
+
+    const SensorPosition sensPos = {layerID, sideID, ladderID, moduleID};
+
+    // Checking if the hit is at the inner double layer to be filtered
+    const DoubleLayerCut* dlCut(0);
+    for (int iCut=0, nCuts=m_dlCuts.size(); iCut<nCuts; ++iCut) {
+      const DoubleLayerCut& cut = m_dlCuts.at(iCut);
+      if( ( layerID != cut.layer0 ) && ( layerID != cut.layer1 ) ) continue;
+      dlCut = &cut;
+      break;
+    }
+
+    // Accepting hit immediately if it's not affected by any double-layer cut
+    if (!dlCut) {
+      hitAccepted[iHit] = true;
+      continue;
+    }
+
+    // Skipping the hit from the first pass if it belongs to the outer sublayer of the cut
+    if (layerID == dlCut->layer1) continue;
+
+    // Getting local and global hit positions
+    dd4hep::rec::Vector3D posGlobal( h.getPosition().x, h.getPosition().y, h.getPosition().z );
+    dd4hep::rec::Vector2D posLocal = globalToLocal( h.getCellID(), posGlobal );
+
+    // Setting the values for closest hits
+    double dR_min(999.0);
+    double dU_closest(0.0);
+    double dTheta_closest(0.0);
+    double dPhi_closest(0.0);
+    double dt_closest(0.0);
+
+    // Looking for the compliment hits in the 2nd sublayer
+    size_t nCompatibleHits(0);
+    SensorPosition sensPos2 = sensPos;
+    sensPos2.layer = dlCut->layer1;
+    dd4hep::rec::ISurface* surf=nullptr;
+    // Checking if there are any hits in the corresponding sensor at the other sublayer
+    if (hitsGrouped.find(sensPos2) == hitsGrouped.end()) continue;
+    for (size_t iHit2 : hitsGrouped.at(sensPos2)) {
+      edm4hep::TrackerHitPlane h2 = inputTrackerHitCollection.at( iHit2 );
+      unsigned int layerID2 = bitFieldCoder.get(h2.getCellID(), "layer");
+
+      // Checking whether hit is in the time acceptance window
+      double dt = h2.getTime() - h.getTime();
+      if (m_dtMax >= 0.0 && std::fabs(dt) > m_dtMax) continue;
+
+      // Getting the local and global hit positions
+      dd4hep::rec::Vector3D posGlobal2( h2.getPosition().x, h2.getPosition().y, h2.getPosition().z );
+      dd4hep::rec::Vector2D posLocal2 = globalToLocal( h2.getCellID(), posGlobal2, &surf );
+
+      // Checking whether hit is close enough to the 1st one
+      double dU = posLocal2.u() - posLocal.u();
+      double dTheta = posGlobal2.theta() - posGlobal.theta();
+      double dPhi = std::fabs(posGlobal2.phi() - posGlobal.phi());
+      if (dPhi > dd4hep::pi) dPhi = dd4hep::twopi - dPhi;
+      double dR = sqrt(dPhi*dPhi + dTheta*dTheta);
+      debug() << " Checking 2nd hit at layer: " << layerID2 << ";  dPhi: " << dPhi << ";  dTheta: " <<  dTheta << endmsg;
+
+      // Updating the minimal values
+      if (dR < dR_min) {
+        dR_min = dR;
+        dU_closest = dU;
+        dTheta_closest = dTheta;
+        dPhi_closest = dPhi;
+        dt_closest = dt;
+      }
+
+      // Skipping if the hit is outside the cut window
+      if (std::fabs(dPhi) > dlCut->dPhi_max) continue;
+      if (std::fabs(dTheta) > dlCut->dTheta_max) continue;
+
+      nCompatibleHits++;
+      hitAccepted[iHit2] = true;
+      debug() << " Accepted 2nd hit at layer: " << layerID2 << ";  dPhi: " << dPhi << ";  dTheta: " <<  dTheta << endmsg;
+    }
+    // Filling diagnostic histograms
+    if (m_fillHistos && dR_min < 998) {
+        char hname[100];
+        sprintf(hname, "h_dU_layers_%d_%d", dlCut->layer0, dlCut->layer1);
+        m_histos.find(hname)->second->Fill(dU_closest);
+        sprintf(hname, "h2_dU_dPhi_layers_%d_%d", dlCut->layer0, dlCut->layer1);
+        m_histos.find(hname)->second->Fill(dU_closest, dPhi_closest*1e3);
+        sprintf(hname, "h_dTheta_layers_%d_%d", dlCut->layer0, dlCut->layer1);
+        m_histos.find(hname)->second->Fill(dTheta_closest*1e3);
+        sprintf(hname, "h_dPhi_layers_%d_%d", dlCut->layer0, dlCut->layer1);
+        m_histos.find(hname)->second->Fill(dPhi_closest*1e3);
+        sprintf(hname, "h_dt_layers_%d_%d", dlCut->layer0, dlCut->layer1);
+        m_histos.find(hname)->second->Fill(dt_closest);
+      }
+
+    // Accepting the first hit if it has at least one compatible pair
+    if (nCompatibleHits > 0) {
+      hitAccepted[iHit] = true;
+      debug() << " Accepted 1st hit at layer: " << layerID << endmsg;
+    }
+  }
+
+  // Adding accepted hits to the output collection
+  size_t nHitsAccepted(0);
+  for (size_t iHit = 0; iHit < nHit; iHit++) {
+    if (!hitAccepted[iHit]) {
+      // Filling the positions of rejected hits
+      if (m_fillHistos) {
+        edm4hep::TrackerHitPlane h = inputTrackerHitCollection.at( iHit );
+        unsigned int layerID = bitFieldCoder.get(h.getCellID(), "layer");
+
+        // Getting local hit position
+        dd4hep::rec::Vector3D posGlobal( h.getPosition().x, h.getPosition().y, h.getPosition().z );
+        dd4hep::rec::Vector2D posLocal = globalToLocal( h.getCellID(), posGlobal );
+
+        char hname[100];
+        sprintf(hname, "h2_posUV_rejected_layer_%d", layerID);
+        m_histos.find(hname)->second->Fill(posLocal.u(), posLocal.v());
+      }
+      continue;
+    }
+    outCol.push_back( inputTrackerHitCollection.at( iHit ) );
+    nHitsAccepted++;
+  }
+	info() << " " << nHitsAccepted << " hits added to collection." << endmsg;
+
+    return outCol;
+}
+
+StatusCode FilterDoubleLayerHits::finalize(){
+  return StatusCode::SUCCESS;
+}

--- a/RecCaloDigi/src/RealisticCaloDigi.cc
+++ b/RecCaloDigi/src/RealisticCaloDigi.cc
@@ -1,0 +1,302 @@
+// Calorimeter digitiser
+#include "RealisticCaloDigi.h"
+
+#include <edm4hep/MutableCalorimeterHit.h>
+#include <edm4hep/CaloHitSimCaloHitLinkCollection.h>
+#include <edm4hep/CaloHitContribution.h>
+#include <CalorimeterHitType.h>
+
+#include <DDSegmentation/BitFieldCoder.h>
+
+#include <k4Interface/IUniqueIDGenSvc.h>
+
+#include <algorithm>
+#include <iostream>
+#include <string>
+#include <assert.h>
+#include <cmath>
+#include <set>
+
+#include "CLHEP/Units/PhysicalConstants.h"
+
+
+using namespace std;
+using namespace std::placeholders;
+
+struct MCC {
+  float energy {0.f};
+  float time {0.f};
+};
+
+RealisticCaloDigi::RealisticCaloDigi(const std::string& name, ISvcLocator* svcLoc) : MultiTransformer(name, svcLoc, 
+    { KeyValues("inputHitCollections", {"SimCalorimeterHits"}),
+      KeyValues("inputHeaderCollections", {"EventHeader"}) },
+    { KeyValues("outputHitCollections", {"CalorimeterHits"}),
+     KeyValues("outputRelationCollections", {"CaloHitLinks"}) }) {}
+
+StatusCode RealisticCaloDigi::initialize() {
+  m_geoSvc = serviceLocator()->service("GeoSvc");
+  if (!m_geoSvc) {
+    error() << "Unable to retrieve the GeoSvc" << endmsg;
+    return StatusCode::FAILURE;
+  }
+  m_uidSvc = service<IUniqueIDGenSvc>("UniqueIDGenSvc", true);
+  if (!m_uidSvc) {
+    error() << "Unable to get UniqueIDGenSvc" << endmsg;
+  }
+
+
+  // unit in which threshold is specified
+  if (m_threshold_unit.value().compare("MIP") == 0){
+    m_threshold_iunit=MIP;
+  } else if (m_threshold_unit.value().compare("GeV") == 0){
+    m_threshold_iunit=GEVDEP;
+  } else if (m_threshold_unit.value().compare("px") == 0){
+    m_threshold_iunit=NPE;
+  } else {
+    error() << "could not identify threshold unit. Please use \"GeV\", \"MIP\" or \"px\"! Aborting." << endmsg;
+  }
+  
+  // convert the threshold to the approriate units (i.e. MIP for silicon, NPE for scint)
+  m_threshold_value = convertEnergy( m_threshold_value, m_threshold_iunit );
+
+  // deal with timing calculations  
+  std::map<std::string, integr_function> integrations = {
+    {"Standard", std::bind(&RealisticCaloDigi::StandardIntegration, this, _1)},
+    {"ROC", std::bind(&RealisticCaloDigi::ROCIntegration, this, _1)}
+  };  
+  auto findIter = integrations.find( m_integration_method ) ;
+  if(integrations.end() == findIter) {
+    error() << "Could not guess timing calculation method!" << endmsg;
+    error() << "Available are: Standard, ROC. Provided: " << m_integration_method << endmsg;
+    error() << "Aborting..." << endmsg;
+  }
+  m_integr_function = findIter->second;
+  
+  // check if parameters are correctly set for the ROC integration
+  if("ROC" == m_integration_method) {
+    if(m_fast_shaper == 0.0f || m_slow_shaper == 0.0f) {
+      error() << "Fast/slow shaper parameter(s) not set. Required for ROC integration!" << endmsg;
+      error() << "Aborting..." << endmsg;
+    }
+  }
+
+  return StatusCode::SUCCESS;
+}
+
+
+
+std::tuple<edm4hep::CalorimeterHitCollection, edm4hep::CaloHitSimCaloHitLinkCollection> RealisticCaloDigi::operator()(
+      const edm4hep::SimCalorimeterHitCollection& inputSim,
+      const edm4hep::EventHeaderCollection& headers) const {
+  auto seed = m_uidSvc->getUniqueID(headers[0].getEventNumber(), headers[0].getRunNumber(), this->name());
+  debug() << "Using seed " << seed << " for event " << headers[0].getEventNumber() << " and run "
+          << headers[0].getRunNumber() << endmsg;
+  m_engine.SetSeed(seed);
+
+  // decide on this event's correlated miscalibration
+  float event_correl_miscalib = ( m_misCalib_correl>0 ) ? m_engine.Gaus(1.0, m_misCalib_correl) : 0;
+
+  edm4hep::CalorimeterHitCollection newcol;
+  edm4hep::CaloHitSimCaloHitLinkCollection relcol;
+
+  CHT::CaloType cht_type = caloTypeFromString(m_calo_type);
+  CHT::CaloID   cht_id   = caloIDFromString(m_calo_id);
+  CHT::Layout   cht_lay  = layoutFromString(m_calo_layout);
+
+  std::string initString;
+  initString = m_geoSvc->constantAsString(m_encodingStringVariable.value());
+  dd4hep::DDSegmentation::BitFieldCoder bitFieldCoder(initString);  // check!
+
+  debug() << "Number of elements = " << inputSim.size() << endmsg;
+  // loop over input hits
+  for (int j=0; j < inputSim.size(); ++j) {
+    edm4hep::SimCalorimeterHit simhit0 = inputSim.at( j );
+    edm4hep::SimCalorimeterHit *simhit = &simhit0;
+
+    // deal with energy integration and timing aspects
+    auto integrationResult = Integrate(simhit);
+    if( ! integrationResult.has_value() ) {
+      continue;
+    }
+    float time      = integrationResult.value().first;
+    float energyDep = integrationResult.value().second;
+    // apply extra energy digitisation onto the energy
+    float energyDig = EnergyDigi(energyDep, event_correl_miscalib);
+
+    if (energyDig > m_threshold_value) { // write out this hit
+      edm4hep::MutableCalorimeterHit newhit = newcol.create();
+      newhit.setCellID( simhit->getCellID() );
+      newhit.setTime( time );
+      newhit.setPosition( simhit->getPosition() );
+	    newhit.setEnergy( energyDig );
+      
+	    int layer = bitFieldCoder.get(simhit->getCellID(), "layer");
+	    newhit.setType( CHT( cht_type, cht_id, cht_lay, layer ) );
+
+      debug() << "orig/new hit energy: " << simhit->getEnergy() << " " << newhit.getEnergy() << endmsg;
+
+      edm4hep::MutableCaloHitSimCaloHitLink rel = relcol.create();
+      rel.setTo(simhit0);
+      rel.setFrom(newhit);
+      rel.setWeight(1.0);
+
+    } // theshold
+  } // input hits 
+
+  return std::make_tuple(std::move(newcol), std::move(relcol));
+}
+
+//------------------------------------------------------------------------------
+
+StatusCode RealisticCaloDigi::finalize(){
+  return StatusCode::SUCCESS;
+}
+
+//------------------------------------------------------------------------------
+
+RealisticCaloDigi::integr_res_opt RealisticCaloDigi::Integrate( const edm4hep::SimCalorimeterHit * hit ) const {
+  return m_integr_function(hit);
+}
+
+//------------------------------------------------------------------------------
+
+float RealisticCaloDigi::EnergyDigi(float energy, float event_correl_miscalib) const{
+  // some extra digi effects
+  // controlled by _applyDigi = 0 (none), 1 (apply)
+  // input parameters: hit energy ( in any unit: effects are all relative )
+  // returns energy ( in units determined by the overloaded digitiseDetectorEnergy )
+
+  float e_out(energy);
+  e_out = digitiseDetectorEnergy(energy); // this is an overloaded method, provides energy in technology-dependent units
+
+  // the following make only relative changes to the energy
+
+  // random miscalib, uncorrelated in cells
+  if (m_misCalib_uncorrel>0) {
+    float miscal(0);
+    miscal = m_engine.Gaus(1.0, m_misCalib_uncorrel);
+    e_out*=miscal;
+  }
+
+  // random miscalib, correlated across cells in one event
+  if (m_misCalib_correl>0) e_out*=event_correl_miscalib;
+
+  float oneMipInMyUnits = convertEnergy( 1.0, MIP );
+  // limited electronics dynamic range
+  if ( m_elec_rangeMip > 0 ) e_out = std::min ( e_out, m_elec_rangeMip*oneMipInMyUnits );
+  // add electronics noise
+  if ( m_elec_noiseMip > 0 ) {
+    e_out += m_engine.Gaus(0, m_elec_noiseMip*oneMipInMyUnits);
+  }
+
+  // random cell kill
+  if (m_deadCell_fraction>0) {
+    if (m_engine.Uniform(0., 1.) < m_deadCell_fraction ) e_out=0;
+  }
+  return e_out;
+}
+
+//------------------------------------------------------------------------------
+
+RealisticCaloDigi::integr_res_opt RealisticCaloDigi::StandardIntegration( const edm4hep::SimCalorimeterHit * hit ) const {
+  // apply timing cuts on simhit contributions
+  // outputs a (time,energy) pair
+  float timeCorrection(0);
+  if ( m_time_correctForPropagation ) { // time of flight from IP to this point
+    float r = pow(hit->getPosition().x,2) + pow(hit->getPosition().y,2) + pow(hit->getPosition().z,2); 
+    timeCorrection = sqrt(r)/CLHEP::c_light; // [speed of light in mm/ns]
+  }
+  // this is Oskar's simple (and probably the most correct) method for treatment of timing
+  //  - collect energy in some predefined time window around collision time (possibly corrected for TOF)
+  //  - assign time of earliest contribution to hit
+  float energySum = 0;
+  float earliestTime=std::numeric_limits<float>::max();
+  for(edm4hep::CaloHitContribution contribution : hit->getContributions()){ // loop over all contributions
+    float timei   = contribution.getTime(); //absolute hit timing of current subhit
+    float energyi = contribution.getEnergy(); //energy of current subhit
+    float relativetime = timei - timeCorrection; // wrt time of flight
+    if (relativetime>m_time_windowMin && relativetime<m_time_windowMax){
+      energySum += energyi;
+      if (relativetime<earliestTime){
+	       earliestTime = relativetime; //use earliest hit time for simpletimingcut
+      }
+    }
+  }
+  if(earliestTime > m_time_windowMin && earliestTime < m_time_windowMax){ //accept this hit
+    return integr_res{SmearTime(earliestTime), energySum};
+  }
+  return std::nullopt;
+}
+
+//------------------------------------------------------------------------------
+
+RealisticCaloDigi::integr_res_opt RealisticCaloDigi::ROCIntegration( const edm4hep::SimCalorimeterHit * hit ) const {
+  const unsigned int ncontrib = hit->contributions_size() ;
+  // Sort MC contribution by time
+  std::vector<MCC> mcconts{ncontrib};
+  for(int i=0; i<hit->getContributions().size();i++){
+    mcconts[i].energy = hit->getContributions(i).getEnergy();
+    mcconts[i].time = hit->getContributions(i).getTime();
+  }
+  std::sort(mcconts.begin(), mcconts.end(), [](auto lhs, auto rhs){
+    return (lhs.time < rhs.time);
+  });
+  // Accumulate energy until threshold is reached.
+  // The first MC contriubtion after the threshold has been reached sets the hit time 
+  bool passThreshold = false;
+  float epar=0.f, hitTime=0.f;
+  unsigned int thresholdIndex=0;
+  // First determine the hit time (hitTime) and the initial hit index 
+  // at which we need to start the integration (thresholdIndex)
+  for(unsigned int i=0; i<ncontrib ; ++i) {
+    const auto timei = mcconts[i].time;
+    thresholdIndex = i ;
+    epar = 0.f;
+    for(unsigned int j=i; j<ncontrib ; ++j) {
+      const auto timej = mcconts[j].time;
+      if( (timej-timei) < m_fast_shaper) {
+        epar += mcconts[j].energy;
+      }
+      else {
+        break;
+      }
+      if( convertEnergy(epar, GEVDEP) > m_threshold_value ) {
+        hitTime = timej;
+        passThreshold = true ;
+        break;
+      }
+    }
+    if(passThreshold) {
+      break;
+    }
+  }
+  // check hit time 
+  const float thresholdTime = mcconts[thresholdIndex].time;
+  if( not (thresholdTime>m_time_windowMin && thresholdTime<m_time_windowMax) ) {
+    return std::nullopt;
+  }
+  // If we've found a hit above the threshold, accumulate the energy until
+  // until the maximum time given by the slow shaper
+  if(passThreshold) {
+    float energySum = 0.f ; 
+    for(unsigned int i=thresholdIndex ; i<ncontrib ; ++i) {
+      if( mcconts[i].time < thresholdTime + m_slow_shaper) {
+        energySum += mcconts[i].energy;
+      }
+    }
+    hitTime = SmearTime(hitTime);
+    return integr_res{hitTime, energySum};
+  }
+  // else no hit dude !
+  else {
+    return std::nullopt;
+  }
+}
+
+//------------------------------------------------------------------------------
+
+float RealisticCaloDigi::SmearTime(float time) const{
+  return m_time_resol>0.f ? time + m_engine.Gaus(0, m_time_resol) : time;
+}
+

--- a/RecCaloDigi/src/RealisticCaloDigiScinPpd.cc
+++ b/RecCaloDigi/src/RealisticCaloDigiScinPpd.cc
@@ -1,0 +1,49 @@
+// Calorimeter digitiser for the IDC ECAL and HCAL
+// For other detectors/models SimpleCaloDigi should be used
+
+#include "RealisticCaloDigiScinPpd.h"
+
+#include <iostream>
+#include <string>
+#include <algorithm>
+#include <assert.h>
+
+#include "CLHEP/Random/RandGauss.h"
+#include "CLHEP/Random/RandBinomial.h"
+
+using namespace std;
+
+DECLARE_COMPONENT(RealisticCaloDigiScinPpd)
+
+RealisticCaloDigiScinPpd::RealisticCaloDigiScinPpd(const std::string& name, ISvcLocator* svcLoc)
+ : RealisticCaloDigi(name, svcLoc) {}
+
+float RealisticCaloDigiScinPpd::convertEnergy( float energy, int inUnit ) const { // convert energy from input to output scale (NPE)
+  if      ( inUnit==NPE ) return energy;
+  else if ( inUnit==MIP ) return m_PPD_pe_per_mip*energy;
+  else if ( inUnit==GEVDEP ) return m_PPD_pe_per_mip*energy/m_calib_mip;
+
+  throw std::runtime_error("RealisticCaloDigiScinPpd::convertEnergy - unknown unit " + std::to_string(inUnit));
+}
+
+float RealisticCaloDigiScinPpd::digitiseDetectorEnergy(float energy) const {
+  // input energy in deposited GeV
+  // output in npe
+  float npe = energy*m_PPD_pe_per_mip/m_calib_mip; // convert to pe scale
+
+  if (m_PPD_n_pixels>0){
+    // apply average sipm saturation behaviour
+    npe = m_PPD_n_pixels*(1.0 - exp( -npe/m_PPD_n_pixels ) );
+    //apply binomial smearing
+    float p = npe/m_PPD_n_pixels; // fraction of hit pixels on SiPM
+    npe = m_engine.Binomial(m_PPD_n_pixels, p); //npe now quantised to integer pixels
+
+    if (m_pixSpread>0) {
+      // variations in pixel capacitance
+      npe *= m_engine.Gaus(1, m_pixSpread/sqrt(npe) );
+    }
+  }
+
+  return npe;
+}
+

--- a/RecCaloDigi/src/RealisticCaloDigiSilicon.cc
+++ b/RecCaloDigi/src/RealisticCaloDigiSilicon.cc
@@ -1,0 +1,44 @@
+// Calorimeter digitiser for the IDC ECAL and HCAL
+// For other detectors/models SimpleCaloDigi should be used
+#include "RealisticCaloDigiSilicon.h"
+
+#include <iostream>
+#include <string>
+#include <algorithm>
+#include <assert.h>
+
+#include "CLHEP/Random/RandPoisson.h"
+#include "CLHEP/Random/RandGauss.h"
+
+using namespace std;
+
+DECLARE_COMPONENT(RealisticCaloDigiSilicon)
+
+RealisticCaloDigiSilicon::RealisticCaloDigiSilicon(const std::string& name, ISvcLocator* svcLoc)
+  : RealisticCaloDigi(name, svcLoc) {}
+
+float RealisticCaloDigiSilicon::convertEnergy( float energy, int inUnit ) const { // convert energy from input to output scale (MIP)
+  // converts input energy to MIP scale
+  if      ( inUnit==MIP ) return energy;
+  else if ( inUnit==GEVDEP ) return energy/m_calib_mip;
+
+  throw std::runtime_error("RealisticCaloDigiSilicon::convertEnergy - unknown unit " + std::to_string(inUnit));
+}
+
+
+float RealisticCaloDigiSilicon::digitiseDetectorEnergy(float energy) const {
+  // applies extra digitisation to silicon hits
+  //  input energy in deposited GeV
+  //  output is MIP scale
+  float smeared_energy(energy);
+  if ( m_ehEnergy>0 ) {
+    // calculate #e-h pairs
+    float nehpairs = 1e9*energy/m_ehEnergy; // check units of energy! _ehEnergy is in eV, energy in GeV
+    // fluctuate it by Poisson (actually an overestimate: Fano factor actually makes it smaller, however even this overstimated effect is tiny for our purposes)
+    smeared_energy *= m_engine.Poisson( nehpairs )/nehpairs;
+  }
+
+  return smeared_energy/m_calib_mip; // convert to MIP units
+}
+
+

--- a/RecCaloDigi/src/RealisticCaloReco.cc
+++ b/RecCaloDigi/src/RealisticCaloReco.cc
@@ -1,0 +1,92 @@
+#include "RealisticCaloReco.h"
+
+#include <DDSegmentation/BitFieldCoder.h>
+
+#include <edm4hep/SimCalorimeterHit.h>
+#include <edm4hep/MutableCalorimeterHit.h>
+#include <edm4hep/CaloHitSimCaloHitLinkCollection.h>
+
+#include <iostream>
+#include <string>
+#include <algorithm>
+#include <assert.h>
+#include <cmath>
+
+using namespace std;
+
+RealisticCaloReco::RealisticCaloReco(const std::string& name, ISvcLocator* svcLoc) : MultiTransformer(name, svcLoc, 
+  { KeyValues("inputLinkCollections", {"CaloHitLinks"}) },
+  { KeyValues("outputHitCollections", {"CalorimeterHitsRec"}),
+   KeyValues("outputRelationCollections", {"CaloHitLinksRec"}) }) {}
+
+StatusCode RealisticCaloReco::initialize() {
+  m_geoSvc = serviceLocator()->service("GeoSvc");
+  if (!m_geoSvc) {
+    error() << "Unable to retrieve the GeoSvc" << endmsg;
+    return StatusCode::FAILURE;
+  }
+
+  assert ( m_calibrCoeff.size()>0 );
+  assert ( m_calibrCoeff.size() == m_calLayers.size() );
+
+  return StatusCode::SUCCESS;
+}
+
+//-----------------------------------------------------------------------------------------------
+
+std::tuple<edm4hep::CalorimeterHitCollection, 
+           edm4hep::CaloHitSimCaloHitLinkCollection> RealisticCaloReco::operator()(
+           const edm4hep::CaloHitSimCaloHitLinkCollection& inputLinks) const {
+  // * Reading Collections of digitised calorimeter Hits *
+  std::string initString;
+  initString = m_geoSvc->constantAsString(m_encodingStringVariable.value());
+  dd4hep::DDSegmentation::BitFieldCoder bitFieldCoder(initString);  // check!
+  
+  edm4hep::CalorimeterHitCollection newcol;
+  edm4hep::CaloHitSimCaloHitLinkCollection relcol;
+  debug()  << " number of elements = " << inputLinks.size() << endmsg;
+
+  for (int j(0); j < inputLinks.size(); ++j) {
+      edm4hep::CaloHitSimCaloHitLink link = inputLinks.at( j ) ;
+      edm4hep::CalorimeterHit hit0 = link.getFrom();
+      edm4hep::CalorimeterHit *hit = &hit0;
+      edm4hep::MutableCalorimeterHit calhit = newcol.create(); // make new hit
+      
+      int cellid = hit->getCellID();
+      float energy = reconstructEnergy( hit, bitFieldCoder.get(cellid, "layer") ); // overloaded method, technology dependent
+
+      calhit.setCellID(cellid);
+      calhit.setEnergy(energy);
+      calhit.setTime( hit->getTime() );
+      calhit.setPosition( hit->getPosition() );
+      calhit.setType( hit->getType() );
+
+      edm4hep::MutableCaloHitSimCaloHitLink newLink = relcol.create();
+      newLink.setFrom(calhit);
+      newLink.setTo(link.getTo());
+      newLink.setWeight(1.0);
+  }
+
+  return std::make_tuple(std::move(newcol), std::move(relcol));
+}
+
+float RealisticCaloReco::getLayerCalib( int ilayer ) const{
+  float calib_coeff = 0;
+  // retrieve calibration constants
+  // Fixed the following logic (DJeans, June 2016)
+  int min(0),max(0);
+  for (unsigned int k(0); k < m_calLayers.size(); ++k) {
+    if ( k > 0 ) min+=m_calLayers[k-1];
+    max+=m_calLayers[k];
+    if (ilayer >= min && ilayer < max) {
+      calib_coeff = m_calibrCoeff[k];
+      break;
+    }
+  }
+  assert( calib_coeff>0 );
+  return calib_coeff;
+}
+
+
+StatusCode RealisticCaloReco::finalize(){ return StatusCode::SUCCESS; }
+

--- a/RecCaloDigi/src/RealisticCaloRecoScinPpd.cc
+++ b/RecCaloDigi/src/RealisticCaloRecoScinPpd.cc
@@ -1,0 +1,31 @@
+#include "RealisticCaloRecoScinPpd.h"
+#include <cmath>
+#include <iostream>
+
+DECLARE_COMPONENT(RealisticCaloRecoScinPpd)
+
+RealisticCaloRecoScinPpd::RealisticCaloRecoScinPpd(const std::string& name, ISvcLocator* svcLoc) : RealisticCaloReco(name, svcLoc) {}
+
+float RealisticCaloRecoScinPpd::reconstructEnergy(const edm4hep::CalorimeterHit* hit, int layer) const{
+  // here the input energy should be in NPE
+  float energy = hit->getEnergy();
+
+  // first de-saturate PPD response
+  // this is the fraction of SiPM pixels fired above which a linear continuation of the saturation-reconstruction function is used. 
+  // 0.95 of nPixel corresponds to a energy correction of factor ~3.
+  const float r = 0.95;
+  if (energy < r*m_PPD_n_pixels){ //current hit below linearisation threshold, reconstruct energy normally:
+    energy = -m_PPD_n_pixels * std::log ( 1. - ( energy / m_PPD_n_pixels ) );
+  } else { //current hit is aove linearisation threshold, reconstruct using linear continuation function:
+    energy = 1/(1-r)*(energy-r*m_PPD_n_pixels)-m_PPD_n_pixels*std::log(1-r);
+  }
+  // then go back to MIP scale
+  energy/=m_PPD_pe_per_mip;
+
+  // now correct for sampling fraction (calibration from MIP -> shower GeV)
+  energy *= getLayerCalib( layer );
+
+  return energy;
+}
+
+

--- a/RecCaloDigi/src/RealisticCaloRecoSilicon.cc
+++ b/RecCaloDigi/src/RealisticCaloRecoSilicon.cc
@@ -1,0 +1,17 @@
+#include "RealisticCaloRecoSilicon.h"
+#include <algorithm>
+#include <cassert>
+#include <iostream>
+
+
+DECLARE_COMPONENT(RealisticCaloRecoSilicon)
+
+RealisticCaloRecoSilicon::RealisticCaloRecoSilicon(const std::string& name, ISvcLocator* svcLoc) : RealisticCaloReco(name, svcLoc) {}
+
+float RealisticCaloRecoSilicon::reconstructEnergy(const edm4hep::CalorimeterHit* hit, int layer) const{
+  // here the input energy should be in MIPs
+  float energy = hit->getEnergy();
+  // now correct for sampling fraction
+  energy *= getLayerCalib( layer );
+  return energy;
+}


### PR DESCRIPTION
This is the second of some amount smaller PRs, designed to split up PR https://github.com/key4hep/k4Reco/pull/50 into more manageable pieces. This PR includes changes to calorimeter digis used by the muon collider project in k4Reco, but being redirected here (see: https://github.com/key4hep/k4Reco/pull/51#issuecomment-4286409207). The original work was done by @samf25. I have renamed `CaloDigi` to` RecCaloDigi` to try and fit what I guess is the naming theme here, but I am entirely flexible on this point. The CMake file was added by me (although written by Claude, my CMake is still rudimentary at best) based on what seems to be the CMake architecture of this repository, with each distinct directory having it's own file. This CMake file works for me and compiles completely on lxplus using the latest nightly release.

As before, this is largely being opened for discussion to start the process of muon collider forks, if the ultimate PR requires a selected subset of these changes, that is something that can be discussed. This PR is being opened in draft because this is not strictly a key4hep repository, and I am not sure that this is a dependency the muon collider would like to add.

@tmadlener @madbaron @samf25, FYI


BEGINRELEASENOTES
- Add muon collider calo digi work originally from k4Reco
ENDRELEASENOTES
