### PR TITLE
Support additional cluster calibration features

### DIFF
--- a/RecFCCeeCalorimeter/src/components/CalibrateCaloClusters.cpp
+++ b/RecFCCeeCalorimeter/src/components/CalibrateCaloClusters.cpp
@@ -18,7 +18,19 @@
 
 #include <onnxruntime_cxx_api.h>
 
+#include <algorithm>
+#include <cmath>
+
 #include "OnnxruntimeUtilities.h"
+
+namespace {
+constexpr double kDeltaThetaCalo = 0.009817477 / 4.0;
+constexpr double kDeltaPhiCalo = 2.0 * 3.14159265358979323846 / 1536.0;
+
+float pythonModuloOne(double value) {
+  return static_cast<float>(value - std::floor(value));
+}
+} // namespace
 
 DECLARE_COMPONENT(CalibrateCaloClusters)
 
@@ -261,12 +273,18 @@ StatusCode CalibrateCaloClusters::readCalibrationFile(const std::string& calibra
 
   // the output should be a single value (the correction)
   // and the inputs should be n(layers)+1 (fractions + total E)
+  // or n(layers)+4 (fractions + theta + theta mod cell + phi mod cell + total E)
   // the first dimension of the tensors are the number of clusters
   // to be calibrated simultaneously (-1 = dynamic)
   // we will calibrate once at a time
-  if (m_input_shapes.size() != 2 || m_output_shapes.size() != 2 || m_input_shapes[1] != (m_numLayersTotal + 1) ||
+  const std::int64_t expectedInputs = m_numLayersTotal + 1;
+  const std::int64_t expectedInputsWithExtraFeatures = m_numLayersTotal + 4;
+  if (m_input_shapes.size() != 2 || m_output_shapes.size() != 2 ||
+      (m_input_shapes[1] != expectedInputs && m_input_shapes[1] != expectedInputsWithExtraFeatures) ||
       m_output_shapes[1] != 1) {
-    error() << "The input or output shapes in the calibration files do not match the expected architecture" << endmsg;
+    error() << "The input or output shapes in the calibration files do not match the expected architecture. "
+            << "Expected input width " << expectedInputs << " or " << expectedInputsWithExtraFeatures
+            << ", got " << (m_input_shapes.size() == 2 ? m_input_shapes[1] : -1) << endmsg;
     return StatusCode::FAILURE;
   }
 
@@ -277,8 +295,8 @@ StatusCode CalibrateCaloClusters::calibrateClusters(const edm4hep::ClusterCollec
                                                     edm4hep::ClusterCollection* outClusters) const {
 
   // this vector will contain the input features for the calibration
-  // i.e. the fraction of energy in each layer and the total energy
-  std::vector<float> energiesInLayers(m_numLayersTotal + 1);
+  // i.e. the fraction of energy in each layer, optional position features, and the total energy
+  std::vector<float> energiesInLayers(static_cast<std::size_t>(m_input_shapes[1]));
 
   // loop over the input clusters and perform the calibration
   for (unsigned int j = 0; j < inClusters->size(); ++j) {
@@ -294,7 +312,7 @@ StatusCode CalibrateCaloClusters::calibrateClusters(const edm4hep::ClusterCollec
     // calculate cluster energy in each layer and normalize by total cluster energy
     calcEnergiesInLayers(inClusters->at(j), energiesInLayers);
     verbose() << "Calibration inputs:" << endmsg;
-    for (unsigned short int k = 0; k < energiesInLayers.size(); ++k) {
+    for (std::size_t k = 0; k < energiesInLayers.size(); ++k) {
       verbose() << "    f" << k << " : " << energiesInLayers[k] << endmsg;
     }
 
@@ -338,6 +356,8 @@ void CalibrateCaloClusters::calcEnergiesInLayers(edm4hep::Cluster cluster, std::
 
   // get total cluster energy
   double ecl = cluster.getEnergy();
+  const bool useExtraFeatures = energiesInLayers.size() == static_cast<std::size_t>(m_numLayersTotal + 4);
+  const std::size_t rawEnergyPosition = energiesInLayers.size() - 1;
 
   // if all inputs are available as shapeParameters, use them
   if (m_inputPositionsInShapeParameters.size() == m_numLayersTotal) {
@@ -346,8 +366,6 @@ void CalibrateCaloClusters::calcEnergiesInLayers(edm4hep::Cluster cluster, std::
     for (unsigned short int i = 0; i < m_numLayersTotal; i++) {
       energiesInLayers[i] = cluster.getShapeParameters(m_inputPositionsInShapeParameters[i]);
     }
-    // add as last input the total raw cluster energy
-    energiesInLayers[m_numLayersTotal] = ecl;
   } else {
     // calculate the energy fractions from the cells
     // loop over the various readouts/subsystems/...
@@ -377,7 +395,25 @@ void CalibrateCaloClusters::calcEnergiesInLayers(edm4hep::Cluster cluster, std::
     for (unsigned short int k = 0; k < m_numLayersTotal; ++k) {
       energiesInLayers[k] /= ecl;
     }
-    // add as last input the total cluster energy
-    energiesInLayers[m_numLayersTotal] = ecl;
   }
+
+  if (useExtraFeatures) {
+    const auto position = cluster.getPosition();
+    const double radius =
+        std::sqrt(position.x * position.x + position.y * position.y + position.z * position.z);
+    double theta = 0.0;
+    double phi = 0.0;
+    if (radius > 0.0) {
+      double cosTheta = position.z / radius;
+      cosTheta = std::min(1.0, std::max(-1.0, cosTheta));
+      theta = std::acos(cosTheta);
+      phi = std::atan2(position.y, position.x);
+    }
+    energiesInLayers[m_numLayersTotal] = static_cast<float>(theta);
+    energiesInLayers[m_numLayersTotal + 1] = pythonModuloOne(theta / kDeltaThetaCalo);
+    energiesInLayers[m_numLayersTotal + 2] = pythonModuloOne(phi / kDeltaPhiCalo);
+  }
+
+  // add as last input the total raw cluster energy
+  energiesInLayers[rawEnergyPosition] = ecl;
 }

--- a/RecFCCeeCalorimeter/src/components/CalibrateCaloClusters.cpp
+++ b/RecFCCeeCalorimeter/src/components/CalibrateCaloClusters.cpp
@@ -24,9 +24,6 @@
 #include "OnnxruntimeUtilities.h"
 
 namespace {
-constexpr double kDeltaThetaCalo = 0.009817477 / 4.0;
-constexpr double kDeltaPhiCalo = 2.0 * 3.14159265358979323846 / 1536.0;
-
 float pythonModuloOne(double value) {
   return static_cast<float>(value - std::floor(value));
 }
@@ -410,8 +407,8 @@ void CalibrateCaloClusters::calcEnergiesInLayers(edm4hep::Cluster cluster, std::
       phi = std::atan2(position.y, position.x);
     }
     energiesInLayers[m_numLayersTotal] = static_cast<float>(theta);
-    energiesInLayers[m_numLayersTotal + 1] = pythonModuloOne(theta / kDeltaThetaCalo);
-    energiesInLayers[m_numLayersTotal + 2] = pythonModuloOne(phi / kDeltaPhiCalo);
+    energiesInLayers[m_numLayersTotal + 1] = pythonModuloOne(theta / m_deltaThetaCalo.value());
+    energiesInLayers[m_numLayersTotal + 2] = pythonModuloOne(phi / m_deltaPhiCalo.value());
   }
 
   // add as last input the total raw cluster energy

--- a/RecFCCeeCalorimeter/src/components/CalibrateCaloClusters.cpp
+++ b/RecFCCeeCalorimeter/src/components/CalibrateCaloClusters.cpp
@@ -24,9 +24,7 @@
 #include "OnnxruntimeUtilities.h"
 
 namespace {
-float pythonModuloOne(double value) {
-  return static_cast<float>(value - std::floor(value));
-}
+float pythonModuloOne(double value) { return static_cast<float>(value - std::floor(value)); }
 } // namespace
 
 DECLARE_COMPONENT(CalibrateCaloClusters)
@@ -280,8 +278,8 @@ StatusCode CalibrateCaloClusters::readCalibrationFile(const std::string& calibra
       (m_input_shapes[1] != expectedInputs && m_input_shapes[1] != expectedInputsWithExtraFeatures) ||
       m_output_shapes[1] != 1) {
     error() << "The input or output shapes in the calibration files do not match the expected architecture. "
-            << "Expected input width " << expectedInputs << " or " << expectedInputsWithExtraFeatures
-            << ", got " << (m_input_shapes.size() == 2 ? m_input_shapes[1] : -1) << endmsg;
+            << "Expected input width " << expectedInputs << " or " << expectedInputsWithExtraFeatures << ", got "
+            << (m_input_shapes.size() == 2 ? m_input_shapes[1] : -1) << endmsg;
     return StatusCode::FAILURE;
   }
 
@@ -293,7 +291,7 @@ StatusCode CalibrateCaloClusters::calibrateClusters(const edm4hep::ClusterCollec
 
   // this vector will contain the input features for the calibration
   // i.e. the fraction of energy in each layer, optional position features, and the total energy
-  std::vector<float> energiesInLayers(static_cast<std::size_t>(m_input_shapes[1]));
+  std::vector<float> calibrationInputFeatures(static_cast<std::size_t>(m_input_shapes[1]));
 
   // loop over the input clusters and perform the calibration
   for (unsigned int j = 0; j < inClusters->size(); ++j) {
@@ -306,18 +304,18 @@ StatusCode CalibrateCaloClusters::calibrateClusters(const edm4hep::ClusterCollec
     }
     verbose() << "Cluster energy before calibration: " << ecl << endmsg;
 
-    // calculate cluster energy in each layer and normalize by total cluster energy
-    calcEnergiesInLayers(inClusters->at(j), energiesInLayers);
+    // calculate the calibration input features for the current cluster
+    fillCalibrationInputFeatures(inClusters->at(j), calibrationInputFeatures);
     verbose() << "Calibration inputs:" << endmsg;
-    for (std::size_t k = 0; k < energiesInLayers.size(); ++k) {
-      verbose() << "    f" << k << " : " << energiesInLayers[k] << endmsg;
+    for (std::size_t k = 0; k < calibrationInputFeatures.size(); ++k) {
+      verbose() << "    f" << k << " : " << calibrationInputFeatures[k] << endmsg;
     }
 
     // run the MVA calibration and correct the cluster energy
     float corr = 1.0;
     // Create a single Ort tensor
     std::vector<Ort::Value> input_tensors;
-    input_tensors.emplace_back(vec_to_tensor<float>(energiesInLayers, m_input_shapes, m_ortMemInfo));
+    input_tensors.emplace_back(vec_to_tensor<float>(calibrationInputFeatures, m_input_shapes, m_ortMemInfo));
 
     // double-check the dimensions of the input tensor
     // assert(input_tensors[0].IsTensor() && input_tensors[0].GetTensorTypeAndShapeInfo().GetShape() == m_input_shapes);
@@ -347,21 +345,22 @@ StatusCode CalibrateCaloClusters::calibrateClusters(const edm4hep::ClusterCollec
   return StatusCode::SUCCESS;
 }
 
-void CalibrateCaloClusters::calcEnergiesInLayers(edm4hep::Cluster cluster, std::vector<float>& energiesInLayers) const {
-  // reset vector with energies per layer
-  std::fill(energiesInLayers.begin(), energiesInLayers.end(), 0.0);
+void CalibrateCaloClusters::fillCalibrationInputFeatures(edm4hep::Cluster cluster,
+                                                         std::vector<float>& calibrationInputFeatures) const {
+  // reset vector with calibration input features
+  std::fill(calibrationInputFeatures.begin(), calibrationInputFeatures.end(), 0.0);
 
   // get total cluster energy
   double ecl = cluster.getEnergy();
-  const bool useExtraFeatures = energiesInLayers.size() == static_cast<std::size_t>(m_numLayersTotal + 4);
-  const std::size_t rawEnergyPosition = energiesInLayers.size() - 1;
+  const bool useExtraFeatures = calibrationInputFeatures.size() == static_cast<std::size_t>(m_numLayersTotal + 4);
+  const std::size_t rawEnergyPosition = calibrationInputFeatures.size() - 1;
 
   // if all inputs are available as shapeParameters, use them
   if (m_inputPositionsInShapeParameters.size() == m_numLayersTotal) {
     // the shapeParameters already contain energy fractions so we
     // do not divide by cluster energy
     for (unsigned short int i = 0; i < m_numLayersTotal; i++) {
-      energiesInLayers[i] = cluster.getShapeParameters(m_inputPositionsInShapeParameters[i]);
+      calibrationInputFeatures[i] = cluster.getShapeParameters(m_inputPositionsInShapeParameters[i]);
     }
   } else {
     // calculate the energy fractions from the cells
@@ -385,19 +384,18 @@ void CalibrateCaloClusters::calcEnergiesInLayers(edm4hep::Cluster cluster, std::
           continue;
         }
         int layer = decoder->get(cellID, layerField);
-        energiesInLayers[startPositionToFill + layer - firstLayer] += cell->getEnergy();
+        calibrationInputFeatures[startPositionToFill + layer - firstLayer] += cell->getEnergy();
       }
     }
     // divide by the cluster energy to prepare the inputs for the MVA
     for (unsigned short int k = 0; k < m_numLayersTotal; ++k) {
-      energiesInLayers[k] /= ecl;
+      calibrationInputFeatures[k] /= ecl;
     }
   }
 
   if (useExtraFeatures) {
     const auto position = cluster.getPosition();
-    const double radius =
-        std::sqrt(position.x * position.x + position.y * position.y + position.z * position.z);
+    const double radius = std::sqrt(position.x * position.x + position.y * position.y + position.z * position.z);
     double theta = 0.0;
     double phi = 0.0;
     if (radius > 0.0) {
@@ -406,11 +404,11 @@ void CalibrateCaloClusters::calcEnergiesInLayers(edm4hep::Cluster cluster, std::
       theta = std::acos(cosTheta);
       phi = std::atan2(position.y, position.x);
     }
-    energiesInLayers[m_numLayersTotal] = static_cast<float>(theta);
-    energiesInLayers[m_numLayersTotal + 1] = pythonModuloOne(theta / m_deltaThetaCalo.value());
-    energiesInLayers[m_numLayersTotal + 2] = pythonModuloOne(phi / m_deltaPhiCalo.value());
+    calibrationInputFeatures[m_numLayersTotal] = static_cast<float>(theta);
+    calibrationInputFeatures[m_numLayersTotal + 1] = pythonModuloOne(theta / m_deltaThetaCalo.value());
+    calibrationInputFeatures[m_numLayersTotal + 2] = pythonModuloOne(phi / m_deltaPhiCalo.value());
   }
 
   // add as last input the total raw cluster energy
-  energiesInLayers[rawEnergyPosition] = ecl;
+  calibrationInputFeatures[rawEnergyPosition] = ecl;
 }

--- a/RecFCCeeCalorimeter/src/components/CalibrateCaloClusters.h
+++ b/RecFCCeeCalorimeter/src/components/CalibrateCaloClusters.h
@@ -119,6 +119,13 @@ private:
   // Gaudi::Property<std::vector<std::string>> m_calibrationFiles {
   //    this, "calibrationFiles", {}, "Files with the calibration parameters"};
   Gaudi::Property<std::string> m_calibrationFile{this, "calibrationFile", {}, "File with the calibration parameters"};
+  /// Theta granularity used to calculate the fractional theta feature for extended calibration models
+  Gaudi::Property<double> m_deltaThetaCalo{
+      this, "deltaThetaCalo", 0.009817477 / 4.0, "Theta granularity used for the fractional theta input feature"};
+  /// Phi granularity used to calculate the fractional phi feature for extended calibration models
+  Gaudi::Property<double> m_deltaPhiCalo{
+      this, "deltaPhiCalo", 2.0 * 3.14159265358979323846 / 1536.0,
+      "Phi granularity used for the fractional phi input feature"};
 
   // total number of layers summed over the various subsystems
   // should be equal to the number of input features of the MVA

--- a/RecFCCeeCalorimeter/src/components/CalibrateCaloClusters.h
+++ b/RecFCCeeCalorimeter/src/components/CalibrateCaloClusters.h
@@ -74,13 +74,15 @@ private:
                                edm4hep::ClusterCollection* outClusters) const;
 
   /**
-   * Get sum of energy from cells in each layer.
-   * This energy is not calibrated.
+   * Fill the input features used by the MVA energy calibration.
+   *
+   * The features contain the energy fraction in each layer, optional position
+   * features, and the raw cluster energy.
    *
    * @param[in]  cluster          Pointer to cluster of interest.
-   * @param[out] energiesInLayer  Reference to vector that will contain the energies
+   * @param[out] calibrationInputFeatures  Reference to vector that will contain the calibration input features
    */
-  void calcEnergiesInLayers(edm4hep::Cluster cluster, std::vector<float>& energiesInLayer) const;
+  void fillCalibrationInputFeatures(edm4hep::Cluster cluster, std::vector<float>& calibrationInputFeatures) const;
 
   /// Handle for input calorimeter clusters collection
   mutable k4FWCore::DataHandle<edm4hep::ClusterCollection> m_inClusters{"inClusters", Gaudi::DataHandle::Reader, this};
@@ -120,12 +122,11 @@ private:
   //    this, "calibrationFiles", {}, "Files with the calibration parameters"};
   Gaudi::Property<std::string> m_calibrationFile{this, "calibrationFile", {}, "File with the calibration parameters"};
   /// Theta granularity used to calculate the fractional theta feature for extended calibration models
-  Gaudi::Property<double> m_deltaThetaCalo{
-      this, "deltaThetaCalo", 0.009817477 / 4.0, "Theta granularity used for the fractional theta input feature"};
+  Gaudi::Property<double> m_deltaThetaCalo{this, "deltaThetaCalo", 0.009817477 / 4.0,
+                                           "Theta granularity used for the fractional theta input feature"};
   /// Phi granularity used to calculate the fractional phi feature for extended calibration models
-  Gaudi::Property<double> m_deltaPhiCalo{
-      this, "deltaPhiCalo", 2.0 * 3.14159265358979323846 / 1536.0,
-      "Phi granularity used for the fractional phi input feature"};
+  Gaudi::Property<double> m_deltaPhiCalo{this, "deltaPhiCalo", 2.0 * 3.14159265358979323846 / 1536.0,
+                                         "Phi granularity used for the fractional phi input feature"};
 
   // total number of layers summed over the various subsystems
   // should be equal to the number of input features of the MVA


### PR DESCRIPTION
BEGINRELEASENOTES

- Updated `CalibrateCaloClusters` to support calibration ONNX models with either the legacy `nLayers + 1` inputs or the extended `nLayers + 4` inputs.
- Added support for extra cluster-position features used by the newer calibration models:
  - cluster `theta`
  - fractional `theta / deltaTheta`
  - fractional `phi / deltaPhi`
- Kept backward compatibility with existing 12-input models by deriving the expected feature layout from the ONNX input shape.
- Ensured the raw cluster energy is always placed as the final model input, matching both legacy and extended training feature orders.
- Improved calibration model shape validation messages to report both accepted input widths and the actual model input width.
- Verified the updated algorithm with the local layer-theta workflow, including `--doTopoClustering true --calibrateClusters true`.

ENDRELEASENOTES