### PR TITLE
Add CaloCellIndexerSvc.

### DIFF
--- a/RecCaloCommon/include/RecCaloCommon/ICaloCellIndexerSvc.h
+++ b/RecCaloCommon/include/RecCaloCommon/ICaloCellIndexerSvc.h
@@ -1,0 +1,54 @@
+// This file's extension implies that it's C, but it's really -*- C++ -*-.
+/**
+ * @file RecCaloCommon/ICaloCellIndexerSvc.h
+ * @author scott snyder <snyder@bnl.gov>
+ * @date Jan, 2026
+ * @brief Holder for calorimeter cell indexers.
+ */
+
+#ifndef RECCALOCOMMON_ICALOCELLINDEXERSVC_H
+#define RECCALOCOMMON_ICALOCELLINDEXERSVC_H
+
+// clang-format off: headers best listed in reverse-dependency order.
+#include "RecCaloCommon/ICaloIndexer.h"
+#include "GaudiKernel/IInterface.h"
+#include <span>
+// clang-format on
+
+namespace k4::recCalo {
+
+/**
+ * @brief Holder for calorimeter cell indexers.
+ *
+ * This holds the indexer objects for different subdetectors.
+ * We put it in a service to avoid duplicating them across different tools.
+ *
+ * One might think of having this be part of ICaloCellConstantsSvc,
+ * but we run into initialization loops in that case.
+ */
+class ICaloCellIndexerSvc : virtual public IInterface {
+public:
+  DeclareInterfaceID(ICaloCellIndexerSvc, 1, 0);
+
+  /**
+   * @brief Return indexer for a given subdetector.
+   * @param detID Subdetector ID for the desired indexer.
+   * @param quiet If true, don't print an error if we don't find an indexer.
+   *
+   * Returns a pointer to the indexer or nullptr if there isn't one defined.
+   */
+  virtual const ICaloIndexer* indexer(int detID, bool quiet = false) const = 0;
+
+  /**
+   * @brief Return indexer for a given set of subdetectors.
+   * @param detIDs Subdetector IDs to index.
+   * @param quiet If true, don't print an error if we don't find an indexer.
+   *
+   * Returns a pointer to the indexer or nullptr if there isn't one defined.
+   */
+  virtual const ICaloIndexer* indexer(std::span<const int> detIDs, bool quiet = false) = 0;
+};
+
+} // namespace k4::recCalo
+
+#endif // not RECCALOCOMMON_ICALOCELLINDEXERSVC_H

