### PR TITLE
Add implementations of ICalorimeterTool for Allegro HCal.

### DIFF
--- a/RecCaloCommon/include/RecCaloCommon/CalorimeterToolBase.h
+++ b/RecCaloCommon/include/RecCaloCommon/CalorimeterToolBase.h
@@ -53,7 +53,16 @@ public:
 
   /** Return the subdetector ID.
    */
-  virtual int id() const final override;
+  virtual int id() const override;
+
+  /** Return the name of this subdetector, to be used to find the
+      subdetector ID.
+      If blank, the detector ID will be found from the detector
+      associated with the segmentation (but this may not always work
+      if there are multiple segmentations associated with a detector).
+      Returns blank by default but may be overridden.
+   */
+  virtual std::string detectorName() const;
 
 protected:
   /// Return the resolved readout.
@@ -81,9 +90,12 @@ private:
   /// Resolved detector readout.
   dd4hep::Readout m_readout;
 
-  // Pointer to the vector of cells.  The vector itself is stored in the
-  // constants service; we create it if it's not already there.
+  /// Pointer to the vector of cells.  The vector itself is stored in the
+  /// constants service; we create it if it's not already there.
   const std::vector<CellID>* m_cells;
+
+  /// The detector ID.
+  int m_id = -1;
 };
 
 #endif // not RECCALOCOMMON_CALORIMETERTOOLBASE_H

--- a/RecCaloCommon/src/CalorimeterToolBase.cpp
+++ b/RecCaloCommon/src/CalorimeterToolBase.cpp
@@ -31,6 +31,16 @@ StatusCode CalorimeterToolBase::initialize() {
     m_readout = it->second;
   }
 
+  // Find the detector ID.
+  std::string detName = this->detectorName();
+  if (detName.empty()) {
+    if (m_readout.isValid()) {
+      m_id = m_readout.segmentation().detector()->id;
+    }
+  } else {
+    m_id = m_geoSvc->getDetector()->constant<int>("DetID_" + detName);
+  }
+
   // Need to do this after m_readout is defined, since it may ask us
   // for our id.
   K4_GAUDI_CHECK(m_constantsSvc.retrieve());