--- a/RecCalorimeter/CMakeLists.txt
+++ b/RecCalorimeter/CMakeLists.txt
@@ -55,7 +55,9 @@ set_test_env(simulateSiPM)
 
 
 gaudi_add_module(k4RecCalorimeterTests
-                 SOURCES tests/src/CaloCellConstantsSvcTestAlg.cpp
+                 SOURCES
+                   tests/src/CaloCellConstantsSvcTestAlg.cpp
+                   tests/src/CaloCellIndexerSvcTestAlg.cpp
                  LINK k4FWCore::k4FWCore
                       k4FWCore::k4Interface
                       Gaudi::GaudiKernel
@@ -66,6 +68,12 @@ add_test(NAME CaloCellConstantsSvc_test
          WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/Testing/Temporary
 )
 set_test_env(CaloCellConstantsSvc_test)
+
+add_test(NAME CaloCellIndexerSvc_test
+         COMMAND k4run ${PROJECT_SOURCE_DIR}/RecCalorimeter/tests/options/CaloCellIndexerSvc_test.py
+         WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/Testing/Temporary
+)
+set_test_env(CaloCellIndexerSvc_test)
 
 
 #install(DIRECTORY ${CMAKE_CURRENT_LIST_DIR}/tests/options DESTINATION ${CMAKE_INSTALL_DATADIR}/${CMAKE_PROJECT_NAME}/Reconstruction/RecCalorimeter)

--- a/RecCalorimeter/src/components/CaloCellIndexerSvc.cpp
+++ b/RecCalorimeter/src/components/CaloCellIndexerSvc.cpp
@@ -1,0 +1,127 @@
+/**
+ * @file CaloCellIndexerSvc.cpp
+ * @author scott snyder <snyder@bnl.gov>
+ * @date Jan, 2026
+ * @brief Holder for calorimeter cell indexers.
+ */
+
+// clang-format off: headers best listed in reverse-dependency order.
+#include "CaloCellIndexerSvc.h"
+#include "RecCaloCommon/MultiIndexer.h"
+#include "k4FWCore/GaudiChecks.h"
+// clang-format on
+
+DECLARE_COMPONENT(k4::recCalo::CaloCellIndexerSvc);
+
+namespace k4::recCalo {
+
+/**
+ * @brief Gaudi initialize method.
+ */
+StatusCode CaloCellIndexerSvc::initialize() {
+  K4_GAUDI_CHECK(Service::initialize());
+  K4_GAUDI_CHECK(m_constantsSvc.retrieve());
+  K4_GAUDI_CHECK(m_geoTools.retrieve());
+
+  std::lock_guard lock(m_mutex);
+
+  // Make indexers for all tools that support it.
+  for (ToolHandle<ICalorimeterTool>& tool : m_geoTools) {
+    std::unique_ptr<ICaloIndexer> indexer = tool->indexer();
+    if (indexer) {
+      int detid = tool->id();
+      if (detid > MAX_DETID) {
+        error() << "Out-of-range detector ID " << detid << endmsg;
+        return StatusCode::FAILURE;
+      }
+      mask_t mask;
+      mask.set(detid);
+      std::unique_ptr<ICaloIndexer>& uptr = m_indexers[mask];
+      if (uptr) {
+        error() << "Duplicate detector ID " << detid << endmsg;
+        return StatusCode::FAILURE;
+      }
+      uptr = std::move(indexer);
+    }
+  }
+
+  return StatusCode::SUCCESS;
+}
+
+/**
+ * @brief Return indexer for a given subdetector.
+ * @param detID Subdetector ID for the desired indexer.
+ * @param quiet If true, don't print an error if we don't find an indexer.
+ *
+ * Returns a pointer to the indexer or nullptr if there isn't one defined.
+ */
+const ICaloIndexer* CaloCellIndexerSvc::indexer(int detID, bool quiet /*= false*/) const {
+  std::lock_guard lock(m_mutex);
+
+  if (detID > MAX_DETID) {
+    error() << "Out-of-range detector ID " << detID << endmsg;
+    return nullptr;
+  }
+  mask_t mask;
+  mask.set(detID);
+  auto it = m_indexers.find(mask);
+  if (it != m_indexers.end()) {
+    return it->second.get();
+  }
+  if (!quiet) {
+    error() << "Cannot find indexer for detID " << detID << endmsg;
+  }
+  return nullptr;
+}
+
+/**
+ * @brief Return indexer for a given set of subdetectors.
+ */
+const ICaloIndexer* CaloCellIndexerSvc::indexer(std::span<const int> detIDs, bool quiet /*= false*/) {
+  // Degenerate cases
+  if (detIDs.empty())
+    return nullptr;
+  if (detIDs.size() == 1) {
+    return indexer(detIDs[0], quiet);
+  }
+
+  std::lock_guard lock(m_mutex);
+
+  // Build detID mask.
+  mask_t mask;
+  for (int id : detIDs) {
+    if (id > MAX_DETID) {
+      error() << "Out-of-range detector ID " << id << endmsg;
+      return nullptr;
+    }
+    mask.set(id);
+  }
+
+  // Do we already have this combination?
+  std::unique_ptr<ICaloIndexer>& uptr = m_indexers[mask];
+  if (uptr) {
+    return uptr.get();
+  }
+
+  // Make a new MultiIndexer.
+  std::vector<const ICaloIndexer*> indexers;
+  size_t detIDBits = 0;
+  for (int id : detIDs) {
+    const ICaloIndexer* indexer = this->indexer(id, quiet);
+    if (!indexer)
+      return nullptr;
+    indexers.push_back(indexer);
+    if (detIDBits == 0)
+      detIDBits = indexer->detIDBits();
+    else if (detIDBits != indexer->detIDBits()) {
+      error() << "Inconsistent detIDBits" << endmsg;
+      return nullptr;
+    }
+  }
+
+  uptr = std::make_unique<MultiIndexer>(detIDBits, indexers, *m_constantsSvc);
+
+  return uptr.get();
+}
+
+} // namespace k4::recCalo

--- a/RecCalorimeter/src/components/CaloCellIndexerSvc.h
+++ b/RecCalorimeter/src/components/CaloCellIndexerSvc.h
@@ -1,0 +1,84 @@
+// This file's extension implies that it's C, but it's really -*- C++ -*-.
+/**
+ * @file RecCalorimeter/src/components/CaloCellIndexerSvc.h
+ * @author scott snyder <snyder@bnl.gov>
+ * @date Jan, 2026
+ * @brief Holder for calorimeter cell indexers.
+ */
+
+#ifndef RECCALORIMETER_CALOCELLINDEXERSVC_H
+#define RECCALORIMETER_CALOCELLINDEXERSVC_H
+
+// clang-format off: headers best listed in reverse-dependency order.
+#include "RecCaloCommon/ICaloCellIndexerSvc.h"
+#include "RecCaloCommon/ICaloCellConstantsSvc.h"
+#include "RecCaloCommon/ICalorimeterTool.h"
+#include "GaudiKernel/Service.h"
+#include "GaudiKernel/ServiceHandle.h"
+#include "GaudiKernel/ToolHandle.h"
+#include <bitset>
+#include <climits>
+#include <mutex>
+#include <unordered_map>
+// clang-format on
+
+namespace k4::recCalo {
+
+/**
+ * @brief Holder for calorimeter cell indexers.
+ *
+ * This holds the indexer objects for different subdetectors.
+ * We put it in a service to avoid duplicating them across different tools.
+ *
+ * One might think of having this be part of ICaloCellConstantsSvc,
+ * but we run into initialization loops in that case.
+ */
+class CaloCellIndexerSvc : public extends<Service, ICaloCellIndexerSvc> {
+public:
+  using base_class::base_class;
+
+  /**
+   * @brief Gaudi initialize method.
+   */
+  virtual StatusCode initialize() override;
+
+  /**
+   * @brief Return indexer for a given subdetector.
+   * @param detID Subdetector ID for the desired indexer.
+   * @param quiet If true, don't print an error if we don't find an indexer.
+   *
+   * Returns a pointer to the indexer or nullptr if there isn't one defined.
+   */
+  const ICaloIndexer* indexer(int detID, bool quiet = false) const override;
+
+  /**
+   * @brief Return indexer for a given set of subdetectors.
+   * @param detIDs Subdetector IDs to index.
+   * @param quiet If true, don't print an error if we don't find an indexer.
+   *
+   * Returns a pointer to the indexer or nullptr if there isn't one defined.
+   */
+  virtual const ICaloIndexer* indexer(std::span<const int> detIDs, bool quiet = false) override;
+
+private:
+  /// List of calorimeter tools that can provide indexers.
+  ToolHandleArray<ICalorimeterTool> m_geoTools{this, "GeoTools", {}};
+
+  /// The cell constants service.
+  // clang-format off: this gets broken illogically.
+  ServiceHandle<k4::recCalo::ICaloCellConstantsSvc> m_constantsSvc
+    { this, "CaloCellConstantsSvc", "k4::recCalo::CaloCellConstantsSvc" };
+  // clang-format on
+
+  /// Map from bit mask of detector IDs to indexer objects.
+  constexpr static int MAX_DETID = 255;
+  using mask_t = std::bitset<MAX_DETID + 1>;
+  std::unordered_map<mask_t, std::unique_ptr<ICaloIndexer>> m_indexers;
+
+  /// Guard access to the map.
+  mutable std::recursive_mutex m_mutex;
+};
+
+} // namespace k4::recCalo
+
+#endif // not RECCALORIMETER_CALOCELLINDEXERSVC_H

--- a/RecCalorimeter/tests/options/CaloCellIndexerSvc_test.py
+++ b/RecCalorimeter/tests/options/CaloCellIndexerSvc_test.py
@@ -1,0 +1,46 @@
+#
+# File: RecCalorimeter/tests/options/CaloCellIndexerSvc_test.py
+# Author: scott snyder <snyder@bnl.gov>
+# Date: Jan, 2026
+# Purpose: Test for CaloCellIndexerSvc
+#
+
+import os
+import Configurables as C
+
+ECAL_Barrel = 4
+HCAL_Barrel = 8
+
+compactFile = "ALLEGRO_o1_v03.xml"
+pathToDetector = (
+    os.environ.get("K4GEO", "")
+    + "/FCCee/ALLEGRO/compact/"
+    + os.path.splitext(compactFile)[0]
+)
+
+geoSvc = C.GeoSvc("GeoSvc", detectors=[os.path.join(pathToDetector, compactFile)])
+
+ecalBarrelTool = C.TubeLayerModuleThetaCaloTool(
+    "ecalBarrelGeometryTool",
+    readoutName="ECalBarrelModuleThetaMerged",
+    activeVolumeName="LAr_sensitive",
+    activeFieldName="layer",
+    activeVolumesNumber=11,
+    fieldNames=["system"],
+    fieldValues=[ECAL_Barrel],
+)
+
+hcalBarrelTool = C.HCalPhiThetaCaloTool(
+    "hcalBarrelGeometryTool", readoutName="HCalBarrelReadout"
+)
+
+indexerSvc = C.k4__recCalo__CaloCellIndexerSvc(
+    GeoTools=[ecalBarrelTool, hcalBarrelTool]
+)
+
+appmgr = C.ApplicationMgr(
+    TopAlg=[
+        C.k4__recCalo__CaloCellIndexerSvcTestAlg(DetIDs=[ECAL_Barrel, HCAL_Barrel])
+    ],
+    ExtSvc=[geoSvc, indexerSvc],
+)

--- a/RecCalorimeter/tests/src/CaloCellIndexerSvcTestAlg.cpp
+++ b/RecCalorimeter/tests/src/CaloCellIndexerSvcTestAlg.cpp
@@ -1,0 +1,81 @@
+/**
+ * @file RecCalorimeter/tests/src/CaloCellIndexerSvcTestAlg.cpp
+ * @author scott snyder <snyder@bnl.gov>
+ * @date Jan, 2026
+ * @brief Test for CaloCellIndexerSvc
+ */
+
+// clang-format off: headers best listed in reverse-dependency order.
+#include "RecCaloCommon/ICaloCellIndexerSvc.h"
+#include "k4FWCore/GaudiChecks.h"
+#include "GaudiKernel/Algorithm.h"
+#include "GaudiKernel/ServiceHandle.h"
+#include <span>
+// clang-format on
+
+namespace k4::recCalo {
+
+class CaloCellIndexerSvcTestAlg : public Algorithm {
+public:
+  using Algorithm::Algorithm;
+
+  virtual StatusCode initialize() override;
+  virtual StatusCode execute() override;
+
+private:
+  // clang-format off
+  ServiceHandle<ICaloCellIndexerSvc> m_svc
+  { this, "CaloCellIndexerSvc", "k4::recCalo::CaloCellIndexerSvc", "" };
+  // clang-format on
+
+  Gaudi::Property<std::vector<int>> m_detIDs{this, "DetIDs", {4}, ""};
+};
+
+DECLARE_COMPONENT(k4::recCalo::CaloCellIndexerSvcTestAlg);
+
+StatusCode CaloCellIndexerSvcTestAlg::initialize() {
+  K4_GAUDI_CHECK(m_svc.retrieve());
+
+  K4_GAUDI_CHECK(m_svc->indexer(999) == nullptr);
+  K4_GAUDI_CHECK(m_detIDs.size() == 2);
+
+  const ICaloIndexer* indexer0 = m_svc->indexer(m_detIDs[0]);
+  K4_GAUDI_CHECK(indexer0 != nullptr);
+  K4_GAUDI_CHECK(indexer0->detIDs().size() == 1);
+  K4_GAUDI_CHECK(indexer0->detIDs()[0] == m_detIDs[0]);
+
+  std::span<const uint64_t> ids0 = indexer0->cellIDs();
+  for (size_t i = 0; i < ids0.size(); ++i) {
+    K4_GAUDI_CHECK(indexer0->index(ids0[i]) == i);
+  }
+
+  const ICaloIndexer* indexer1 = m_svc->indexer(m_detIDs[1]);
+  K4_GAUDI_CHECK(indexer1 != nullptr);
+  K4_GAUDI_CHECK(indexer1->detIDs().size() == 1);
+  K4_GAUDI_CHECK(indexer1->detIDs()[0] == m_detIDs[1]);
+
+  std::span<const uint64_t> ids1 = indexer1->cellIDs();
+  for (size_t i = 0; i < ids1.size(); ++i) {
+    K4_GAUDI_CHECK(indexer1->index(ids1[i]) == i);
+  }
+
+  const ICaloIndexer* indexer01 = m_svc->indexer(m_detIDs);
+  K4_GAUDI_CHECK(indexer01 != nullptr);
+  K4_GAUDI_CHECK(indexer01->detIDs().size() == 2);
+  K4_GAUDI_CHECK(indexer01->detIDs()[0] == m_detIDs[0]);
+  K4_GAUDI_CHECK(indexer01->detIDs()[1] == m_detIDs[1]);
+
+  std::span<const uint64_t> ids01 = indexer01->cellIDs();
+  K4_GAUDI_CHECK(ids01.size() == ids0.size() + ids1.size());
+  K4_GAUDI_CHECK(std::equal(ids0.begin(), ids0.end(), ids01.begin()));
+  K4_GAUDI_CHECK(std::equal(ids1.begin(), ids1.end(), ids01.begin() + ids0.size()));
+  for (size_t i = 0; i < ids01.size(); ++i) {
+    K4_GAUDI_CHECK(indexer01->index(ids01[i]) == i);
+  }
+
+  return StatusCode::SUCCESS;
+}
+
+StatusCode CaloCellIndexerSvcTestAlg::execute() { return StatusCode::SUCCESS; }
+
+} // namespace k4::recCalo


### PR DESCRIPTION
For efficiency, we want to be able to identify cells via a dense index; this is done by ICaloIndexer objects.  Add a service to manage these objects: given a detector ID, or set of detector IDs, it returns an ICaloIndexer object appropriate for that combination.

BEGINRELEASENOTES
- Add CaloCellIndexerSvc
ENDRELEASENOTES