@@ -77,11 +87,16 @@ const std::string& CalorimeterToolBase::readoutName() const { return m_readoutNa
 /** Return the subdetector ID.
  */
 int CalorimeterToolBase::id() const {
-  if (!m_readout) {
-    error() << name() << ": " << "Readout not found; can't find detector ID" << endmsg;
+  if (m_id < 0) {
+    error() << name() << ": " << "Detector ID not defined." << endmsg;
   }
-  return m_readout.segmentation().detector()->id;
+  return m_id;
 }
+
+/** Return the name of this subdetector, to be used to find the
+    subdetector ID.
+*/
+std::string CalorimeterToolBase::detectorName() const { return ""; }
 
 /** Create the list of cells and store with the constants service.
  */

--- a/RecFCCeeCalorimeter/CMakeLists.txt
+++ b/RecFCCeeCalorimeter/CMakeLists.txt
@@ -72,8 +72,11 @@ set_tests_properties(FCCeeCalo_DigitizationWhiteningFilter PROPERTIES FIXTURES_R
 
 if(BUILD_TESTING)
   gaudi_add_module( k4RecFCCeeCalorimeterTests
-                    SOURCES tests/src/TubeLayerModuleThetaCaloToolTestAlg.cpp
+                    SOURCES
+                    tests/src/TubeLayerModuleThetaCaloToolTestAlg.cpp
+                    tests/src/HCalPhiCaloToolTestAlg.cpp
                     LINK k4FWCore::k4FWCore
+                    k4geo::detectorSegmentations
                     k4FWCore::k4Interface
                     Gaudi::GaudiKernel
                     RecCaloCommon
@@ -84,4 +87,22 @@ if(BUILD_TESTING)
             WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/Testing/Temporary
           )
   set_test_env( TubeLayerModuleThetaCaloTool_test )
+
+  add_test( NAME HCalPhiThetaCaloTool_test
+            COMMAND k4run ${PROJECT_SOURCE_DIR}/RecFCCeeCalorimeter/tests/options/HCalPhiThetaCaloTool_test.py
+            WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/Testing/Temporary
+        )
+  set_test_env( HCalPhiThetaCaloTool_test )
+
+  add_test( NAME HCalPhiRowCaloTool_test
+            COMMAND k4run ${PROJECT_SOURCE_DIR}/RecFCCeeCalorimeter/tests/options/HCalPhiRowCaloTool_test.py
+            WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/Testing/Temporary
+        )
+  set_test_env( HCalPhiRowCaloTool_test )
+
+  add_test( NAME HCalPhiGroupedRowCaloTool_test
+            COMMAND k4run ${PROJECT_SOURCE_DIR}/RecFCCeeCalorimeter/tests/options/HCalPhiGroupedRowCaloTool_test.py
+            WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/Testing/Temporary
+        )
+  set_test_env( HCalPhiGroupedRowCaloTool_test )
 endif()

--- a/RecFCCeeCalorimeter/src/components/HCalPhiRowCaloTool.cpp
+++ b/RecFCCeeCalorimeter/src/components/HCalPhiRowCaloTool.cpp
@@ -1,0 +1,102 @@
+/**
+ * @file RecFCCeeCalorimeter/src/components/HCalPhiRowCaloTool.cpp
+ * @author scott snyder <snyder@bnl.gov>
+ * @date May, 2026
+ * @brief Calorimeter tool for Allegro HCal (with row indexing).
+ */
+
+#include "HCalPhiRowCaloTool.h"
+#include "RecCaloCommon/IDMapIndexer.h"
+#include "detectorSegmentations/FCCSWHCalPhiRow_k4geo.h"
+#include "k4FWCore/GaudiChecks.h"
+
+DECLARE_COMPONENT(HCalPhiRowCaloTool)
+
+/** Return the name of this subdetector, to be used to find the
+    subdetector ID.
+*/
+std::string HCalPhiRowCaloTool::detectorName() const {
+  if (readoutName() == "HCalBarrelReadoutPhiRow")
+    return "HCAL_Barrel";
+  else
+    return "HCAL_Endcap";
+}
+
+/** Fill vector with all existing cells for this geometry.
+ */
+StatusCode HCalPhiRowCaloTool::collectCells(std::vector<uint64_t>& cells) const {
+  bool is_barrel = (readoutName() == "HCalBarrelReadoutPhiRow");
+  cells.reserve(is_barrel ? 1031680 : 1164800);
+  const auto* seg =
+      dynamic_cast<const dd4hep::DDSegmentation::FCCSWHCalPhiRow_k4geo*>(readout().segmentation().segmentation());
+  if (!seg) {
+    error() << "Unable to cast segmentation pointer!!!! Tool only applicable to FCCSWHCalPhiRow_k4geo "
+               "segmentation."
+            << endmsg;
+    return StatusCode::FAILURE;
+  }
+
+  const dd4hep::DDSegmentation::BitFieldCoder& decoder = *readout().idSpec().decoder();
+
+  dd4hep::DDSegmentation::CellID cID = 0;
+  decoder.set(cID, "system", this->id());
+
+  size_t layer_id = decoder.index(seg->fieldNameLayer());
+  size_t row_id = decoder.index(seg->fieldNameRow());
+  size_t phi_id = decoder.index(seg->fieldNamePhi());
+  size_t pseudolayer_id = is_barrel ? 0 : decoder.index(seg->fieldNamePseudoLayer());
+
+  int numLayers = 0;
+  for (int n : seg->numLayers())
+    numLayers += n;
+  for (int layer = 0; layer < numLayers; ++layer) {
+    decoder.set(cID, layer_id, layer);
+    for (int row : seg->cellIndexes(layer)) {
+      decoder.set(cID, row_id, row);
+      if (!is_barrel)
+        decoder.set(cID, pseudolayer_id, seg->definePseudoLayer(cID));
+      for (int phi = 0; phi < seg->phiBins(); ++phi) {
+        decoder.set(cID, phi_id, phi);
+        cells.push_back(cID);
+      }
+    }
+  }
+
+  return StatusCode::SUCCESS;
+}
+
+/** Return a new indexer object for this subdetector.
+ */
+std::unique_ptr<k4::recCalo::ICaloIndexer> HCalPhiRowCaloTool::indexer() const {
+  const auto* seg =
+      dynamic_cast<const dd4hep::DDSegmentation::FCCSWHCalPhiRow_k4geo*>(readout().segmentation().segmentation());
+  if (!seg) {
+    error() << "Unable to cast segmentation pointer!!!! Tool only applicable to FCCSWHCalPhiTow_k4geo "
+               "segmentation."
+            << endmsg;
+    return nullptr;
+  }
+
+  bool is_barrel = (readoutName() == "HCalBarrelReadoutPhiRow");
+
+  using Indexer_t = k4::recCalo::IDMapIndexer<3>;
+  dd4hep::IDDescriptor idSpec = readout().idSpec();
+  // Sorry for the ugly formatting, but clang-format insists.
+  std::vector<Indexer_t::FieldDesc_t> fields{Indexer_t::IDMap_t::makeDesc(*idSpec.field(seg->fieldNameLayer())),
+                                             Indexer_t::IDMap_t::makeDesc(*idSpec.field(seg->fieldNameRow())),
+                                             Indexer_t::IDMap_t::makeDesc(*idSpec.field(seg->fieldNamePhi()))};
+
+  const dd4hep::BitFieldElement& sysField = *idSpec.field("system");
+  if (sysField.offset() != 0) {
+    throw std::runtime_error("Bad system field offset; must be zero");
+  }
+
+  std::vector<Indexer_t::FieldDesc_t> ignoredFields;
+  if (!is_barrel) {
+    ignoredFields.push_back(Indexer_t::IDMap_t::makeDesc(*idSpec.field(seg->fieldNamePseudoLayer())));
+  }
+
+  // Again, clang-format complains if this is written legibly...
+  return std::make_unique<Indexer_t>(this->id(), sysField.width(), fields, cellIDs(), is_barrel ? 4200000 : 1000000,
+                                     ignoredFields);
+}

--- a/RecFCCeeCalorimeter/src/components/HCalPhiRowCaloTool.h
+++ b/RecFCCeeCalorimeter/src/components/HCalPhiRowCaloTool.h
@@ -1,0 +1,38 @@
+// This file's extension implies that it's C, but it's really -*- C++ -*-.
+/**
+ * @file RecFCCeeCalorimeter/src/components/HCalPhiRowCaloTool.h
+ * @author scott snyder <snyder@bnl.gov>
+ * @date May, 2026
+ * @brief Calorimeter tool for Allegro HCal (with row indexing).
+ */
+
+#ifndef RECFCCEECALORIMETER_HCALPHIROWCALOTOOL_H
+#define RECFCCEECALORIMETER_HCALPHIROWCALOTOOL_H
+
+#include "RecCaloCommon/CalorimeterToolBase.h"
+
+/** @class HCalPhiRowCaloTool
+ *
+ *  Manage IDs for HCal (with row indexing).
+ */
+class HCalPhiRowCaloTool : public CalorimeterToolBase {
+public:
+  using CalorimeterToolBase::CalorimeterToolBase;
+  virtual ~HCalPhiRowCaloTool() = default;
+
+  /** Return the name of this subdetector, to be used to find the
+      subdetector ID.
+   */
+  virtual std::string detectorName() const override;
+
+  /** Return a new indexer object for this subdetector.
+   */
+  virtual std::unique_ptr<k4::recCalo::ICaloIndexer> indexer() const override final;
+
+protected:
+  /** Fill vector with all existing cells for this geometry.
+   */
+  virtual StatusCode collectCells(std::vector<uint64_t>& cells) const override final;
+};
+
+#endif /* RECFCCEECALORIMETER_HCALPHIROWCALOTOOL_H */

--- a/RecFCCeeCalorimeter/src/components/HCalPhiThetaCaloTool.cpp
+++ b/RecFCCeeCalorimeter/src/components/HCalPhiThetaCaloTool.cpp
@@ -1,0 +1,92 @@
+/**
+ * @file RecFCCeeCalorimeter/src/components/HCalPhiThetaCaloTool.cpp
+ * @author scott snyder <snyder@bnl.gov>
+ * @date Feb, 2026
+ * @brief Calorimeter tool for Allegro HCal.
+ */
+
+#include "HCalPhiThetaCaloTool.h"
+#include "RecCaloCommon/IDMapIndexer.h"
+#include "detectorSegmentations/FCCSWHCalPhiTheta_k4geo.h"
+#include "k4FWCore/GaudiChecks.h"
+
+DECLARE_COMPONENT(HCalPhiThetaCaloTool)
+
+/** Return the name of this subdetector, to be used to find the
+    subdetector ID.
+*/
+std::string HCalPhiThetaCaloTool::detectorName() const {
+  if (readoutName() == "HCalBarrelReadout")
+    return "HCAL_Barrel";
+  else
+    return "HCAL_Endcap";
+}
+
+/** Fill vector with all existing cells for this geometry.
+ */
+StatusCode HCalPhiThetaCaloTool::collectCells(std::vector<uint64_t>& cells) const {
+  cells.reserve(readoutName() == "HCalBarrelReadout" ? 210944 : 80896);
+  const auto* seg =
+      dynamic_cast<const dd4hep::DDSegmentation::FCCSWHCalPhiTheta_k4geo*>(readout().segmentation().segmentation());
+  if (!seg) {
+    error() << "Unable to cast segmentation pointer!!!! Tool only applicable to FCCSWHCalPhiTheta_k4geo "
+               "segmentation."
+            << endmsg;
+    return StatusCode::FAILURE;
+  }
+
+  const dd4hep::DDSegmentation::BitFieldCoder& decoder = *readout().idSpec().decoder();
+
+  dd4hep::DDSegmentation::CellID cID = 0;
+  decoder.set(cID, "system", this->id());
+
+  size_t layer_id = decoder.index(seg->fieldNameLayer());
+  size_t theta_id = decoder.index(seg->fieldNameTheta());
+  size_t phi_id = decoder.index(seg->fieldNamePhi());
+
+  int numLayers = 0;
+  for (int n : seg->numLayers())
+    numLayers += n;
+  for (int layer = 0; layer < numLayers; ++layer) {
+    const std::vector<int>& thetaBins = seg->thetaBins(layer);
+    decoder.set(cID, layer_id, layer);
+    for (int theta : thetaBins) {
+      decoder.set(cID, theta_id, theta);
+      for (int phi = 0; phi < seg->phiBins(); ++phi) {
+        decoder.set(cID, phi_id, phi);
+        cells.push_back(cID);
+      }
+    }
+  }
+
+  return StatusCode::SUCCESS;
+}
+
+/** Return a new indexer object for this subdetector.
+ */
+std::unique_ptr<k4::recCalo::ICaloIndexer> HCalPhiThetaCaloTool::indexer() const {
+  const auto* seg =
+      dynamic_cast<const dd4hep::DDSegmentation::FCCSWHCalPhiTheta_k4geo*>(readout().segmentation().segmentation());
+  if (!seg) {
+    error() << "Unable to cast segmentation pointer!!!! Tool only applicable to FCCSWHCalPhiTheta_k4geo "
+               "segmentation."
+            << endmsg;
+    return nullptr;
+  }
+
+  using Indexer_t = k4::recCalo::IDMapIndexer<3>;
+  dd4hep::IDDescriptor idSpec = readout().idSpec();
+  // Sorry, clang-format insists on making this hard to read.
+  std::vector<Indexer_t::FieldDesc_t> fields{Indexer_t::IDMap_t::makeDesc(*idSpec.field(seg->fieldNameLayer())),
+                                             Indexer_t::IDMap_t::makeDesc(*idSpec.field(seg->fieldNameTheta())),
+                                             Indexer_t::IDMap_t::makeDesc(*idSpec.field(seg->fieldNamePhi()))};
+
+  const dd4hep::BitFieldElement& sysField = *idSpec.field("system");
+  if (sysField.offset() != 0) {
+    throw std::runtime_error("Bad system field offset; must be zero");
+  }
+
+  // Again, clang-format...
+  return std::make_unique<Indexer_t>(this->id(), sysField.width(), fields, cellIDs(),
+                                     readoutName() == "HCalBarrelReadout" ? 900000 : 700000);
+}

--- a/RecFCCeeCalorimeter/src/components/HCalPhiThetaCaloTool.h
+++ b/RecFCCeeCalorimeter/src/components/HCalPhiThetaCaloTool.h
@@ -1,0 +1,38 @@
+// This file's extension implies that it's C, but it's really -*- C++ -*-.
+/**
+ * @file RecFCCeeCalorimeter/src/components/HCalPhiThetaCaloTool.h
+ * @author scott snyder <snyder@bnl.gov>
+ * @date Feb, 2026
+ * @brief Calorimeter tool for Allegro HCal.
+ */
+
+#ifndef RECFCCEECALORIMETER_HCALPHITHETACALOTOOL_H
+#define RECFCCEECALORIMETER_HCALPHITHETACALOTOOL_H
+
+#include "RecCaloCommon/CalorimeterToolBase.h"
+
+/** @class HCalPhiThetaCaloTool
+ *
+ *  Manage IDs for HCal.
+ */
+class HCalPhiThetaCaloTool : public CalorimeterToolBase {
+public:
+  using CalorimeterToolBase::CalorimeterToolBase;
+  virtual ~HCalPhiThetaCaloTool() = default;
+
+  /** Return the name of this subdetector, to be used to find the
+      subdetector ID.
+   */
+  virtual std::string detectorName() const override;
+
+  /** Return a new indexer object for this subdetector.
+   */
+  virtual std::unique_ptr<k4::recCalo::ICaloIndexer> indexer() const override final;
+
+protected:
+  /** Fill vector with all existing cells for this geometry.
+   */
+  virtual StatusCode collectCells(std::vector<uint64_t>& cells) const override final;
+};
+
+#endif /* RECFCCEECALORIMETER_HCALPHITHETACALOTOOL_H */

--- a/RecFCCeeCalorimeter/tests/options/HCalPhiGroupedRowCaloTool_test.py
+++ b/RecFCCeeCalorimeter/tests/options/HCalPhiGroupedRowCaloTool_test.py
@@ -1,0 +1,42 @@
+#
+# File: RecFCCeeCalorimeter/tests/options/HCalPhiGroupedRowCaloTool_test.py
+# Author: scott snyder <snyder@bnl.gov>
+# Date: May, 2026
+# Purpose: Test for HCalPhiTowCaloTool
+#
+
+import os
+import Configurables as C
+
+compactFile = "ALLEGRO_o1_v03.xml"
+pathToDetector = (
+    os.environ.get("K4GEO", "")
+    + "/FCCee/ALLEGRO/compact/"
+    + os.path.splitext(compactFile)[0]
+)
+
+geoSvc = C.GeoSvc("GeoSvc", detectors=[os.path.join(pathToDetector, compactFile)])
+
+hcalBarrelTool = C.HCalPhiRowCaloTool(
+    "hcalBarrelGeometryTool", readoutName="HCalBarrelReadoutPhiRow"
+)
+hcalEndcapTool = C.HCalPhiRowCaloTool(
+    "hcalEndcapGeometryTool", readoutName="HCalEndcapReadoutPhiRow"
+)
+
+# Sorry about the lack of whitespace and ugly formatting, but ruff-format
+# complains if this is written legibly.
+appmgr = C.ApplicationMgr(
+    TopAlg=[
+        C.k4__recCalo__HCalPhiCaloToolTestAlg(
+            HCalBarrelTool=hcalBarrelTool,
+            HCalEndcapTool=hcalEndcapTool,
+            GroupRows=True,
+            ExpectedBarrelReadout="HCalBarrelReadoutPhiRow",
+            ExpectedEndcapReadout="HCalEndcapReadoutPhiRow",
+            ExpectedBarrelCells=1031680,
+            ExpectedEndcapCells=104448,
+        )
+    ],
+    ExtSvc=[geoSvc],
+)

--- a/RecFCCeeCalorimeter/tests/options/HCalPhiRowCaloTool_test.py
+++ b/RecFCCeeCalorimeter/tests/options/HCalPhiRowCaloTool_test.py
@@ -1,0 +1,42 @@
+#
+# File: RecFCCeeCalorimeter/tests/options/HCalPhiRowCaloTool_test.py
+# Author: scott snyder <snyder@bnl.gov>
+# Date: May, 2026
+# Purpose: Test for HCalPhiTowCaloTool
+#
+
+import os
+import Configurables as C
+
+compactFile = "ALLEGRO_o1_v03.xml"
+pathToDetector = (
+    os.environ.get("K4GEO", "")
+    + "/FCCee/ALLEGRO/compact/"
+    + os.path.splitext(compactFile)[0]
+)
+
+geoSvc = C.GeoSvc("GeoSvc", detectors=[os.path.join(pathToDetector, compactFile)])
+
+hcalBarrelTool = C.HCalPhiRowCaloTool(
+    "hcalBarrelGeometryTool", readoutName="HCalBarrelReadoutPhiRow"
+)
+hcalEndcapTool = C.HCalPhiRowCaloTool(
+    "hcalEndcapGeometryTool", readoutName="HCalEndcapReadoutPhiRow"
+)
+
+
+# Sorry about the lack of whitespace and ugly formatting, but ruff-format
+# complains if this is written legibly.
+appmgr = C.ApplicationMgr(
+    TopAlg=[
+        C.k4__recCalo__HCalPhiCaloToolTestAlg(
+            HCalBarrelTool=hcalBarrelTool,
+            HCalEndcapTool=hcalEndcapTool,
+            ExpectedBarrelReadout="HCalBarrelReadoutPhiRow",
+            ExpectedEndcapReadout="HCalEndcapReadoutPhiRow",
+            ExpectedBarrelCells=1031680,
+            ExpectedEndcapCells=1164800,
+        )
+    ],
+    ExtSvc=[geoSvc],
+)

--- a/RecFCCeeCalorimeter/tests/options/HCalPhiThetaCaloTool_test.py
+++ b/RecFCCeeCalorimeter/tests/options/HCalPhiThetaCaloTool_test.py
@@ -1,0 +1,42 @@
+#
+# File: RecFCCeeCalorimeter/tests/options/HCalPhiThetaCaloTool_test.py
+# Author: scott snyder <snyder@bnl.gov>
+# Date: Feb, 2026
+# Purpose: Test for HCalPhiThetaCaloTool
+#
+
+import os
+import Configurables as C
+
+compactFile = "ALLEGRO_o1_v03.xml"
+pathToDetector = (
+    os.environ.get("K4GEO", "")
+    + "/FCCee/ALLEGRO/compact/"
+    + os.path.splitext(compactFile)[0]
+)
+
+geoSvc = C.GeoSvc("GeoSvc", detectors=[os.path.join(pathToDetector, compactFile)])
+
+hcalBarrelTool = C.HCalPhiThetaCaloTool(
+    "hcalBarrelGeometryTool", readoutName="HCalBarrelReadout"
+)
+hcalEndcapTool = C.HCalPhiThetaCaloTool(
+    "hcalEndcapGeometryTool", readoutName="HCalEndcapReadout"
+)
+
+
+# Sorry about the lack of whitespace and ugly formatting, but ruff-format
+# complains if this is written legibly.
+appmgr = C.ApplicationMgr(
+    TopAlg=[
+        C.k4__recCalo__HCalPhiCaloToolTestAlg(
+            HCalBarrelTool=hcalBarrelTool,
+            HCalEndcapTool=hcalEndcapTool,
+            ExpectedBarrelReadout="HCalBarrelReadout",
+            ExpectedEndcapReadout="HCalEndcapReadout",
+            ExpectedBarrelCells=210944,
+            ExpectedEndcapCells=80896,
+        )
+    ],
+    ExtSvc=[geoSvc],
+)

--- a/RecFCCeeCalorimeter/tests/src/HCalPhiCaloToolTestAlg.cpp
+++ b/RecFCCeeCalorimeter/tests/src/HCalPhiCaloToolTestAlg.cpp
@@ -1,0 +1,116 @@
+/**
+ * @file RecFCCeeCalorimeter/tests/src/HCalPhiCaloToolTestAlg.cpp
+ * @author scott snyder <snyder@bnl.gov>
+ * @date May, 2026
+ * @brief Test for HCalPhiThetaCaloTool/HCalPhiRowCaloTool
+ */
+
+#undef NDEBUG
+// Headers should really be in reverse-dependency order, but clang-format
+// complains if i do that...
+#include "DD4hep/Detector.h"
+#include "DD4hep/Readout.h"
+#include "GaudiKernel/Algorithm.h"
+#include "GaudiKernel/ServiceHandle.h"
+#include "GaudiKernel/ToolHandle.h"
+#include "RecCaloCommon/ICalorimeterTool.h"
+#include "detectorSegmentations/FCCSWHCalPhiRow_k4geo.h"
+#include "k4FWCore/GaudiChecks.h"
+#include "k4Interface/IGeoSvc.h"
+#include <cassert>
+#include <fstream>
+#include <span>
+
+namespace k4::recCalo {
+
+class HCalPhiCaloToolTestAlg : public Algorithm {
+  using Algorithm::Algorithm;
+
+  virtual StatusCode initialize() override;
+  virtual StatusCode execute() override;
+
+private:
+  StatusCode testTool(const k4::recCalo::ICalorimeterTool& tool, size_t exp_ncells) const;
+
+  Gaudi::Property<int> m_expectedBarrelCells{this, "ExpectedBarrelCells", 0, ""};
+  Gaudi::Property<int> m_expectedEndcapCells{this, "ExpectedEndcapCells", 0, ""};
+
+  Gaudi::Property<std::string> m_expectedBarrelReadout{this, "ExpectedBarrelReadout", "", ""};
+  Gaudi::Property<std::string> m_expectedEndcapReadout{this, "ExpectedEndcapReadout", "", ""};
+
+  Gaudi::Property<bool> m_groupRows{this, "GroupRows", false, ""};
+  Gaudi::Property<bool> m_dumpCells{this, "DumpCells", false, ""};
+
+  ToolHandle<k4::recCalo::ICalorimeterTool> m_barrelTool{this, "HCalBarrelTool", "", ""};
+  ToolHandle<k4::recCalo::ICalorimeterTool> m_endcapTool{this, "HCalEndcapTool", "", ""};
+
+  /// Handle to the geometry service.
+  ServiceHandle<IGeoSvc> m_geoSvc{this, "GeoSvc", "GeoSvc"};
+};
+
+DECLARE_COMPONENT(k4::recCalo::HCalPhiCaloToolTestAlg);
+
+StatusCode HCalPhiCaloToolTestAlg::initialize() {
+  if (m_groupRows) {
+    K4_GAUDI_CHECK(m_geoSvc.retrieve());
+    const dd4hep::Detector* det = m_geoSvc->getDetector();
+    auto it = det->readouts().find("HCalEndcapReadoutPhiRow");
+    if (it == det->readouts().end()) {
+      error() << "Readout HCalEndcapReadoutPhiRow does not exist." << endmsg;
+      return StatusCode::FAILURE;
+    }
+    dd4hep::Readout readout = it->second;
+    auto* seg = dynamic_cast<dd4hep::DDSegmentation::FCCSWHCalPhiRow_k4geo*>(readout.segmentation().segmentation());
+    if (!seg) {
+      error() << "Unable to cast segmentation pointer to FCCSWHCalPhiRow_k4geo!!!!" << endmsg;
+      return StatusCode::FAILURE;
+    }
+    // This is three groups of 6, but clang-format won't let me write it
+    // in a way that shows the actual structure.
+    seg->setGroupedRows(std::vector<int>{3, 3, 3, 6, 6, 6, 6, 6, 6, 9, 0, 0, 10, 10, 10, 15, 15, 25});
+  }
+
+  K4_GAUDI_CHECK(m_barrelTool.retrieve());
+  K4_GAUDI_CHECK(m_endcapTool.retrieve());
+
+  K4_GAUDI_CHECK(m_barrelTool->readoutName() == m_expectedBarrelReadout);
+  K4_GAUDI_CHECK(m_barrelTool->id() == 8);
+  K4_GAUDI_CHECK(m_endcapTool->readoutName() == m_expectedEndcapReadout);
+  K4_GAUDI_CHECK(m_endcapTool->id() == 9);
+
+  K4_GAUDI_CHECK(testTool(*m_barrelTool, m_expectedBarrelCells));
+  K4_GAUDI_CHECK(testTool(*m_endcapTool, m_expectedEndcapCells));
+
+  return StatusCode::SUCCESS;
+}
+
+StatusCode HCalPhiCaloToolTestAlg::testTool(const k4::recCalo::ICalorimeterTool& tool, size_t exp_ncells) const {
+  std::span<const uint64_t> ids = tool.cellIDs();
+  size_t ncells = ids.size();
+  K4_GAUDI_CHECK(ncells == exp_ncells);
+
+  std::unique_ptr<ICaloIndexer> indexer = tool.indexer();
+  K4_GAUDI_CHECK(indexer != nullptr);
+  K4_GAUDI_CHECK(indexer->detIDBits() == 4);
+
+  K4_GAUDI_CHECK(indexer->cellIDs().size() == ncells);
+  for (size_t i = 0; i < ncells; i++) {
+    K4_GAUDI_CHECK(ids[i] == indexer->cellIDs()[i]);
+    K4_GAUDI_CHECK(indexer->index(ids[i]) == i);
+  }
+
+  if (m_dumpCells) {
+    std::string fname = tool.readoutName() + ".cells";
+    std::ofstream os(fname);
+    for (uint64_t id : ids) {
+      os << id << "\n";
+    }
+    os.close();
+  }
+
+  return StatusCode::SUCCESS;
+}
+
+StatusCode HCalPhiCaloToolTestAlg::execute() { return StatusCode::SUCCESS; }
+
+} // namespace k4::recCalo


### PR DESCRIPTION
Add HCalPhiThetaCaloTool and HCalPhiRowCaloTool, implementing ICalorimeterTool for the two segmentation varieties for the Allegro HCal.

Will be needed to use indexing for HCal cells.

BEGINRELEASENOTES
- Add implementations of ICalorimeterTool for the Allegro HCal.
ENDRELEASENOTES
