### PR TITLE
Factorise common code into a base noise tool and add a test 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,7 +46,7 @@ set(GAUDI_GENCONF_DIR "genConfDir")
 
 function(set_test_env _testname)
   set_property(TEST ${_testname} APPEND PROPERTY ENVIRONMENT
-               LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}:$<TARGET_FILE_DIR:k4RecCalorimeterPlugins>:${CMAKE_BINARY_DIR}:$<TARGET_FILE_DIR:k4RecFCCeeCalorimeterPlugins>:${CMAKE_BINARY_DIR}:$<TARGET_FILE_DIR:k4RecFCChhCalorimeterPlugins>:$<TARGET_FILE_DIR:ROOT::Core>:$<TARGET_FILE_DIR:k4FWCore::k4FWCore>:$<TARGET_FILE_DIR:EDM4HEP::edm4hep>:$<TARGET_FILE_DIR:podio::podio>:$ENV{LD_LIBRARY_PATH})
+               LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}:${CMAKE_INSTALL_PREFIX}/lib64:$<TARGET_FILE_DIR:k4RecCalorimeterPlugins>:$<TARGET_FILE_DIR:k4RecFCCeeCalorimeterPlugins>:$<TARGET_FILE_DIR:k4RecFCChhCalorimeterPlugins>:$<TARGET_FILE_DIR:ROOT::Core>:$<TARGET_FILE_DIR:k4FWCore::k4FWCore>:$<TARGET_FILE_DIR:EDM4HEP::edm4hep>:$<TARGET_FILE_DIR:podio::podio>:$ENV{LD_LIBRARY_PATH})
 
   set_property(TEST ${_testname} APPEND PROPERTY ENVIRONMENT
                PYTHONPATH=${CMAKE_BINARY_DIR}/RecCalorimeter/${GAUDI_GENCONF_DIR}:${CMAKE_BINARY_DIR}/RecFCCeeCalorimeter/${GAUDI_GENCONF_DIR}:${CMAKE_BINARY_DIR}/RecFCChhCalorimeter/${GAUDI_GENCONF_DIR}:$ENV{PYTHONPATH}:$<TARGET_FILE_DIR:k4FWCore::k4FWCore>/../python:$ENV{PYTHONPATH})

--- a/RecFCCeeCalorimeter/CMakeLists.txt
+++ b/RecFCCeeCalorimeter/CMakeLists.txt
@@ -18,6 +18,7 @@ gaudi_add_module(k4RecFCCeeCalorimeterPlugins
                       ROOT::Hist
                       onnxruntime::onnxruntime
                       nlohmann_json::nlohmann_json
+                      RecCaloCommon
                       )
 install(TARGETS k4RecFCCeeCalorimeterPlugins
   EXPORT k4RecCalorimeterTargets

--- a/RecFCCeeCalorimeter/CMakeLists.txt
+++ b/RecFCCeeCalorimeter/CMakeLists.txt
@@ -18,7 +18,6 @@ gaudi_add_module(k4RecFCCeeCalorimeterPlugins
                       ROOT::Hist
                       onnxruntime::onnxruntime
                       nlohmann_json::nlohmann_json
-                      RecCaloCommon
                       )
 install(TARGETS k4RecFCCeeCalorimeterPlugins
   EXPORT k4RecCalorimeterTargets
@@ -28,6 +27,12 @@ install(TARGETS k4RecFCCeeCalorimeterPlugins
 
 
 install(DIRECTORY ${CMAKE_CURRENT_LIST_DIR}/tests DESTINATION ${CMAKE_INSTALL_DATADIR}/${CMAKE_PROJECT_NAME}/RecFCCeeCalorimeter)
+
+add_test(NAME test_noise
+         COMMAND ${PROJECT_SOURCE_DIR}/RecFCCeeCalorimeter/tests/options/test_noise.sh
+         WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/Testing/Temporary
+)
+set_test_env(test_noise)
 
 add_test(NAME ALLEGRO_o1_v03_sim_reco
          COMMAND ${PROJECT_SOURCE_DIR}/RecFCCeeCalorimeter/tests/options/ALLEGRO_o1_v03.sh

--- a/RecFCCeeCalorimeter/CMakeLists.txt
+++ b/RecFCCeeCalorimeter/CMakeLists.txt
@@ -18,7 +18,6 @@ gaudi_add_module(k4RecFCCeeCalorimeterPlugins
                       ROOT::Hist
                       onnxruntime::onnxruntime
                       nlohmann_json::nlohmann_json
-                      RecCaloCommon
                       )
 install(TARGETS k4RecFCCeeCalorimeterPlugins
   EXPORT k4RecCalorimeterTargets

--- a/RecFCCeeCalorimeter/src/components/NoiseCaloCellsFromFileBarrelTool.cpp
+++ b/RecFCCeeCalorimeter/src/components/NoiseCaloCellsFromFileBarrelTool.cpp
@@ -2,7 +2,7 @@
 
 DECLARE_COMPONENT(NoiseCaloCellsFromFileBarrelTool)
 
-unsigned NoiseCaloCellsFromFileBarrelTool::getBin(k4::recCalo::INoiseCaloCellsTool::CellID aCellId) const {
+unsigned NoiseCaloCellsFromFileBarrelTool::getBin(CellID aCellId) const {
   double cellTheta = m_cellPositionsTool->xyzPosition(aCellId).Theta();
 
   // All histograms have same binning, all bins with same size

--- a/RecFCCeeCalorimeter/src/components/NoiseCaloCellsFromFileBarrelTool.cpp
+++ b/RecFCCeeCalorimeter/src/components/NoiseCaloCellsFromFileBarrelTool.cpp
@@ -2,7 +2,7 @@
 
 DECLARE_COMPONENT(NoiseCaloCellsFromFileBarrelTool)
 
-unsigned NoiseCaloCellsFromFileBarrelTool::getBin(CellID aCellId) const {
+unsigned NoiseCaloCellsFromFileBarrelTool::getBin(k4::recCalo::INoiseCaloCellsTool::CellID aCellId) const {
   double cellTheta = m_cellPositionsTool->xyzPosition(aCellId).Theta();
 
   // All histograms have same binning, all bins with same size

--- a/RecFCCeeCalorimeter/src/components/NoiseCaloCellsFromFileBarrelTool.cpp
+++ b/RecFCCeeCalorimeter/src/components/NoiseCaloCellsFromFileBarrelTool.cpp
@@ -1,0 +1,20 @@
+#include "NoiseCaloCellsFromFileBarrelTool.h"
+
+DECLARE_COMPONENT(NoiseCaloCellsFromFileBarrelTool)
+
+unsigned NoiseCaloCellsFromFileBarrelTool::getBin(CellID aCellId) const {
+  double cellTheta = m_cellPositionsTool->xyzPosition(aCellId).Theta();
+
+  // All histograms have same binning, all bins with same size
+  // Using the histogram in the first layer to get the bin size
+  int Nbins = m_histoElecNoiseRMS.at(0)->GetNbinsX();
+  int ibin = m_histoElecNoiseRMS.at(0)->FindFixBin(cellTheta);
+
+  if (ibin > Nbins) {
+    error() << "theta outside range of the histograms! Cell theta: " << cellTheta << " Nbins in histogram: " << Nbins
+            << endmsg;
+    ibin = Nbins;
+  }
+
+  return ibin;
+}

--- a/RecFCCeeCalorimeter/src/components/NoiseCaloCellsFromFileBarrelTool.h
+++ b/RecFCCeeCalorimeter/src/components/NoiseCaloCellsFromFileBarrelTool.h
@@ -21,7 +21,7 @@ public:
 
 private:
   /// get bin in histogram for given cellID
-  unsigned getBin(CellID aCellId) const override final;
+  unsigned getBin(k4::recCalo::INoiseCaloCellsTool::CellID aCellId) const override final;
 };
 
 #endif /* RECFCCEECALORIMETER_NOISECALOCELLFROMFILEBARRELTOOL_H */

--- a/RecFCCeeCalorimeter/src/components/NoiseCaloCellsFromFileBarrelTool.h
+++ b/RecFCCeeCalorimeter/src/components/NoiseCaloCellsFromFileBarrelTool.h
@@ -21,7 +21,7 @@ public:
 
 private:
   /// get bin in histogram for given cellID
-  unsigned getBin(k4::recCalo::INoiseCaloCellsTool::CellID aCellId) const override final;
+  unsigned getBin(CellID aCellId) const override final;
 };
 
 #endif /* RECFCCEECALORIMETER_NOISECALOCELLFROMFILEBARRELTOOL_H */

--- a/RecFCCeeCalorimeter/src/components/NoiseCaloCellsFromFileBarrelTool.h
+++ b/RecFCCeeCalorimeter/src/components/NoiseCaloCellsFromFileBarrelTool.h
@@ -1,0 +1,27 @@
+#ifndef RECFCCEECALORIMETER_NOISECALOCELLSFROMFILEBARRELTOOL_H
+#define RECFCCEECALORIMETER_NOISECALOCELLSFROMFILEBARRELTOOL_H
+
+#include "NoiseCaloCellsFromFileBaseTool.h"
+
+/** @class NoiseCaloCellsFromFileBarrelTool
+ *
+ *  Tool for calorimeter noise - in barrel, with noise histograms per layer,
+ *  implemented as 1D hists vs theta.
+ *  Inherits from common base tool and defines how to retrieve proper bin in
+ *  noise histograms for cell with given cellID
+ *
+ *  @author Giovanni Marchiori
+ *  @date   2026-06
+ *
+ */
+
+class NoiseCaloCellsFromFileBarrelTool : public NoiseCaloCellsFromFileBaseTool {
+public:
+  using NoiseCaloCellsFromFileBaseTool::NoiseCaloCellsFromFileBaseTool;
+
+private:
+  /// get bin in histogram for given cellID
+  unsigned getBin(CellID aCellId) const override final;
+};
+
+#endif /* RECFCCEECALORIMETER_NOISECALOCELLFROMFILEBARRELTOOL_H */

--- a/RecFCCeeCalorimeter/src/components/NoiseCaloCellsFromFileBaseTool.cpp
+++ b/RecFCCeeCalorimeter/src/components/NoiseCaloCellsFromFileBaseTool.cpp
@@ -1,0 +1,268 @@
+#include "NoiseCaloCellsFromFileBaseTool.h"
+#include "RecCaloCommon/k4RecCalorimeter_check.h"
+
+// k4geo
+#include "detectorCommon/DetUtils_k4geo.h"
+
+// k4FWCore
+#include "k4Interface/IGeoSvc.h"
+
+// DD4hep
+#include "DD4hep/Detector.h"
+
+// ROOT
+#include "TFile.h"
+#include "TSystem.h"
+
+StatusCode NoiseCaloCellsFromFileBaseTool::initialize() {
+  K4RECCALORIMETER_CHECK( m_geoSvc.retrieve() );
+  K4RECCALORIMETER_CHECK( m_cellPositionsTool.retrieve() );
+  K4RECCALORIMETER_CHECK( m_randSvc = service<IRndmGenSvc> ("RndmGenSvc", false) );
+  K4RECCALORIMETER_CHECK( m_gauss.initialize(m_randSvc, Rndm::Gauss(0., 1.)) );
+
+  // open and check file, read the histograms with noise constants
+  K4RECCALORIMETER_CHECK( initNoiseFromFile() );
+
+  // Get decoder and get index of layer/wheel field .. should put in try catch block
+  m_decoder = m_geoSvc->getDetector()->readout(m_readoutName).idSpec().decoder();
+  m_index_activeField = m_decoder->index(m_activeFieldName);
+
+  debug() << "Filter noise threshold: " << m_filterThreshold << "*sigma" << endmsg;
+
+  K4RECCALORIMETER_CHECK( AlgTool::initialize() );
+
+  return StatusCode::SUCCESS;
+}
+
+template <class C>
+void NoiseCaloCellsFromFileBaseTool::addRandomCellNoiseT(C& aCells) const {
+  for (auto& p : aCells) {
+    p.second += getNoiseOffsetPerCell(p.first);
+    p.second += (getNoiseRMSPerCell(p.first) * m_gauss.shoot());
+  }
+}
+
+void NoiseCaloCellsFromFileBaseTool::addRandomCellNoise(std::unordered_map<CellID, double>& aCells) const {
+  addRandomCellNoiseT(aCells);
+}
+
+void NoiseCaloCellsFromFileBaseTool::addRandomCellNoise(std::vector<std::pair<CellID, double> >& aCells) const {
+  addRandomCellNoiseT(aCells);
+}
+
+template <typename C>
+void NoiseCaloCellsFromFileBaseTool::filterCellNoiseT(C& aCells) const {
+  // Erase a cell if it has energy below a threshold from the vector
+  if (m_useAbsInFilter) {
+    std::erase_if(aCells,
+                  [&](auto& p) { return std::abs(p.second-getNoiseOffsetPerCell(p.first)) < m_filterThreshold * getNoiseRMSPerCell(p.first); });
+  }
+  else {
+    std::erase_if(aCells,
+                  [&](auto& p) { return p.second < getNoiseOffsetPerCell(p.first) + m_filterThreshold * getNoiseRMSPerCell(p.first); });
+  }
+}
+
+void NoiseCaloCellsFromFileBaseTool::filterCellNoise(std::unordered_map<CellID, double>& aCells) const {
+  filterCellNoiseT (aCells);
+}
+
+void NoiseCaloCellsFromFileBaseTool::filterCellNoise(std::vector<std::pair<CellID, double> >& aCells) const {
+  filterCellNoiseT (aCells);
+}
+
+StatusCode NoiseCaloCellsFromFileBaseTool::readHistograms(TFile* noiseFile) {
+  std::string elecNoiseRMSLayerHistoName, pileupNoiseRMSLayerHistoName;
+  std::string elecNoiseOffsetLayerHistoName, pileupNoiseOffsetLayerHistoName;
+  debug() << "Retrieving histograms" << endmsg;
+  // Read the histograms with electronics noise and pileup from the file
+  for (unsigned i = 0; i < m_numHistograms; i++) {
+    elecNoiseRMSLayerHistoName = m_elecNoiseRMSHistoName + std::to_string(i + 1);
+    debug() << "Getting histogram with a name " << elecNoiseRMSLayerHistoName << endmsg;
+    m_histoElecNoiseRMS.push_back(dynamic_cast<TH1*>(noiseFile->Get(elecNoiseRMSLayerHistoName.c_str())));
+    if (m_histoElecNoiseRMS.at(i)->GetNbinsX() < 1) {
+      error() << "Histogram  " << elecNoiseRMSLayerHistoName
+              << " has 0 bins! check the file with noise and the name of the histogram!" << endmsg;
+      return StatusCode::FAILURE;
+    }
+    m_histoElecNoiseRMS.at(i)->SetDirectory(0); // prevent deletion when file is closed
+    if (m_setNoiseOffset) {
+      elecNoiseOffsetLayerHistoName = m_elecNoiseOffsetHistoName + std::to_string(i + 1);
+      debug() << "Getting histogram with a name " << elecNoiseOffsetLayerHistoName << endmsg;
+      m_histoElecNoiseOffset.push_back(dynamic_cast<TH1*>(noiseFile->Get(elecNoiseOffsetLayerHistoName.c_str())));
+      if (m_histoElecNoiseOffset.at(i)->GetNbinsX() < 1) {
+        error() << "Histogram  " << elecNoiseOffsetLayerHistoName
+                << " has 0 bins! check the file with noise and the name of the histogram!" << endmsg;
+        return StatusCode::FAILURE;
+      }
+      m_histoElecNoiseOffset.at(i)->SetDirectory(0); // prevent deletion when file is closed
+    }
+    if (m_addPileup) {
+      pileupNoiseRMSLayerHistoName = m_pileupNoiseRMSHistoName + std::to_string(i + 1);
+      debug() << "Getting histogram with a name " << pileupNoiseRMSLayerHistoName << endmsg;
+      m_histoPileupNoiseRMS.push_back(dynamic_cast<TH1*>(noiseFile->Get(pileupNoiseRMSLayerHistoName.c_str())));
+      if (m_histoPileupNoiseRMS.at(i)->GetNbinsX() < 1) {
+        error() << "Histogram  " << pileupNoiseRMSLayerHistoName
+                << " has 0 bins! check the file with noise and the name of the histogram!" << endmsg;
+        return StatusCode::FAILURE;
+      }
+      m_histoPileupNoiseRMS.at(i)->SetDirectory(0); // prevent deletion when file is closed
+      if (m_setNoiseOffset) {
+        pileupNoiseOffsetLayerHistoName = m_pileupNoiseOffsetHistoName + std::to_string(i + 1);
+        debug() << "Getting histogram with a name " << pileupNoiseOffsetLayerHistoName << endmsg;
+        m_histoPileupNoiseOffset.push_back(
+            dynamic_cast<TH1*>(noiseFile->Get(pileupNoiseOffsetLayerHistoName.c_str())));
+        if (m_histoPileupNoiseOffset.at(i)->GetNbinsX() < 1) {
+          error() << "Histogram  " << pileupNoiseOffsetLayerHistoName
+                  << " has 0 bins! check the file with noise and the name of the histogram!" << endmsg;
+          return StatusCode::FAILURE;
+        }
+        m_histoPileupNoiseOffset.at(i)->SetDirectory(0); // prevent deletion when file is closed
+      }
+    }
+  }
+  return StatusCode::SUCCESS;
+}
+
+StatusCode NoiseCaloCellsFromFileBaseTool::initNoiseFromFile() {
+  // Check if file exists
+  if (m_noiseFileName.empty()) {
+    error() << "Name of the file with the noise values not provided!" << endmsg;
+    return StatusCode::FAILURE;
+  }
+  if (gSystem->AccessPathName(m_noiseFileName.value().c_str())) {
+    error() << "Provided file with the noise values not found!" << endmsg;
+    error() << "File path: " << m_noiseFileName.value() << endmsg;
+    return StatusCode::FAILURE;
+  }
+  std::unique_ptr<TFile> noiseFile(TFile::Open(m_noiseFileName.value().c_str(), "READ"));
+  if (!noiseFile || noiseFile->IsZombie()) {
+    error() << "Unable to open the file with the noise values!" << endmsg;
+    error() << "File path: " << m_noiseFileName.value() << endmsg;
+    return StatusCode::FAILURE;
+  } else {
+    info() << "Using the following file with noise values: " << m_noiseFileName.value() << endmsg;
+  }
+
+  K4RECCALORIMETER_CHECK(readHistograms(noiseFile.get()));
+
+  noiseFile->Close();
+
+  // Check if we have same number of histograms (all layers) for pileup and electronics noise
+  if (m_histoElecNoiseRMS.size() == 0) {
+    error() << "No histograms with noise found!!!!" << endmsg;
+    return StatusCode::FAILURE;
+  }
+  if (m_addPileup) {
+    if (m_histoElecNoiseRMS.size() != m_histoPileupNoiseRMS.size()) {
+      error() << "Missing histograms! Different number of histograms for electronics noise RMS and pileup noise RMS!!!!"
+              << endmsg;
+      return StatusCode::FAILURE;
+    }
+  }
+  if (m_setNoiseOffset) {
+    if (m_histoElecNoiseOffset.size() != m_histoElecNoiseRMS.size()) {
+      error() << "Missing histograms! Different number of histograms for electronics noise RMS and offset!!!!"
+              << endmsg;
+      return StatusCode::FAILURE;
+    }
+    if (m_addPileup) {
+      if (m_histoPileupNoiseOffset.size() != m_histoElecNoiseRMS.size()) {
+        error() << "Missing histograms! Different number of histograms for electronics noise RMS and pileup noise "
+                   "offset!!!!"
+                << endmsg;
+        return StatusCode::FAILURE;
+      }
+    }
+  }
+
+  return StatusCode::SUCCESS;
+}
+
+unsigned NoiseCaloCellsFromFileBaseTool::getIndexHistogram(CellID aCellId) const {
+  return m_decoder->get(aCellId, m_index_activeField);
+}
+
+double NoiseCaloCellsFromFileBaseTool::getNoiseRMSPerCell(CellID aCellId) const {
+
+  double elecNoiseRMS = 0.;
+  double pileupNoiseRMS = 0.;
+
+  if (m_histoElecNoiseRMS.size() != 0) {
+    // retrieve index of histogram
+    unsigned indexHistogram = getIndexHistogram(aCellId);
+    // retrieve bin in histogram
+    int ibin = getBin(aCellId);
+
+    if (indexHistogram < m_histoElecNoiseRMS.size()) {
+      elecNoiseRMS = m_histoElecNoiseRMS.at(indexHistogram)->GetBinContent(ibin);
+      if (m_addPileup) {
+        pileupNoiseRMS = m_histoPileupNoiseRMS.at(indexHistogram)->GetBinContent(ibin);
+      }
+    } else {
+      error()
+          << "Index of histogram is larger than the number of noise histograms that are available !!!! Using the last one for all histograms outside the range."
+          << endmsg;
+    }
+  } else {
+    error() << "No histograms with noise constants!!!!! " << endmsg;
+  }
+
+  // Total noise: electronics noise + pileup
+  double totalNoiseRMS = 0;
+  if (m_addPileup) {
+    totalNoiseRMS = sqrt(elecNoiseRMS * elecNoiseRMS + pileupNoiseRMS * pileupNoiseRMS) * m_scaleFactor;
+  } else { // avoid useless math operations if no pileup
+    totalNoiseRMS = elecNoiseRMS * m_scaleFactor;
+  }
+
+  if (totalNoiseRMS < 1e-6) {
+      warning() << "Zero noise RMS: cell ID " << aCellId
+              << endmsg;
+  }
+
+  return totalNoiseRMS;
+}
+
+double NoiseCaloCellsFromFileBaseTool::getNoiseOffsetPerCell(CellID aCellId) const {
+
+  if (!m_setNoiseOffset)
+    return 0.;
+
+  double elecNoiseOffset = 0.;
+  double pileupNoiseOffset = 0.;
+
+  if (m_histoElecNoiseOffset.size() != 0) {
+    // retrieve index of histogram
+    unsigned indexHistogram = getIndexHistogram(aCellId);
+    // retrieve bin in histogram
+    int ibin = getBin(aCellId);
+
+    if (indexHistogram < m_histoElecNoiseOffset.size()) {
+      elecNoiseOffset = m_histoElecNoiseOffset.at(indexHistogram)->GetBinContent(ibin);
+      if (m_addPileup) {
+        pileupNoiseOffset = m_histoPileupNoiseOffset.at(indexHistogram)->GetBinContent(ibin);
+      }
+    } else {
+      error()
+          << "Index of histogram is larger than the number of noise histograms that are available !!!! Using the last one for all histograms outside the range."
+          << endmsg;
+    }
+  } else {
+    error() << "No histograms with noise offset!!!!! " << endmsg;
+  }
+
+  // Total noise offset: electronics noise + pileup (linear or quadratic sum??)
+  // double totalNoiseOffset = sqrt(pow(elecNoiseOffset, 2) + pow(pileupNoiseOffset, 2)) * m_scaleFactor;
+  double totalNoiseOffset = (elecNoiseOffset + pileupNoiseOffset) * m_scaleFactor;
+
+  return totalNoiseOffset;
+}
+
+
+std::pair<double, double>
+NoiseCaloCellsFromFileBaseTool::getNoisePerCell(CellID aCellId) const
+{
+  return std::make_pair (getNoiseRMSPerCell(aCellId),
+                         getNoiseOffsetPerCell(aCellId));
+}

--- a/RecFCCeeCalorimeter/src/components/NoiseCaloCellsFromFileBaseTool.cpp
+++ b/RecFCCeeCalorimeter/src/components/NoiseCaloCellsFromFileBaseTool.cpp
@@ -15,13 +15,13 @@
 #include "TSystem.h"
 
 StatusCode NoiseCaloCellsFromFileBaseTool::initialize() {
-  K4RECCALORIMETER_CHECK( m_geoSvc.retrieve() );
-  K4RECCALORIMETER_CHECK( m_cellPositionsTool.retrieve() );
-  K4RECCALORIMETER_CHECK( m_randSvc = service<IRndmGenSvc> ("RndmGenSvc", false) );
-  K4RECCALORIMETER_CHECK( m_gauss.initialize(m_randSvc, Rndm::Gauss(0., 1.)) );
+  K4RECCALORIMETER_CHECK(m_geoSvc.retrieve());
+  K4RECCALORIMETER_CHECK(m_cellPositionsTool.retrieve());
+  K4RECCALORIMETER_CHECK(m_randSvc = service<IRndmGenSvc>("RndmGenSvc", false));
+  K4RECCALORIMETER_CHECK(m_gauss.initialize(m_randSvc, Rndm::Gauss(0., 1.)));
 
   // open and check file, read the histograms with noise constants
-  K4RECCALORIMETER_CHECK( initNoiseFromFile() );
+  K4RECCALORIMETER_CHECK(initNoiseFromFile());
 
   // Get decoder and get index of layer/wheel field .. should put in try catch block
   m_decoder = m_geoSvc->getDetector()->readout(m_readoutName).idSpec().decoder();
@@ -29,7 +29,7 @@ StatusCode NoiseCaloCellsFromFileBaseTool::initialize() {
 
   debug() << "Filter noise threshold: " << m_filterThreshold << "*sigma" << endmsg;
 
-  K4RECCALORIMETER_CHECK( AlgTool::initialize() );
+  K4RECCALORIMETER_CHECK(AlgTool::initialize());
 
   return StatusCode::SUCCESS;
 }
@@ -46,7 +46,7 @@ void NoiseCaloCellsFromFileBaseTool::addRandomCellNoise(std::unordered_map<CellI
   addRandomCellNoiseT(aCells);
 }
 
-void NoiseCaloCellsFromFileBaseTool::addRandomCellNoise(std::vector<std::pair<CellID, double> >& aCells) const {
+void NoiseCaloCellsFromFileBaseTool::addRandomCellNoise(std::vector<std::pair<CellID, double>>& aCells) const {
   addRandomCellNoiseT(aCells);
 }
 
@@ -54,21 +54,22 @@ template <typename C>
 void NoiseCaloCellsFromFileBaseTool::filterCellNoiseT(C& aCells) const {
   // Erase a cell if it has energy below a threshold from the vector
   if (m_useAbsInFilter) {
-    std::erase_if(aCells,
-                  [&](auto& p) { return std::abs(p.second-getNoiseOffsetPerCell(p.first)) < m_filterThreshold * getNoiseRMSPerCell(p.first); });
-  }
-  else {
-    std::erase_if(aCells,
-                  [&](auto& p) { return p.second < getNoiseOffsetPerCell(p.first) + m_filterThreshold * getNoiseRMSPerCell(p.first); });
+    std::erase_if(aCells, [&](auto& p) {
+      return std::abs(p.second - getNoiseOffsetPerCell(p.first)) < m_filterThreshold * getNoiseRMSPerCell(p.first);
+    });
+  } else {
+    std::erase_if(aCells, [&](auto& p) {
+      return p.second < getNoiseOffsetPerCell(p.first) + m_filterThreshold * getNoiseRMSPerCell(p.first);
+    });
   }
 }
 
 void NoiseCaloCellsFromFileBaseTool::filterCellNoise(std::unordered_map<CellID, double>& aCells) const {
-  filterCellNoiseT (aCells);
+  filterCellNoiseT(aCells);
 }
 
-void NoiseCaloCellsFromFileBaseTool::filterCellNoise(std::vector<std::pair<CellID, double> >& aCells) const {
-  filterCellNoiseT (aCells);
+void NoiseCaloCellsFromFileBaseTool::filterCellNoise(std::vector<std::pair<CellID, double>>& aCells) const {
+  filterCellNoiseT(aCells);
 }
 
 StatusCode NoiseCaloCellsFromFileBaseTool::readHistograms(TFile* noiseFile) {
@@ -110,8 +111,7 @@ StatusCode NoiseCaloCellsFromFileBaseTool::readHistograms(TFile* noiseFile) {
       if (m_setNoiseOffset) {
         pileupNoiseOffsetLayerHistoName = m_pileupNoiseOffsetHistoName + std::to_string(i + 1);
         debug() << "Getting histogram with a name " << pileupNoiseOffsetLayerHistoName << endmsg;
-        m_histoPileupNoiseOffset.push_back(
-            dynamic_cast<TH1*>(noiseFile->Get(pileupNoiseOffsetLayerHistoName.c_str())));
+        m_histoPileupNoiseOffset.push_back(dynamic_cast<TH1*>(noiseFile->Get(pileupNoiseOffsetLayerHistoName.c_str())));
         if (m_histoPileupNoiseOffset.at(i)->GetNbinsX() < 1) {
           error() << "Histogram  " << pileupNoiseOffsetLayerHistoName
                   << " has 0 bins! check the file with noise and the name of the histogram!" << endmsg;
@@ -200,9 +200,9 @@ double NoiseCaloCellsFromFileBaseTool::getNoiseRMSPerCell(CellID aCellId) const 
         pileupNoiseRMS = m_histoPileupNoiseRMS.at(indexHistogram)->GetBinContent(ibin);
       }
     } else {
-      error()
-          << "Index of histogram is larger than the number of noise histograms that are available !!!! Using the last one for all histograms outside the range."
-          << endmsg;
+      error() << "Index of histogram is larger than the number of noise histograms that are available !!!! Using the "
+                 "last one for all histograms outside the range."
+              << endmsg;
     }
   } else {
     error() << "No histograms with noise constants!!!!! " << endmsg;
@@ -217,8 +217,7 @@ double NoiseCaloCellsFromFileBaseTool::getNoiseRMSPerCell(CellID aCellId) const 
   }
 
   if (totalNoiseRMS < 1e-6) {
-      warning() << "Zero noise RMS: cell ID " << aCellId
-              << endmsg;
+    warning() << "Zero noise RMS: cell ID " << aCellId << endmsg;
   }
 
   return totalNoiseRMS;
@@ -244,9 +243,9 @@ double NoiseCaloCellsFromFileBaseTool::getNoiseOffsetPerCell(CellID aCellId) con
         pileupNoiseOffset = m_histoPileupNoiseOffset.at(indexHistogram)->GetBinContent(ibin);
       }
     } else {
-      error()
-          << "Index of histogram is larger than the number of noise histograms that are available !!!! Using the last one for all histograms outside the range."
-          << endmsg;
+      error() << "Index of histogram is larger than the number of noise histograms that are available !!!! Using the "
+                 "last one for all histograms outside the range."
+              << endmsg;
     }
   } else {
     error() << "No histograms with noise offset!!!!! " << endmsg;
@@ -259,10 +258,6 @@ double NoiseCaloCellsFromFileBaseTool::getNoiseOffsetPerCell(CellID aCellId) con
   return totalNoiseOffset;
 }
 
-
-std::pair<double, double>
-NoiseCaloCellsFromFileBaseTool::getNoisePerCell(CellID aCellId) const
-{
-  return std::make_pair (getNoiseRMSPerCell(aCellId),
-                         getNoiseOffsetPerCell(aCellId));
+std::pair<double, double> NoiseCaloCellsFromFileBaseTool::getNoisePerCell(CellID aCellId) const {
+  return std::make_pair(getNoiseRMSPerCell(aCellId), getNoiseOffsetPerCell(aCellId));
 }

--- a/RecFCCeeCalorimeter/src/components/NoiseCaloCellsFromFileBaseTool.h
+++ b/RecFCCeeCalorimeter/src/components/NoiseCaloCellsFromFileBaseTool.h
@@ -19,7 +19,6 @@
 #include "TH1F.h"
 class TFile;
 
-
 /** @class NoiseCaloCellsFromFileBaseTool
  *
  *  Common base class for calorimeter noise-from-file tools
@@ -34,7 +33,8 @@ class TFile;
  *
  */
 
-class NoiseCaloCellsFromFileBaseTool : public extends<AlgTool, k4::recCalo::INoiseCaloCellsTool,  k4::recCalo::INoiseConstTool> {
+class NoiseCaloCellsFromFileBaseTool
+    : public extends<AlgTool, k4::recCalo::INoiseCaloCellsTool, k4::recCalo::INoiseConstTool> {
 public:
   using CellID = k4::recCalo::INoiseCaloCellsTool::CellID;
 
@@ -50,7 +50,7 @@ public:
   /** @brief Create random CaloHits (gaussian distribution) for the vector of cells (aCells).
    * Vector of cells must contain all cells in the calorimeter with their cellIDs.
    */
-  virtual void addRandomCellNoise(std::vector<std::pair<CellID, double> >& aCells) const override final;
+  virtual void addRandomCellNoise(std::vector<std::pair<CellID, double>>& aCells) const override final;
 
   /** @brief Remove cells with energy below threshold*sigma from the vector of cells
    */
@@ -58,7 +58,7 @@ public:
 
   /** @brief Remove cells with energy below threshold*sigma from the vector of cells
    */
-  virtual void filterCellNoise(std::vector<std::pair<CellID, double> >& aCells) const override final;
+  virtual void filterCellNoise(std::vector<std::pair<CellID, double>>& aCells) const override final;
 
   /// Open file and read noise histograms in the memory
   StatusCode initNoiseFromFile();
@@ -71,7 +71,7 @@ public:
 protected:
   /// Handle for tool to get cell positions - available also to derived classes
   ToolHandle<k4::recCalo::ICellPositionsTool> m_cellPositionsTool{this, "cellPositionsTool", "CellPositionsDummyTool",
-      "Handle for tool to retrieve cell positions"};
+                                                                  "Handle for tool to retrieve cell positions"};
   // Decoder for readout
   dd4hep::DDSegmentation::BitFieldCoder* m_decoder;
   /// index of layer or wheel
@@ -87,9 +87,9 @@ protected:
 
 private:
   template <typename C>
-  void addRandomCellNoiseT (C& aCells) const;
+  void addRandomCellNoiseT(C& aCells) const;
   template <typename C>
-  void filterCellNoiseT (C& aCells) const;
+  void filterCellNoiseT(C& aCells) const;
 
   /// Add pileup contribution to the electronics noise? (only if read from file)
   Gaudi::Property<bool> m_addPileup{this, "addPileup", true,
@@ -138,7 +138,7 @@ private:
   Rndm::Numbers m_gauss;
 
   /// Pointer to the geometry service
-  ServiceHandle<IGeoSvc> m_geoSvc { this, "GeoSvc", "GeoSvc" };
+  ServiceHandle<IGeoSvc> m_geoSvc{this, "GeoSvc", "GeoSvc"};
 
   /// get index of histogram for given cellID
   unsigned getIndexHistogram(CellID aCellId) const;

--- a/RecFCCeeCalorimeter/src/components/NoiseCaloCellsFromFileBaseTool.h
+++ b/RecFCCeeCalorimeter/src/components/NoiseCaloCellsFromFileBaseTool.h
@@ -1,5 +1,5 @@
-#ifndef RECFCCEECALORIMETER_NOISECALOCELLSTURBINEENDCAPFROMFILETOOL_H
-#define RECFCCEECALORIMETER_NOISECALOCELLSTURBINEENDCAPFROMFILETOOL_H
+#ifndef RECFCCEECALORIMETER_NOISECALOCELLSFROMFILEBASETOOL_H
+#define RECFCCEECALORIMETER_NOISECALOCELLSFROMFILEBASETOOL_H
 
 // from Gaudi
 #include "GaudiKernel/AlgTool.h"
@@ -11,31 +11,36 @@
 #include "RecCaloCommon/INoiseCaloCellsTool.h"
 #include "RecCaloCommon/INoiseConstTool.h"
 
-class IGeoSvc;
+// k4FWCore
+#include "k4Interface/IGeoSvc.h"
+// class IGeoSvc;
 
 // Root
-class TH1F;
+#include "TH1F.h"
+class TFile;
 
-/** @class NoiseCaloCellsTurbineEndcapFromFileTool
+
+/** @class NoiseCaloCellsFromFileBaseTool
  *
- *  Tool for calorimeter noise
+ *  Common base class for calorimeter noise-from-file tools
  *  Access noise constants from histograms saved in ROOT file
  *  createRandomCellNoise: Create random CaloHits (gaussian distribution) for the vector of cells
  *  filterCellNoise: remove cells with energy below threshold*sigma from the vector of cells
+ *  The tool needs a cell positioning tool to translate cellID to position
+ *  Geometry-specific maaping is delegated to derived classes
  *
- *  @author Erich Varnes
- *  @date   2026-03
+ *  @author Giovanni Marchiori
+ *  @date   2026-06
  *
  */
 
-class NoiseCaloCellsTurbineEndcapFromFileTool
-    : public extends<AlgTool, k4::recCalo::INoiseCaloCellsTool, k4::recCalo::INoiseConstTool> {
+class NoiseCaloCellsFromFileBaseTool : public extends<AlgTool, k4::recCalo::INoiseCaloCellsTool,  k4::recCalo::INoiseConstTool> {
 public:
   using CellID = k4::recCalo::INoiseCaloCellsTool::CellID;
 
   using base_class::base_class;
-  virtual ~NoiseCaloCellsTurbineEndcapFromFileTool() = default;
-  virtual StatusCode initialize() override final;
+  virtual ~NoiseCaloCellsFromFileBaseTool() = default;
+  StatusCode initialize() override;
 
   /** @brief Create random CaloHits (gaussian distribution) for the vector of cells (aCells).
    * Vector of cells must contain all cells in the calorimeter with their cellIDs.
@@ -57,20 +62,34 @@ public:
 
   /// Open file and read noise histograms in the memory
   StatusCode initNoiseFromFile();
+  StatusCode readHistograms(TFile* noiseFile);
   /// Find the appropriate noise RMS from the histogram
   virtual double getNoiseRMSPerCell(CellID aCellID) const override final;
   virtual double getNoiseOffsetPerCell(CellID aCellID) const override final;
   virtual std::pair<double, double> getNoisePerCell(CellID aCellID) const override final;
+
+protected:
+  /// Handle for tool to get cell positions - available also to derived classes
+  ToolHandle<k4::recCalo::ICellPositionsTool> m_cellPositionsTool{this, "cellPositionsTool", "CellPositionsDummyTool",
+      "Handle for tool to retrieve cell positions"};
+  // Decoder for readout
+  dd4hep::DDSegmentation::BitFieldCoder* m_decoder;
+  /// index of layer or wheel
+  int m_index_activeField;
+  /// Histograms with pileup noise RMS (index in array - radial layer)
+  std::vector<TH1*> m_histoPileupNoiseRMS;
+  /// Histograms with electronics noise RMS (index in array - radial layer)
+  std::vector<TH1*> m_histoElecNoiseRMS;
+  /// Histograms with pileup offset (index in array - radial layer)
+  std::vector<TH1*> m_histoPileupNoiseOffset;
+  /// Histograms with electronics noise offset (index in array - radial layer)
+  std::vector<TH1*> m_histoElecNoiseOffset;
 
 private:
   template <typename C>
   void addRandomCellNoiseT (C& aCells) const;
   template <typename C>
   void filterCellNoiseT (C& aCells) const;
-
-  /// Handle for tool to get cell positions
-  ToolHandle<k4::recCalo::ICellPositionsTool> m_cellPositionsTool{this, "cellPositionsTool", "CellPositionsDummyTool",
-                                                                  "Handle for tool to retrieve cell positions"};
 
   /// Add pileup contribution to the electronics noise? (only if read from file)
   Gaudi::Property<bool> m_addPileup{this, "addPileup", true,
@@ -82,10 +101,10 @@ private:
   /// Factor to apply to the noise values to get them in GeV if e.g. they were produced in MeV
   Gaudi::Property<float> m_scaleFactor{this, "scaleFactor", 1, "Factor to apply to the noise values"};
   /// Name of the detector readout (only needed to retrieve the decoder)
-  Gaudi::Property<std::string> m_readoutName{this, "readoutName", "ECalEndcapTurbine",
+  Gaudi::Property<std::string> m_readoutName{this, "readoutName", "ECalBarrelModuleThetaMerged",
                                              "Name of the detector readout"};
-  /// Name of active layers for sampling calorimeter
-  Gaudi::Property<std::string> m_activeFieldName{this, "activeFieldName", "layer",
+  /// Name of active layers/wheels for barrel/endcap sampling calorimeter
+  Gaudi::Property<std::string> m_activeFieldName{this, "activeFieldName", "active_layer",
                                                  "Name of active layers for sampling calorimeter"};
   /// Name of pileup noise RMS histogram
   Gaudi::Property<std::string> m_pileupNoiseRMSHistoName{this, "pileupNoiseRMSHistoName", "h_pileup_layer",
@@ -110,17 +129,8 @@ private:
   Gaudi::Property<bool> m_useAbsInFilter{
       this, "useAbsInFilter", false,
       "If set, cell filtering condition becomes: drop cell if abs(Ecell-offset) < filterThreshold*m_cellNoise"};
-  /// Number of radial layers
-  Gaudi::Property<uint> m_numWheels{this, "numWheels", 3, "Number of wheels"};
-
-  /// Histogram with pileup noise RMS (histograms binned in rho and z, array index -- wheel )
-  std::vector<TH2F> m_histoPileupNoiseRMS;
-  /// Histograms with electronics noise RMS (histograms binned in rho and z, array index -- wheel )
-  std::vector<TH2F> m_histoElecNoiseRMS;
-  /// Histograms with pileup offset (histograms binned in rho and z, array index -- wheel )
-  std::vector<TH2F> m_histoPileupNoiseOffset;
-  /// Histograms with electronics noise offset (histograms binned in rho and z, array index -- wheel )
-  std::vector<TH2F> m_histoElecNoiseOffset;
+  /// Number of radial layers/wheels
+  Gaudi::Property<uint> m_numHistograms{this, "numHistograms", 0, "Number of histograms"};
 
   /// Random Number Service
   SmartIF<IRndmGenSvc> m_randSvc;
@@ -130,9 +140,11 @@ private:
   /// Pointer to the geometry service
   ServiceHandle<IGeoSvc> m_geoSvc { this, "GeoSvc", "GeoSvc" };
 
-  /// Decoder for readout
-  dd4hep::DDSegmentation::BitFieldCoder* m_decoder;
-  int m_index_activeField;
+  /// get index of histogram for given cellID
+  unsigned getIndexHistogram(CellID aCellId) const;
+
+  /// get bin in histogram for given cellID
+  virtual unsigned getBin(CellID aCellId) const = 0;
 };
 
-#endif /* RECFCCEECALORIMETER_NOISECALOCELLSTURBINEENDCAPFROMFILETOOL_H */
+#endif /* RECFCCEECALORIMETER_NOISECALOCELLSVSTHETAFROMFILEBASETOOL_H */

--- a/RecFCCeeCalorimeter/src/components/NoiseCaloCellsFromFileTurbineEndcapTool.cpp
+++ b/RecFCCeeCalorimeter/src/components/NoiseCaloCellsFromFileTurbineEndcapTool.cpp
@@ -1,0 +1,24 @@
+#include "NoiseCaloCellsFromFileTurbineEndcapTool.h"
+
+DECLARE_COMPONENT(NoiseCaloCellsFromFileTurbineEndcapTool)
+
+unsigned NoiseCaloCellsFromFileTurbineEndcapTool::getBin(CellID aCellId) const {
+  unsigned iHist = m_decoder->get(aCellId, m_index_activeField);
+  unsigned iRho = m_decoder->get(aCellId, "rho") + 1;
+  unsigned iZ = m_decoder->get(aCellId, "z") + 1;
+
+  unsigned NbinsZ = m_histoElecNoiseRMS.at(iHist)->GetNbinsX();
+  unsigned NbinsRho = m_histoElecNoiseRMS.at(iHist)->GetNbinsY();
+
+  unsigned ibin = 0;
+  if (iRho > NbinsRho || iZ > NbinsZ) {
+    error() << "bins outside range of the histograms! Bins: " << iRho << "," << iZ
+            << " , Nbins in histogram: " << NbinsRho << "," << NbinsZ
+            << endmsg;
+  }
+  else {
+    ibin = m_histoElecNoiseRMS.at(iHist)->GetBin(iZ, iRho);
+  }
+
+  return ibin;
+}

--- a/RecFCCeeCalorimeter/src/components/NoiseCaloCellsFromFileTurbineEndcapTool.cpp
+++ b/RecFCCeeCalorimeter/src/components/NoiseCaloCellsFromFileTurbineEndcapTool.cpp
@@ -13,10 +13,8 @@ unsigned NoiseCaloCellsFromFileTurbineEndcapTool::getBin(CellID aCellId) const {
   unsigned ibin = 0;
   if (iRho > NbinsRho || iZ > NbinsZ) {
     error() << "bins outside range of the histograms! Bins: " << iRho << "," << iZ
-            << " , Nbins in histogram: " << NbinsRho << "," << NbinsZ
-            << endmsg;
-  }
-  else {
+            << " , Nbins in histogram: " << NbinsRho << "," << NbinsZ << endmsg;
+  } else {
     ibin = m_histoElecNoiseRMS.at(iHist)->GetBin(iZ, iRho);
   }
 

--- a/RecFCCeeCalorimeter/src/components/NoiseCaloCellsFromFileTurbineEndcapTool.h
+++ b/RecFCCeeCalorimeter/src/components/NoiseCaloCellsFromFileTurbineEndcapTool.h
@@ -1,0 +1,28 @@
+#ifndef RECFCCEECALORIMETER_NOISECALOCELLSFROMFILETURBINEENDCAPTOOL_H
+#define RECFCCEECALORIMETER_NOISECALOCELLSFROMFILETURBINEENDCAPTOOL_H
+
+#include "NoiseCaloCellsFromFileBaseTool.h"
+
+/** @class NoiseCaloCellsFromFileTurbineEndcapTool
+ *
+ *  Tool for calorimeter noise - in endcap, with noise histograms per wheel,
+ *  implemented as 2D hists vs rho, z.
+ *  Inherits from common base tool and defines how to retrieve proper bin in
+ *  noise histograms for cell with given cellID
+ *
+ *  @author Erich Varnes
+ *  @author Giovanni Marchiori
+ *  @date   2026-06
+ *
+ */
+
+class NoiseCaloCellsFromFileTurbineEndcapTool : public NoiseCaloCellsFromFileBaseTool {
+public:
+  using NoiseCaloCellsFromFileBaseTool::NoiseCaloCellsFromFileBaseTool;
+
+private:
+  /// get bin in histogram for given cellID
+  unsigned getBin(CellID aCellId) const override final;
+};
+
+#endif /* RECFCCEECALORIMETER_NOISECALOCELLFROMFILETURBINEENDCAPTOOL_H */

--- a/RecFCCeeCalorimeter/src/components/NoiseCaloCellsTurbineEndcapFromFileTool.cpp
+++ b/RecFCCeeCalorimeter/src/components/NoiseCaloCellsTurbineEndcapFromFileTool.cpp
@@ -13,19 +13,18 @@
 // ROOT
 #include "TFile.h"
 #include "TH2F.h"
-#include "TMath.h"
 #include "TSystem.h"
 
 DECLARE_COMPONENT(NoiseCaloCellsTurbineEndcapFromFileTool)
 
 StatusCode NoiseCaloCellsTurbineEndcapFromFileTool::initialize() {
-  K4RECCALORIMETER_CHECK(m_geoSvc.retrieve());
-  K4RECCALORIMETER_CHECK(m_cellPositionsTool.retrieve());
-  K4RECCALORIMETER_CHECK(m_randSvc = service<IRndmGenSvc>("RndmGenSvc", false));
-  K4RECCALORIMETER_CHECK(m_gauss.initialize(m_randSvc, Rndm::Gauss(0., 1.)));
+  K4RECCALORIMETER_CHECK( m_geoSvc.retrieve() );
+  K4RECCALORIMETER_CHECK( m_cellPositionsTool.retrieve() );
+  K4RECCALORIMETER_CHECK( m_randSvc = service<IRndmGenSvc> ("RndmGenSvc", false) );
+  K4RECCALORIMETER_CHECK( m_gauss.initialize(m_randSvc, Rndm::Gauss(0., 1.)) );
 
   // open and check file, read the histograms with noise constants
-  K4RECCALORIMETER_CHECK(initNoiseFromFile());
+  K4RECCALORIMETER_CHECK( initNoiseFromFile() );
 
   // Get decoder and index of layer field
   // put in try... block
@@ -34,7 +33,7 @@ StatusCode NoiseCaloCellsTurbineEndcapFromFileTool::initialize() {
 
   debug() << "Filter noise threshold: " << m_filterThreshold << "*sigma" << endmsg;
 
-  K4RECCALORIMETER_CHECK(AlgTool::initialize());
+  K4RECCALORIMETER_CHECK( AlgTool::initialize() );
 
   return StatusCode::SUCCESS;
 }
@@ -47,12 +46,11 @@ void NoiseCaloCellsTurbineEndcapFromFileTool::addRandomCellNoiseT(C& aCells) con
   }
 }
 
-void NoiseCaloCellsTurbineEndcapFromFileTool::addRandomCellNoise(std::unordered_map<uint64_t, double>& aCells) const {
+void NoiseCaloCellsTurbineEndcapFromFileTool::addRandomCellNoise(std::unordered_map<CellID, double>& aCells) const {
   addRandomCellNoiseT(aCells);
 }
 
-void NoiseCaloCellsTurbineEndcapFromFileTool::addRandomCellNoise(
-    std::vector<std::pair<uint64_t, double>>& aCells) const {
+void NoiseCaloCellsTurbineEndcapFromFileTool::addRandomCellNoise(std::vector<std::pair<CellID, double>>& aCells) const {
   addRandomCellNoiseT(aCells);
 }
 
@@ -61,20 +59,20 @@ void NoiseCaloCellsTurbineEndcapFromFileTool::filterCellNoiseT(C& aCells) const 
   // Erase a cell if it has energy below a threshold from the vector
   if (m_useAbsInFilter) {
     std::erase_if(aCells, [&](auto& p) {
-      return std::abs(p.second - getNoiseOffsetPerCell(p.first)) < m_filterThreshold * getNoiseRMSPerCell(p.first);
+        return std::abs(p.second - getNoiseOffsetPerCell(p.first)) < m_filterThreshold * getNoiseRMSPerCell(p.first);
     });
   } else {
     std::erase_if(aCells, [&](auto& p) {
-      return p.second < getNoiseOffsetPerCell(p.first) + m_filterThreshold * getNoiseRMSPerCell(p.first);
+        return p.second < getNoiseOffsetPerCell(p.first) + m_filterThreshold * getNoiseRMSPerCell(p.first);
     });
   }
 }
 
-void NoiseCaloCellsTurbineEndcapFromFileTool::filterCellNoise(std::unordered_map<uint64_t, double>& aCells) const {
+void NoiseCaloCellsTurbineEndcapFromFileTool::filterCellNoise(std::unordered_map<CellID, double>& aCells) const {
   filterCellNoiseT(aCells);
 }
 
-void NoiseCaloCellsTurbineEndcapFromFileTool::filterCellNoise(std::vector<std::pair<uint64_t, double>>& aCells) const {
+void NoiseCaloCellsTurbineEndcapFromFileTool::filterCellNoise(std::vector<std::pair<CellID, double>>& aCells) const {
   filterCellNoiseT(aCells);
 }
 
@@ -147,7 +145,7 @@ StatusCode NoiseCaloCellsTurbineEndcapFromFileTool::initNoiseFromFile() {
   return StatusCode::SUCCESS;
 }
 
-double NoiseCaloCellsTurbineEndcapFromFileTool::getNoiseRMSPerCell(uint64_t aCellId) const {
+double NoiseCaloCellsTurbineEndcapFromFileTool::getNoiseRMSPerCell(CellID aCellId) const {
 
   double elecNoiseRMS = 0.;
   double pileupNoiseRMS = 0.;
@@ -188,7 +186,7 @@ double NoiseCaloCellsTurbineEndcapFromFileTool::getNoiseRMSPerCell(uint64_t aCel
   return totalNoiseRMS;
 }
 
-double NoiseCaloCellsTurbineEndcapFromFileTool::getNoiseOffsetPerCell(uint64_t aCellId) const {
+double NoiseCaloCellsTurbineEndcapFromFileTool::getNoiseOffsetPerCell(CellID aCellId) const {
 
   if (!m_setNoiseOffset)
     return 0.;
@@ -232,6 +230,6 @@ double NoiseCaloCellsTurbineEndcapFromFileTool::getNoiseOffsetPerCell(uint64_t a
   return totalNoiseOffset;
 }
 
-std::pair<double, double> NoiseCaloCellsTurbineEndcapFromFileTool::getNoisePerCell(uint64_t aCellId) const {
+std::pair<double, double> NoiseCaloCellsTurbineEndcapFromFileTool::getNoisePerCell(CellID aCellId) const {
   return std::make_pair(getNoiseRMSPerCell(aCellId), getNoiseOffsetPerCell(aCellId));
 }

--- a/RecFCCeeCalorimeter/src/components/NoiseCaloCellsTurbineEndcapFromFileTool.cpp
+++ b/RecFCCeeCalorimeter/src/components/NoiseCaloCellsTurbineEndcapFromFileTool.cpp
@@ -18,13 +18,13 @@
 DECLARE_COMPONENT(NoiseCaloCellsTurbineEndcapFromFileTool)
 
 StatusCode NoiseCaloCellsTurbineEndcapFromFileTool::initialize() {
-  K4RECCALORIMETER_CHECK( m_geoSvc.retrieve() );
-  K4RECCALORIMETER_CHECK( m_cellPositionsTool.retrieve() );
-  K4RECCALORIMETER_CHECK( m_randSvc = service<IRndmGenSvc> ("RndmGenSvc", false) );
-  K4RECCALORIMETER_CHECK( m_gauss.initialize(m_randSvc, Rndm::Gauss(0., 1.)) );
+  K4RECCALORIMETER_CHECK(m_geoSvc.retrieve());
+  K4RECCALORIMETER_CHECK(m_cellPositionsTool.retrieve());
+  K4RECCALORIMETER_CHECK(m_randSvc = service<IRndmGenSvc>("RndmGenSvc", false));
+  K4RECCALORIMETER_CHECK(m_gauss.initialize(m_randSvc, Rndm::Gauss(0., 1.)));
 
   // open and check file, read the histograms with noise constants
-  K4RECCALORIMETER_CHECK( initNoiseFromFile() );
+  K4RECCALORIMETER_CHECK(initNoiseFromFile());
 
   // Get decoder and index of layer field
   // put in try... block
@@ -33,7 +33,7 @@ StatusCode NoiseCaloCellsTurbineEndcapFromFileTool::initialize() {
 
   debug() << "Filter noise threshold: " << m_filterThreshold << "*sigma" << endmsg;
 
-  K4RECCALORIMETER_CHECK( AlgTool::initialize() );
+  K4RECCALORIMETER_CHECK(AlgTool::initialize());
 
   return StatusCode::SUCCESS;
 }
@@ -59,11 +59,11 @@ void NoiseCaloCellsTurbineEndcapFromFileTool::filterCellNoiseT(C& aCells) const 
   // Erase a cell if it has energy below a threshold from the vector
   if (m_useAbsInFilter) {
     std::erase_if(aCells, [&](auto& p) {
-        return std::abs(p.second - getNoiseOffsetPerCell(p.first)) < m_filterThreshold * getNoiseRMSPerCell(p.first);
+      return std::abs(p.second - getNoiseOffsetPerCell(p.first)) < m_filterThreshold * getNoiseRMSPerCell(p.first);
     });
   } else {
     std::erase_if(aCells, [&](auto& p) {
-        return p.second < getNoiseOffsetPerCell(p.first) + m_filterThreshold * getNoiseRMSPerCell(p.first);
+      return p.second < getNoiseOffsetPerCell(p.first) + m_filterThreshold * getNoiseRMSPerCell(p.first);
     });
   }
 }

--- a/RecFCCeeCalorimeter/src/components/NoiseCaloCellsTurbineEndcapFromFileTool.h
+++ b/RecFCCeeCalorimeter/src/components/NoiseCaloCellsTurbineEndcapFromFileTool.h
@@ -45,7 +45,7 @@ public:
   /** @brief Create random CaloHits (gaussian distribution) for the vector of cells (aCells).
    * Vector of cells must contain all cells in the calorimeter with their cellIDs.
    */
-  virtual void addRandomCellNoise(std::vector<std::pair<CellID, double> >& aCells) const override final;
+  virtual void addRandomCellNoise(std::vector<std::pair<CellID, double>>& aCells) const override final;
 
   /** @brief Remove cells with energy below threshold*sigma from the vector of cells
    */
@@ -53,7 +53,7 @@ public:
 
   /** @brief Remove cells with energy below threshold*sigma from the vector of cells
    */
-  virtual void filterCellNoise(std::vector<std::pair<CellID, double> >& aCells) const override final;
+  virtual void filterCellNoise(std::vector<std::pair<CellID, double>>& aCells) const override final;
 
   /// Open file and read noise histograms in the memory
   StatusCode initNoiseFromFile();
@@ -64,9 +64,9 @@ public:
 
 private:
   template <typename C>
-  void addRandomCellNoiseT (C& aCells) const;
+  void addRandomCellNoiseT(C& aCells) const;
   template <typename C>
-  void filterCellNoiseT (C& aCells) const;
+  void filterCellNoiseT(C& aCells) const;
 
   /// Handle for tool to get cell positions
   ToolHandle<k4::recCalo::ICellPositionsTool> m_cellPositionsTool{this, "cellPositionsTool", "CellPositionsDummyTool",
@@ -82,8 +82,7 @@ private:
   /// Factor to apply to the noise values to get them in GeV if e.g. they were produced in MeV
   Gaudi::Property<float> m_scaleFactor{this, "scaleFactor", 1, "Factor to apply to the noise values"};
   /// Name of the detector readout (only needed to retrieve the decoder)
-  Gaudi::Property<std::string> m_readoutName{this, "readoutName", "ECalEndcapTurbine",
-                                             "Name of the detector readout"};
+  Gaudi::Property<std::string> m_readoutName{this, "readoutName", "ECalEndcapTurbine", "Name of the detector readout"};
   /// Name of active layers for sampling calorimeter
   Gaudi::Property<std::string> m_activeFieldName{this, "activeFieldName", "layer",
                                                  "Name of active layers for sampling calorimeter"};
@@ -128,7 +127,7 @@ private:
   Rndm::Numbers m_gauss;
 
   /// Pointer to the geometry service
-  ServiceHandle<IGeoSvc> m_geoSvc { this, "GeoSvc", "GeoSvc" };
+  ServiceHandle<IGeoSvc> m_geoSvc{this, "GeoSvc", "GeoSvc"};
 
   /// Decoder for readout
   dd4hep::DDSegmentation::BitFieldCoder* m_decoder;

--- a/RecFCCeeCalorimeter/tests/options/ALLEGRO_o1_v03_digi_reco.py
+++ b/RecFCCeeCalorimeter/tests/options/ALLEGRO_o1_v03_digi_reco.py
@@ -411,9 +411,9 @@ else:
 if addNoise:
     ecalBarrelNoisePath = "elecNoise_ecalBarrelFCCee_theta.root"
     ecalBarrelNoiseRMSHistName = "h_elecNoise_fcc_"
-    from Configurables import NoiseCaloCellsVsThetaFromFileTool
+    from Configurables import NoiseCaloCellsFromFileBarrelTool
 
-    ecalBarrelNoiseTool = NoiseCaloCellsVsThetaFromFileTool(
+    ecalBarrelNoiseTool = NoiseCaloCellsFromFileBarrelTool(
         "ecalBarrelNoiseTool",
         cellPositionsTool=cellPositionEcalBarrelToolForNoise,
         readoutName=ecalBarrelReadoutName,
@@ -424,7 +424,7 @@ if addNoise:
         addPileup=False,
         filterNoiseThreshold=1,
         useAbsInFilter=True,
-        numRadialLayers=ecalBarrelLayers,
+        numHistograms=ecalBarrelLayers,
         scaleFactor=1 / 1000.0,  # MeV to GeV
         OutputLevel=INFO,
     )

--- a/RecFCCeeCalorimeter/tests/options/test_noise.py
+++ b/RecFCCeeCalorimeter/tests/options/test_noise.py
@@ -1,0 +1,446 @@
+#
+# COMMON IMPORTS
+#
+
+# Logger
+from Gaudi.Configuration import INFO, DEBUG, VERBOSE
+# units and physical constants
+from GaudiKernel.PhysicalConstants import pi
+
+
+#
+# SETTINGS
+#
+
+# - general settings
+#
+inputfile = "noise_sim.root"               # input file produced with ddsim
+outputfile = "noise_digi.root"             # output file to be produced
+Nevts = -1                                 # -1 means all events
+addNoise = True                            # add noise or not to the cell energy
+runHCal = False                            # off since no noise added to HCal so far..
+
+# - what to save in output file
+#
+# always drop uncalibrated cells, except for tests and debugging
+# dropUncalibratedCells = True
+dropUncalibratedCells = False
+
+# for big productions, save significant space removing hits and cells
+# saveHits = False
+# saveCells = False
+saveHits = True
+saveCells = True
+
+# ECAL barrel parameters for digitisation
+ecalBarrelSamplingFraction = [0.3800493723322256] * 1 + [0.13494147915064658] * 1 + [0.142866851721152] * 1 + [0.14839315921940666] * 1 + [0.15298362570665006] * 1 + [0.15709704561942747] * 1 + [0.16063717490147533] * 1 + [0.1641723795419055] * 1 + [0.16845490287689746] * 1 + [0.17111520115997653] * 1 + [0.1730605163148862] * 1
+ecalBarrelUpstreamParameters = [[0.028158491043365624, -1.564259408365951, -76.52312805346982, 0.7442903558010191, -34.894692961350195, -74.19340877431723]]
+ecalBarrelDownstreamParameters = [[0.00010587711361028165, 0.0052371999097777355, 0.69906696456064, -0.9348243433360095, -0.0364714212117143, 8.360401126995626]]
+ecalBarrelLayers = len(ecalBarrelSamplingFraction)
+# ECAL endcap parameters for digitisation
+ecalEndcapLayers = 98
+ecalEndcapSamplingFraction = [0.0897818] * 1+ [0.221318] * 1+ [0.0820002] * 1+ [0.994281] * 1+ [0.0414437] * 1+ [0.1148] * 1+ [0.178831] * 1+ [0.142449] * 1+ [0.181206] * 1+ [0.342843] * 1+ [0.137479] * 1+ [0.176479] * 1+ [0.153273] * 1+ [0.195836] * 1+ [0.0780405] * 1+ [0.150202] * 1+ [0.17846] * 1+ [0.164886] * 1+ [0.175758] * 1+ [0.10836] * 1+ [0.160243] * 1+ [0.183373] * 1+ [0.171818] * 1+ [0.194848] * 1+ [0.111899] * 1+ [0.170704] * 1+ [0.188455] * 1+ [0.178164] * 1+ [0.209113] * 1+ [0.105241] * 1+ [0.180637] * 1+ [0.192206] * 1+ [0.186096] * 1+ [0.211962] * 1+ [0.112019] * 1+ [0.180344] * 1+ [0.195684] * 1+ [0.190778] * 1+ [0.218259] * 1+ [0.118516] * 1+ [0.207786] * 1+ [0.204474] * 1+ [0.207048] * 1+ [0.225913] * 1+ [0.111325] * 1+ [0.147875] * 1+ [0.195625] * 1+ [0.173326] * 1+ [0.175449] * 1+ [0.104087] * 1+ [0.153645] * 1+ [0.161263] * 1+ [0.165499] * 1+ [0.171758] * 1+ [0.175789] * 1+ [0.180657] * 1+ [0.184563] * 1+ [0.187876] * 1+ [0.191762] * 1+ [0.19426] * 1+ [0.197959] * 1+ [0.199021] * 1+ [0.204428] * 1+ [0.195709] * 1+ [0.151751] * 1+ [0.171477] * 1+ [0.165509] * 1+ [0.172565] * 1+ [0.172961] * 1+ [0.175534] * 1+ [0.177989] * 1+ [0.18026] * 1+ [0.181898] * 1+ [0.183912] * 1+ [0.185654] * 1+ [0.187515] * 1+ [0.190408] * 1+ [0.188794] * 1+ [0.193699] * 1+ [0.192287] * 1+ [0.19755] * 1+ [0.190943] * 1+ [0.218553] * 1+ [0.161085] * 1+ [0.373086] * 1+ [0.122495] * 1+ [0.21103] * 1+ [1] * 1+ [0.138686] * 1+ [0.0545171] * 1+ [1] * 1+ [1] * 1+ [0.227945] * 1+ [0.0122872] * 1+ [0.00437334] * 1+ [0.00363533] * 1+ [1] * 1+ [1] * 1
+
+
+#
+# ALGORITHMS AND SERVICES SETUP
+#
+TopAlg = []  # alg sequence
+ExtSvc = []  # list of external services
+
+
+# Event counter
+from Configurables import EventCounter
+eventCounter = EventCounter("EventCounter",
+                            OutputLevel=INFO,
+                            Frequency=1)
+TopAlg += [eventCounter]
+# add a message sink service if you want a summary table at the end (not needed..)
+# ExtSvc += ["Gaudi::Monitoring::MessageSvcSink"]
+
+# CPU information
+from Configurables import AuditorSvc, ChronoAuditor
+chra = ChronoAuditor()
+audsvc = AuditorSvc()
+audsvc.Auditors = [chra]
+ExtSvc += [audsvc]
+
+
+# Detector geometry
+# prefix all xmls with path_to_detector
+# if K4GEO is empty, this should use relative path to working directory
+from Configurables import GeoSvc
+import os
+geoservice = GeoSvc("GeoSvc",
+                    OutputLevel=INFO
+                    # OutputLevel=DEBUG  # set to DEBUG to print dd4hep::DEBUG messages in k4geo C++ drivers
+                    )
+
+path_to_detector = os.environ.get("K4GEO", "") + "/FCCee/ALLEGRO/compact/ALLEGRO_o1_v03/"
+detectors_to_use = [
+    'ALLEGRO_o1_v03.xml'
+]
+geoservice.detectors = [
+    os.path.join(path_to_detector, _det) for _det in detectors_to_use
+]
+ExtSvc += [geoservice]
+
+# retrieve subdetector IDs
+import xml.etree.ElementTree as ET
+tree = ET.parse(path_to_detector + 'DectDimensions.xml')
+root = tree.getroot()
+IDs = {}
+for constant in root.find('define').findall('constant'):
+    if (
+        constant.get('name') == 'DetID_VXD_Barrel'
+        or constant.get('name') == 'DetID_VXD_Disks'
+        or constant.get('name') == 'DetID_DCH'
+        or constant.get('name') == 'DetID_SiWr_Barrel'
+        or constant.get('name') == 'DetID_SiWr_Disks'
+        or constant.get('name') == 'DetID_ECAL_Barrel'
+        or constant.get('name') == 'DetID_ECAL_Endcap'
+        or constant.get('name') == 'DetID_HCAL_Barrel'
+        or constant.get('name') == 'DetID_HCAL_Endcap'
+        or constant.get('name') == 'DetID_Muon_Barrel'
+    ):
+        IDs[constant.get("name")[6:]] = int(constant.get('value'))
+    if (constant.get('name') == 'DetID_Muon_Endcap_1'):
+        IDs[constant.get("name")[6:-2]] = int(constant.get('value'))
+# debug
+print("Subdetector IDs:")
+print(IDs)
+
+# Input/Output handling
+from k4FWCore import IOSvc
+from Configurables import EventDataSvc
+io_svc = IOSvc("IOSvc")
+io_svc.Input = inputfile
+io_svc.Output = outputfile
+ExtSvc += [EventDataSvc("EventDataSvc")]
+
+# Calorimeter digitisation (merging hits into cells, EM scale calibration via sampling fractions)
+
+# - ECAL readouts
+ecalBarrelReadoutName = "ECalBarrelModuleThetaMerged"      # barrel, original segmentation (baseline)
+ecalEndcapReadoutName = "ECalEndcapTurbine"                # endcap, turbine-like (baseline)
+# - HCAL readouts
+if runHCal:
+    hcalBarrelReadoutName = "HCalBarrelReadout"            # barrel, original segmentation (phi-theta)
+    # hcalBarrelReadoutName = "HCalBarrelReadoutPhiRow"    # barrel, alternative segmentation (phi-row)
+    hcalEndcapReadoutName = "HCalEndcapReadout"            # endcap, original segmentation
+else:
+    hcalBarrelReadoutName = ""
+    hcalEndcapReadoutName = ""
+
+# - EM scale calibration (sampling fraction)
+from Configurables import CalibrateInLayersTool
+#   * ECAL barrel
+calibEcalBarrel = CalibrateInLayersTool("CalibrateECalBarrel",
+                                        samplingFraction=ecalBarrelSamplingFraction,
+                                        readoutName=ecalBarrelReadoutName,
+                                        layerFieldName="layer")
+#   * ECAL endcap
+calibEcalEndcap = CalibrateInLayersTool("CalibrateECalEndcap",
+                                        samplingFraction=ecalEndcapSamplingFraction,
+                                        readoutName=ecalEndcapReadoutName,
+                                        layerFieldName="layer")
+
+if runHCal:
+    from Configurables import CalibrateCaloHitsTool
+    # HCAL barrel
+    calibHCalBarrel = CalibrateCaloHitsTool(
+        "CalibrateHCalBarrel", invSamplingFraction="29.4202")
+    # HCAL endcap
+    calibHCalEndcap = CalibrateCaloHitsTool(
+        "CalibrateHCalEndcap", invSamplingFraction="29.4202")  # FIXME: to be updated for ddsim
+
+# - cell positioning tools
+from Configurables import CellPositionsECalBarrelModuleThetaSegTool
+cellPositionEcalBarrelTool = CellPositionsECalBarrelModuleThetaSegTool(
+    "CellPositionsECalBarrel",
+    readoutName=ecalBarrelReadoutName,
+    OutputLevel=INFO
+)
+
+# the noise tool needs the positioning tool, but if I reuse the previous one the code crashes..
+cellPositionEcalBarrelToolForNoise = CellPositionsECalBarrelModuleThetaSegTool(
+    "CellPositionsECalBarrelForNoise",
+    readoutName=ecalBarrelReadoutName,
+    OutputLevel=INFO
+)
+
+from Configurables import CellPositionsECalEndcapTurbineSegTool
+cellPositionEcalEndcapTool = CellPositionsECalEndcapTurbineSegTool(
+    "CellPositionsECalEndcap",
+    readoutName=ecalEndcapReadoutName,
+    OutputLevel=INFO
+)
+
+# in principle not needed - have to make c++ code of noise tool not fail if position tool is None
+# and fail only later when/if tool is used
+cellPositionEcalEndcapToolForNoise = CellPositionsECalEndcapTurbineSegTool(
+    "CellPositionsECalEndcapForNoise",
+    readoutName=ecalEndcapReadoutName,
+    OutputLevel=INFO
+)
+
+if runHCal:
+    from Configurables import CellPositionsHCalPhiThetaSegTool
+    cellPositionHCalBarrelTool = CellPositionsHCalPhiThetaSegTool(
+        "CellPositionsHCalBarrel",
+        readoutName=hcalBarrelReadoutName,
+        detectorName="HCalBarrel",
+        OutputLevel=INFO
+    )
+    cellPositionHCalEndcapTool = CellPositionsHCalPhiThetaSegTool(
+        "CellPositionsHCalEndcap",
+        readoutName=hcalEndcapReadoutName,
+        detectorName="HCalThreePartsEndcap",
+        numLayersHCalThreeParts=[6, 9, 22],
+        OutputLevel=INFO
+    )
+
+# - noise tool
+if addNoise:
+    ecalBarrelNoisePath = "elecNoise_ecalBarrelFCCee_theta.root"
+    ecalBarrelNoiseRMSHistName = "h_elecNoise_fcc_"
+    from Configurables import NoiseCaloCellsFromFileBarrelTool
+    ecalBarrelNoiseTool = NoiseCaloCellsFromFileBarrelTool("ecalBarrelNoiseTool",
+                                                           cellPositionsTool=cellPositionEcalBarrelToolForNoise,
+                                                           readoutName=ecalBarrelReadoutName,
+                                                           noiseFileName=ecalBarrelNoisePath,
+                                                           elecNoiseRMSHistoName=ecalBarrelNoiseRMSHistName,
+                                                           setNoiseOffset=False,
+                                                           activeFieldName="layer",
+                                                           addPileup=False,
+                                                           filterNoiseThreshold=1,
+                                                           useAbsInFilter=True,
+                                                           numHistograms=ecalBarrelLayers,
+                                                           scaleFactor=1 / 1000.,  # MeV to GeV
+                                                           OutputLevel=INFO)
+
+    from Configurables import TubeLayerModuleThetaCaloTool
+    ecalBarrelGeometryTool = TubeLayerModuleThetaCaloTool("ecalBarrelGeometryTool",
+                                                          readoutName=ecalBarrelReadoutName,
+                                                          activeVolumeName="LAr_sensitive",
+                                                          activeFieldName="layer",
+                                                          activeVolumesNumber=ecalBarrelLayers,
+                                                          fieldNames=["system"],
+                                                          fieldValues=[IDs["ECAL_Barrel"]],
+                                                          OutputLevel=INFO)
+    ecalEndcapNoisePath = "elecNoise_ecalendcap.root"
+    ecalEndcapNoiseRMSHistName = "noise_endcap_wheel"
+
+    # can enable only when geometry tool for ecal endcap is implemented
+    # ecalEndcapGeometryTool = ..
+    # from Configurables import NoiseCaloCellsFromFileTurbineEndcapTool
+    # ecalEndcapNoiseTool = NoiseCaloCellsFromFileTurbineEndcapTool("ecalEndcapNoiseTool",
+    #                                                               cellPositionsTool=cellPositionEcalEndcapToolForNoise,
+    #                                                               readoutName=ecalEndcapReadoutName,
+    #                                                               noiseFileName=ecalEndcapNoisePath,
+    #                                                               elecNoiseRMSHistoName=ecalEndcapNoiseRMSHistName,
+    #                                                               setNoiseOffset=False,
+    #                                                               activeFieldName="wheel",
+    #                                                               addPileup=False,
+    #                                                               filterNoiseThreshold=1,
+    #                                                               useAbsInFilter=True,
+    #                                                               numHistograms=3,  # 3 wheels
+    #                                                               scaleFactor=1 / 1000.,  # MeV to GeV
+    #                                                               OutputLevel=INFO)
+else:
+    ecalBarrelNoiseTool = None
+    ecalBarrelGeometryTool = None
+    ecalEndcapNoiseTool = None
+
+# Create cells in ECal barrel (calibrated and positioned - optionally with xtalk and noise added)
+# from uncalibrated cells (+cellID info) from ddsim
+ecalBarrelPositionedCellsName = ecalBarrelReadoutName + "Positioned"
+ecalBarrelLinks = ecalBarrelPositionedCellsName + "SimCaloHitLinks"
+from Configurables import CreatePositionedCaloCells
+createEcalBarrelCells = CreatePositionedCaloCells("CreatePositionedECalBarrelCells",
+                                                  doCellCalibration=True,
+                                                  calibTool=calibEcalBarrel,
+                                                  positionsTool=cellPositionEcalBarrelTool,
+                                                  addCrosstalk=False,
+                                                  crosstalkTool=None,
+                                                  addCellNoise=False,
+                                                  filterCellNoise=False,
+                                                  OutputLevel=INFO,
+                                                  hits=ecalBarrelReadoutName,
+                                                  cells=ecalBarrelPositionedCellsName,
+                                                  links=ecalBarrelLinks
+                                                  )
+TopAlg += [createEcalBarrelCells]
+
+# Create cells in ECal endcap (needed if one wants to apply cell calibration,
+# which is not performed by ddsim)
+ecalEndcapPositionedCellsName = ecalEndcapReadoutName + "Positioned"
+ecalEndcapLinks = ecalEndcapPositionedCellsName + "SimCaloHitLinks"
+createEcalEndcapCells = CreatePositionedCaloCells("CreatePositionedECalEndcapCells",
+                                                  doCellCalibration=True,
+                                                  positionsTool=cellPositionEcalEndcapTool,
+                                                  calibTool=calibEcalEndcap,
+                                                  crosstalkTool=None,
+                                                  addCrosstalk=False,
+                                                  addCellNoise=False,
+                                                  filterCellNoise=False,
+                                                  OutputLevel=INFO,
+                                                  hits=ecalEndcapReadoutName,
+                                                  cells=ecalEndcapPositionedCellsName,
+                                                  links=ecalEndcapLinks)
+TopAlg += [createEcalEndcapCells]
+
+if addNoise:
+    # cells with noise not filtered
+    ecalBarrelCellsNoiseLinks = ecalBarrelPositionedCellsName + "WithNoise" + "SimCaloHitLinks"
+    createEcalBarrelCellsNoise = CreatePositionedCaloCells("CreatePositionedECalBarrelCellsWithNoise",
+                                                           doCellCalibration=True,
+                                                           calibTool=calibEcalBarrel,
+                                                           positionsTool=cellPositionEcalBarrelTool,
+                                                           addCellNoise=True,
+                                                           filterCellNoise=False,
+                                                           noiseTool=ecalBarrelNoiseTool,
+                                                           geometryTool=ecalBarrelGeometryTool,
+                                                           OutputLevel=INFO,
+                                                           hits=ecalBarrelReadoutName,
+                                                           cells=ecalBarrelPositionedCellsName + "WithNoise",
+                                                           links=ecalBarrelCellsNoiseLinks)
+    TopAlg += [createEcalBarrelCellsNoise]
+
+    # cells with noise filtered
+    ecalBarrelCellsNoiseFilteredLinks = ecalBarrelPositionedCellsName + "WithNoiseFiltered" + "SimCaloHitLinks"
+    createEcalBarrelCellsNoiseFiltered = CreatePositionedCaloCells("CreatePositionedECalBarrelCellsWithNoiseFiltered",
+                                                                   doCellCalibration=True,
+                                                                   calibTool=calibEcalBarrel,
+                                                                   positionsTool=cellPositionEcalBarrelTool,
+                                                                   addCellNoise=True,
+                                                                   filterCellNoise=True,
+                                                                   noiseTool=ecalBarrelNoiseTool,
+                                                                   geometryTool=ecalBarrelGeometryTool,
+                                                                   OutputLevel=INFO,
+                                                                   hits=ecalBarrelReadoutName,  # uncalibrated & unpositioned cells without noise
+                                                                   cells=ecalBarrelPositionedCellsName + "WithNoiseFiltered",
+                                                                   links=ecalBarrelCellsNoiseFilteredLinks
+                                                                   )
+    TopAlg += [createEcalBarrelCellsNoiseFiltered]
+
+    # can enable only when geometry tool for ecal endcap is implemented
+    # # cells with noise not filtered
+    # ecalEndcapCellsNoiseLinks = ecalEndcapPositionedCellsName + "WithNoise" + "SimCaloHitLinks"
+    # createEcalEndcapCellsNoise = CreatePositionedCaloCells("CreatePositionedECalEndcapCellsWithNoise",
+    #                                                        doCellCalibration=True,
+    #                                                        calibTool=calibEcalEndcap,
+    #                                                        positionsTool=cellPositionEcalEndcapTool,
+    #                                                        addCellNoise=True,
+    #                                                        filterCellNoise=False,
+    #                                                        noiseTool=ecalEndcapNoiseTool,
+    #                                                        geometryTool=ecalEndcapGeometryTool,
+    #                                                        OutputLevel=INFO,
+    #                                                        hits=ecalEndcapReadoutName,
+    #                                                        cells=ecalEndcapPositionedCellsName + "WithNoise",
+    #                                                        links=ecalEndcapCellsNoiseLinks)
+    # TopAlg += [createEcalEndcapCellsNoise]
+
+    # # cells with noise filtered
+    # ecalEndcapCellsNoiseFilteredLinks = ecalEndcapPositionedCellsName + "WithNoiseFiltered" + "SimCaloHitLinks"
+    # createEcalEndcapCellsNoiseFiltered = CreatePositionedCaloCells("CreatePositionedECalEndcapCellsWithNoiseFiltered",
+    #                                                                doCellCalibration=True,
+    #                                                                calibTool=calibEcalEndcap,
+    #                                                                positionsTool=cellPositionEcalEndcapTool,
+    #                                                                addCellNoise=True,
+    #                                                                filterCellNoise=True,
+    #                                                                noiseTool=ecalEndcapNoiseTool,
+    #                                                                geometryTool=ecalEndcapGeometryTool,
+    #                                                                OutputLevel=INFO,
+    #                                                                hits=ecalEndcapReadoutName,  # uncalibrated & unpositioned cells without noise
+    #                                                                cells=ecalEndcapPositionedCellsName + "WithNoiseFiltered",
+    #                                                                links=ecalEndcapCellsNoiseFilteredLinks
+    #                                                                )
+    # TopAlg += [createEcalEndcapCellsNoiseFiltered]
+
+if runHCal:
+    # Apply calibration and positioning to cells in HCal barrel
+    hcalBarrelPositionedCellsName = hcalBarrelReadoutName + "Positioned"
+    hcalBarrelLinks = hcalBarrelPositionedCellsName + "SimCaloHitLinks"
+    createHCalBarrelCells = CreatePositionedCaloCells("CreatePositionedHCalBarrelCells",
+                                                      doCellCalibration=True,
+                                                      calibTool=calibHCalBarrel,
+                                                      positionsTool=cellPositionHCalBarrelTool,
+                                                      addCellNoise=False,
+                                                      filterCellNoise=False,
+                                                      hits=hcalBarrelReadoutName,
+                                                      cells=hcalBarrelPositionedCellsName,
+                                                      links=hcalBarrelLinks,
+                                                      OutputLevel=INFO)
+    TopAlg += [createHCalBarrelCells]
+
+    # Apply calibration and positioning to cells in HCal endcap
+    hcalEndcapPositionedCellsName = hcalEndcapReadoutName + "Positioned"
+    hcalEndcapLinks = hcalEndcapPositionedCellsName + "SimCaloHitLinks"
+    createHCalEndcapCells = CreatePositionedCaloCells("CreatePositionedHCalEndcapCells",
+                                                      doCellCalibration=True,
+                                                      calibTool=calibHCalEndcap,
+                                                      addCellNoise=False,
+                                                      filterCellNoise=False,
+                                                      positionsTool=cellPositionHCalEndcapTool,
+                                                      OutputLevel=INFO,
+                                                      hits=hcalEndcapReadoutName,
+                                                      cells=hcalEndcapPositionedCellsName,
+                                                      links=hcalEndcapLinks)
+    TopAlg += [createHCalEndcapCells]
+
+
+# Configure output
+io_svc.outputCommands = ["keep *",
+                         "drop emptyCaloCells"]
+
+# drop the uncalibrated cells
+if dropUncalibratedCells:
+    io_svc.outputCommands.append("drop %s" % ecalBarrelReadoutName)
+    io_svc.outputCommands.append("drop %s" % ecalEndcapReadoutName)
+    if runHCal:
+        io_svc.outputCommands.append("drop %s" % hcalBarrelReadoutName)
+        io_svc.outputCommands.append("drop %s" % hcalEndcapReadoutName)
+    else:
+        io_svc.outputCommands += ["drop HCal*"]
+
+# drop lumi, vertex, DCH, Muons (unless want to keep for event display)
+io_svc.outputCommands.append("drop Lumi*")
+io_svc.outputCommands.append("drop Vertex*")
+io_svc.outputCommands.append("drop DriftChamber_simHits*")
+io_svc.outputCommands.append("drop MuonTagger*")
+
+# drop hits/positioned cells if desired
+if not saveHits:
+    io_svc.outputCommands.append("drop *%sContributions" % ecalBarrelReadoutName)
+    io_svc.outputCommands.append("drop *%sContributions" % ecalEndcapReadoutName)
+    if runHCal:
+        io_svc.outputCommands.append("drop *%sContributions" % hcalBarrelReadoutName)
+        io_svc.outputCommands.append("drop *%sContributions" % hcalEndcapReadoutName)
+if not saveCells:
+    io_svc.outputCommands.append("drop %s" % ecalBarrelPositionedCellsName)
+    io_svc.outputCommands.append("drop %s" % ecalEndcapPositionedCellsName)
+    if runHCal:
+        io_svc.outputCommands.append("drop %s" % hcalBarrelPositionedCellsName)
+        io_svc.outputCommands.append("drop %s" % hcalEndcapPositionedCellsName)
+# drop hits<->cells links if either of the two collections are not saved
+if not saveHits or not saveCells:
+    io_svc.outputCommands.append("drop *SimCaloHitLinks")
+
+
+# configure the application
+print(TopAlg)
+print(ExtSvc)
+from k4FWCore import ApplicationMgr
+applicationMgr = ApplicationMgr(
+    TopAlg=TopAlg,
+    EvtSel='NONE',
+    EvtMax=Nevts,
+    ExtSvc=ExtSvc,
+    StopOnSignal=True,
+)
+
+for algo in applicationMgr.TopAlg:
+    algo.AuditExecute = True
+    # for debug
+    # algo.OutputLevel = DEBUG

--- a/RecFCCeeCalorimeter/tests/options/test_noise.py
+++ b/RecFCCeeCalorimeter/tests/options/test_noise.py
@@ -609,4 +609,4 @@ applicationMgr = ApplicationMgr(
 for algo in applicationMgr.TopAlg:
     algo.AuditExecute = True
     # for debug
-    # algo.OutputLevel = DEBUG
+    algo.OutputLevel = DEBUG

--- a/RecFCCeeCalorimeter/tests/options/test_noise.py
+++ b/RecFCCeeCalorimeter/tests/options/test_noise.py
@@ -609,4 +609,4 @@ applicationMgr = ApplicationMgr(
 for algo in applicationMgr.TopAlg:
     algo.AuditExecute = True
     # for debug
-    algo.OutputLevel = DEBUG
+    # algo.OutputLevel = DEBUG

--- a/RecFCCeeCalorimeter/tests/options/test_noise.py
+++ b/RecFCCeeCalorimeter/tests/options/test_noise.py
@@ -4,6 +4,7 @@
 
 # Logger
 from Gaudi.Configuration import INFO, DEBUG, VERBOSE
+
 # units and physical constants
 from GaudiKernel.PhysicalConstants import pi
 
@@ -14,11 +15,11 @@ from GaudiKernel.PhysicalConstants import pi
 
 # - general settings
 #
-inputfile = "noise_sim.root"               # input file produced with ddsim
-outputfile = "noise_digi.root"             # output file to be produced
-Nevts = -1                                 # -1 means all events
-addNoise = True                            # add noise or not to the cell energy
-runHCal = False                            # off since no noise added to HCal so far..
+inputfile = "noise_sim.root"  # input file produced with ddsim
+outputfile = "noise_digi.root"  # output file to be produced
+Nevts = -1  # -1 means all events
+addNoise = True  # add noise or not to the cell energy
+runHCal = False  # off since no noise added to HCal so far..
 
 # - what to save in output file
 #
@@ -33,13 +34,142 @@ saveHits = True
 saveCells = True
 
 # ECAL barrel parameters for digitisation
-ecalBarrelSamplingFraction = [0.3800493723322256] * 1 + [0.13494147915064658] * 1 + [0.142866851721152] * 1 + [0.14839315921940666] * 1 + [0.15298362570665006] * 1 + [0.15709704561942747] * 1 + [0.16063717490147533] * 1 + [0.1641723795419055] * 1 + [0.16845490287689746] * 1 + [0.17111520115997653] * 1 + [0.1730605163148862] * 1
-ecalBarrelUpstreamParameters = [[0.028158491043365624, -1.564259408365951, -76.52312805346982, 0.7442903558010191, -34.894692961350195, -74.19340877431723]]
-ecalBarrelDownstreamParameters = [[0.00010587711361028165, 0.0052371999097777355, 0.69906696456064, -0.9348243433360095, -0.0364714212117143, 8.360401126995626]]
+ecalBarrelSamplingFraction = (
+    [0.3800493723322256] * 1
+    + [0.13494147915064658] * 1
+    + [0.142866851721152] * 1
+    + [0.14839315921940666] * 1
+    + [0.15298362570665006] * 1
+    + [0.15709704561942747] * 1
+    + [0.16063717490147533] * 1
+    + [0.1641723795419055] * 1
+    + [0.16845490287689746] * 1
+    + [0.17111520115997653] * 1
+    + [0.1730605163148862] * 1
+)
+ecalBarrelUpstreamParameters = [
+    [
+        0.028158491043365624,
+        -1.564259408365951,
+        -76.52312805346982,
+        0.7442903558010191,
+        -34.894692961350195,
+        -74.19340877431723,
+    ]
+]
+ecalBarrelDownstreamParameters = [
+    [
+        0.00010587711361028165,
+        0.0052371999097777355,
+        0.69906696456064,
+        -0.9348243433360095,
+        -0.0364714212117143,
+        8.360401126995626,
+    ]
+]
 ecalBarrelLayers = len(ecalBarrelSamplingFraction)
 # ECAL endcap parameters for digitisation
 ecalEndcapLayers = 98
-ecalEndcapSamplingFraction = [0.0897818] * 1+ [0.221318] * 1+ [0.0820002] * 1+ [0.994281] * 1+ [0.0414437] * 1+ [0.1148] * 1+ [0.178831] * 1+ [0.142449] * 1+ [0.181206] * 1+ [0.342843] * 1+ [0.137479] * 1+ [0.176479] * 1+ [0.153273] * 1+ [0.195836] * 1+ [0.0780405] * 1+ [0.150202] * 1+ [0.17846] * 1+ [0.164886] * 1+ [0.175758] * 1+ [0.10836] * 1+ [0.160243] * 1+ [0.183373] * 1+ [0.171818] * 1+ [0.194848] * 1+ [0.111899] * 1+ [0.170704] * 1+ [0.188455] * 1+ [0.178164] * 1+ [0.209113] * 1+ [0.105241] * 1+ [0.180637] * 1+ [0.192206] * 1+ [0.186096] * 1+ [0.211962] * 1+ [0.112019] * 1+ [0.180344] * 1+ [0.195684] * 1+ [0.190778] * 1+ [0.218259] * 1+ [0.118516] * 1+ [0.207786] * 1+ [0.204474] * 1+ [0.207048] * 1+ [0.225913] * 1+ [0.111325] * 1+ [0.147875] * 1+ [0.195625] * 1+ [0.173326] * 1+ [0.175449] * 1+ [0.104087] * 1+ [0.153645] * 1+ [0.161263] * 1+ [0.165499] * 1+ [0.171758] * 1+ [0.175789] * 1+ [0.180657] * 1+ [0.184563] * 1+ [0.187876] * 1+ [0.191762] * 1+ [0.19426] * 1+ [0.197959] * 1+ [0.199021] * 1+ [0.204428] * 1+ [0.195709] * 1+ [0.151751] * 1+ [0.171477] * 1+ [0.165509] * 1+ [0.172565] * 1+ [0.172961] * 1+ [0.175534] * 1+ [0.177989] * 1+ [0.18026] * 1+ [0.181898] * 1+ [0.183912] * 1+ [0.185654] * 1+ [0.187515] * 1+ [0.190408] * 1+ [0.188794] * 1+ [0.193699] * 1+ [0.192287] * 1+ [0.19755] * 1+ [0.190943] * 1+ [0.218553] * 1+ [0.161085] * 1+ [0.373086] * 1+ [0.122495] * 1+ [0.21103] * 1+ [1] * 1+ [0.138686] * 1+ [0.0545171] * 1+ [1] * 1+ [1] * 1+ [0.227945] * 1+ [0.0122872] * 1+ [0.00437334] * 1+ [0.00363533] * 1+ [1] * 1+ [1] * 1
+ecalEndcapSamplingFraction = (
+    [0.0897818] * 1
+    + [0.221318] * 1
+    + [0.0820002] * 1
+    + [0.994281] * 1
+    + [0.0414437] * 1
+    + [0.1148] * 1
+    + [0.178831] * 1
+    + [0.142449] * 1
+    + [0.181206] * 1
+    + [0.342843] * 1
+    + [0.137479] * 1
+    + [0.176479] * 1
+    + [0.153273] * 1
+    + [0.195836] * 1
+    + [0.0780405] * 1
+    + [0.150202] * 1
+    + [0.17846] * 1
+    + [0.164886] * 1
+    + [0.175758] * 1
+    + [0.10836] * 1
+    + [0.160243] * 1
+    + [0.183373] * 1
+    + [0.171818] * 1
+    + [0.194848] * 1
+    + [0.111899] * 1
+    + [0.170704] * 1
+    + [0.188455] * 1
+    + [0.178164] * 1
+    + [0.209113] * 1
+    + [0.105241] * 1
+    + [0.180637] * 1
+    + [0.192206] * 1
+    + [0.186096] * 1
+    + [0.211962] * 1
+    + [0.112019] * 1
+    + [0.180344] * 1
+    + [0.195684] * 1
+    + [0.190778] * 1
+    + [0.218259] * 1
+    + [0.118516] * 1
+    + [0.207786] * 1
+    + [0.204474] * 1
+    + [0.207048] * 1
+    + [0.225913] * 1
+    + [0.111325] * 1
+    + [0.147875] * 1
+    + [0.195625] * 1
+    + [0.173326] * 1
+    + [0.175449] * 1
+    + [0.104087] * 1
+    + [0.153645] * 1
+    + [0.161263] * 1
+    + [0.165499] * 1
+    + [0.171758] * 1
+    + [0.175789] * 1
+    + [0.180657] * 1
+    + [0.184563] * 1
+    + [0.187876] * 1
+    + [0.191762] * 1
+    + [0.19426] * 1
+    + [0.197959] * 1
+    + [0.199021] * 1
+    + [0.204428] * 1
+    + [0.195709] * 1
+    + [0.151751] * 1
+    + [0.171477] * 1
+    + [0.165509] * 1
+    + [0.172565] * 1
+    + [0.172961] * 1
+    + [0.175534] * 1
+    + [0.177989] * 1
+    + [0.18026] * 1
+    + [0.181898] * 1
+    + [0.183912] * 1
+    + [0.185654] * 1
+    + [0.187515] * 1
+    + [0.190408] * 1
+    + [0.188794] * 1
+    + [0.193699] * 1
+    + [0.192287] * 1
+    + [0.19755] * 1
+    + [0.190943] * 1
+    + [0.218553] * 1
+    + [0.161085] * 1
+    + [0.373086] * 1
+    + [0.122495] * 1
+    + [0.21103] * 1
+    + [1] * 1
+    + [0.138686] * 1
+    + [0.0545171] * 1
+    + [1] * 1
+    + [1] * 1
+    + [0.227945] * 1
+    + [0.0122872] * 1
+    + [0.00437334] * 1
+    + [0.00363533] * 1
+    + [1] * 1
+    + [1] * 1
+)
 
 
 #
@@ -51,15 +181,15 @@ ExtSvc = []  # list of external services
 
 # Event counter
 from Configurables import EventCounter
-eventCounter = EventCounter("EventCounter",
-                            OutputLevel=INFO,
-                            Frequency=1)
+
+eventCounter = EventCounter("EventCounter", OutputLevel=INFO, Frequency=1)
 TopAlg += [eventCounter]
 # add a message sink service if you want a summary table at the end (not needed..)
 # ExtSvc += ["Gaudi::Monitoring::MessageSvcSink"]
 
 # CPU information
 from Configurables import AuditorSvc, ChronoAuditor
+
 chra = ChronoAuditor()
 audsvc = AuditorSvc()
 audsvc.Auditors = [chra]
@@ -71,15 +201,17 @@ ExtSvc += [audsvc]
 # if K4GEO is empty, this should use relative path to working directory
 from Configurables import GeoSvc
 import os
-geoservice = GeoSvc("GeoSvc",
-                    OutputLevel=INFO
-                    # OutputLevel=DEBUG  # set to DEBUG to print dd4hep::DEBUG messages in k4geo C++ drivers
-                    )
 
-path_to_detector = os.environ.get("K4GEO", "") + "/FCCee/ALLEGRO/compact/ALLEGRO_o1_v03/"
-detectors_to_use = [
-    'ALLEGRO_o1_v03.xml'
-]
+geoservice = GeoSvc(
+    "GeoSvc",
+    OutputLevel=INFO,
+    # OutputLevel=DEBUG  # set to DEBUG to print dd4hep::DEBUG messages in k4geo C++ drivers
+)
+
+path_to_detector = (
+    os.environ.get("K4GEO", "") + "/FCCee/ALLEGRO/compact/ALLEGRO_o1_v03/"
+)
+detectors_to_use = ["ALLEGRO_o1_v03.xml"]
 geoservice.detectors = [
     os.path.join(path_to_detector, _det) for _det in detectors_to_use
 ]
@@ -87,25 +219,26 @@ ExtSvc += [geoservice]
 
 # retrieve subdetector IDs
 import xml.etree.ElementTree as ET
-tree = ET.parse(path_to_detector + 'DectDimensions.xml')
+
+tree = ET.parse(path_to_detector + "DectDimensions.xml")
 root = tree.getroot()
 IDs = {}
-for constant in root.find('define').findall('constant'):
+for constant in root.find("define").findall("constant"):
     if (
-        constant.get('name') == 'DetID_VXD_Barrel'
-        or constant.get('name') == 'DetID_VXD_Disks'
-        or constant.get('name') == 'DetID_DCH'
-        or constant.get('name') == 'DetID_SiWr_Barrel'
-        or constant.get('name') == 'DetID_SiWr_Disks'
-        or constant.get('name') == 'DetID_ECAL_Barrel'
-        or constant.get('name') == 'DetID_ECAL_Endcap'
-        or constant.get('name') == 'DetID_HCAL_Barrel'
-        or constant.get('name') == 'DetID_HCAL_Endcap'
-        or constant.get('name') == 'DetID_Muon_Barrel'
+        constant.get("name") == "DetID_VXD_Barrel"
+        or constant.get("name") == "DetID_VXD_Disks"
+        or constant.get("name") == "DetID_DCH"
+        or constant.get("name") == "DetID_SiWr_Barrel"
+        or constant.get("name") == "DetID_SiWr_Disks"
+        or constant.get("name") == "DetID_ECAL_Barrel"
+        or constant.get("name") == "DetID_ECAL_Endcap"
+        or constant.get("name") == "DetID_HCAL_Barrel"
+        or constant.get("name") == "DetID_HCAL_Endcap"
+        or constant.get("name") == "DetID_Muon_Barrel"
     ):
-        IDs[constant.get("name")[6:]] = int(constant.get('value'))
-    if (constant.get('name') == 'DetID_Muon_Endcap_1'):
-        IDs[constant.get("name")[6:-2]] = int(constant.get('value'))
+        IDs[constant.get("name")[6:]] = int(constant.get("value"))
+    if constant.get("name") == "DetID_Muon_Endcap_1":
+        IDs[constant.get("name")[6:-2]] = int(constant.get("value"))
 # debug
 print("Subdetector IDs:")
 print(IDs)
@@ -113,6 +246,7 @@ print(IDs)
 # Input/Output handling
 from k4FWCore import IOSvc
 from Configurables import EventDataSvc
+
 io_svc = IOSvc("IOSvc")
 io_svc.Input = inputfile
 io_svc.Output = outputfile
@@ -121,59 +255,69 @@ ExtSvc += [EventDataSvc("EventDataSvc")]
 # Calorimeter digitisation (merging hits into cells, EM scale calibration via sampling fractions)
 
 # - ECAL readouts
-ecalBarrelReadoutName = "ECalBarrelModuleThetaMerged"      # barrel, original segmentation (baseline)
-ecalEndcapReadoutName = "ECalEndcapTurbine"                # endcap, turbine-like (baseline)
+ecalBarrelReadoutName = (
+    "ECalBarrelModuleThetaMerged"  # barrel, original segmentation (baseline)
+)
+ecalEndcapReadoutName = "ECalEndcapTurbine"  # endcap, turbine-like (baseline)
 # - HCAL readouts
 if runHCal:
-    hcalBarrelReadoutName = "HCalBarrelReadout"            # barrel, original segmentation (phi-theta)
+    hcalBarrelReadoutName = (
+        "HCalBarrelReadout"  # barrel, original segmentation (phi-theta)
+    )
     # hcalBarrelReadoutName = "HCalBarrelReadoutPhiRow"    # barrel, alternative segmentation (phi-row)
-    hcalEndcapReadoutName = "HCalEndcapReadout"            # endcap, original segmentation
+    hcalEndcapReadoutName = "HCalEndcapReadout"  # endcap, original segmentation
 else:
     hcalBarrelReadoutName = ""
     hcalEndcapReadoutName = ""
 
 # - EM scale calibration (sampling fraction)
 from Configurables import CalibrateInLayersTool
+
 #   * ECAL barrel
-calibEcalBarrel = CalibrateInLayersTool("CalibrateECalBarrel",
-                                        samplingFraction=ecalBarrelSamplingFraction,
-                                        readoutName=ecalBarrelReadoutName,
-                                        layerFieldName="layer")
+calibEcalBarrel = CalibrateInLayersTool(
+    "CalibrateECalBarrel",
+    samplingFraction=ecalBarrelSamplingFraction,
+    readoutName=ecalBarrelReadoutName,
+    layerFieldName="layer",
+)
 #   * ECAL endcap
-calibEcalEndcap = CalibrateInLayersTool("CalibrateECalEndcap",
-                                        samplingFraction=ecalEndcapSamplingFraction,
-                                        readoutName=ecalEndcapReadoutName,
-                                        layerFieldName="layer")
+calibEcalEndcap = CalibrateInLayersTool(
+    "CalibrateECalEndcap",
+    samplingFraction=ecalEndcapSamplingFraction,
+    readoutName=ecalEndcapReadoutName,
+    layerFieldName="layer",
+)
 
 if runHCal:
     from Configurables import CalibrateCaloHitsTool
+
     # HCAL barrel
     calibHCalBarrel = CalibrateCaloHitsTool(
-        "CalibrateHCalBarrel", invSamplingFraction="29.4202")
+        "CalibrateHCalBarrel", invSamplingFraction="29.4202"
+    )
     # HCAL endcap
     calibHCalEndcap = CalibrateCaloHitsTool(
-        "CalibrateHCalEndcap", invSamplingFraction="29.4202")  # FIXME: to be updated for ddsim
+        "CalibrateHCalEndcap", invSamplingFraction="29.4202"
+    )  # FIXME: to be updated for ddsim
 
 # - cell positioning tools
 from Configurables import CellPositionsECalBarrelModuleThetaSegTool
+
 cellPositionEcalBarrelTool = CellPositionsECalBarrelModuleThetaSegTool(
-    "CellPositionsECalBarrel",
-    readoutName=ecalBarrelReadoutName,
-    OutputLevel=INFO
+    "CellPositionsECalBarrel", readoutName=ecalBarrelReadoutName, OutputLevel=INFO
 )
 
 # the noise tool needs the positioning tool, but if I reuse the previous one the code crashes..
 cellPositionEcalBarrelToolForNoise = CellPositionsECalBarrelModuleThetaSegTool(
     "CellPositionsECalBarrelForNoise",
     readoutName=ecalBarrelReadoutName,
-    OutputLevel=INFO
+    OutputLevel=INFO,
 )
 
 from Configurables import CellPositionsECalEndcapTurbineSegTool
+
 cellPositionEcalEndcapTool = CellPositionsECalEndcapTurbineSegTool(
-    "CellPositionsECalEndcap",
-    readoutName=ecalEndcapReadoutName,
-    OutputLevel=INFO
+    "CellPositionsECalEndcap", readoutName=ecalEndcapReadoutName, OutputLevel=INFO
 )
 
 # in principle not needed - have to make c++ code of noise tool not fail if position tool is None
@@ -181,23 +325,24 @@ cellPositionEcalEndcapTool = CellPositionsECalEndcapTurbineSegTool(
 cellPositionEcalEndcapToolForNoise = CellPositionsECalEndcapTurbineSegTool(
     "CellPositionsECalEndcapForNoise",
     readoutName=ecalEndcapReadoutName,
-    OutputLevel=INFO
+    OutputLevel=INFO,
 )
 
 if runHCal:
     from Configurables import CellPositionsHCalPhiThetaSegTool
+
     cellPositionHCalBarrelTool = CellPositionsHCalPhiThetaSegTool(
         "CellPositionsHCalBarrel",
         readoutName=hcalBarrelReadoutName,
         detectorName="HCalBarrel",
-        OutputLevel=INFO
+        OutputLevel=INFO,
     )
     cellPositionHCalEndcapTool = CellPositionsHCalPhiThetaSegTool(
         "CellPositionsHCalEndcap",
         readoutName=hcalEndcapReadoutName,
         detectorName="HCalThreePartsEndcap",
         numLayersHCalThreeParts=[6, 9, 22],
-        OutputLevel=INFO
+        OutputLevel=INFO,
     )
 
 # - noise tool
@@ -205,29 +350,35 @@ if addNoise:
     ecalBarrelNoisePath = "elecNoise_ecalBarrelFCCee_theta.root"
     ecalBarrelNoiseRMSHistName = "h_elecNoise_fcc_"
     from Configurables import NoiseCaloCellsFromFileBarrelTool
-    ecalBarrelNoiseTool = NoiseCaloCellsFromFileBarrelTool("ecalBarrelNoiseTool",
-                                                           cellPositionsTool=cellPositionEcalBarrelToolForNoise,
-                                                           readoutName=ecalBarrelReadoutName,
-                                                           noiseFileName=ecalBarrelNoisePath,
-                                                           elecNoiseRMSHistoName=ecalBarrelNoiseRMSHistName,
-                                                           setNoiseOffset=False,
-                                                           activeFieldName="layer",
-                                                           addPileup=False,
-                                                           filterNoiseThreshold=1,
-                                                           useAbsInFilter=True,
-                                                           numHistograms=ecalBarrelLayers,
-                                                           scaleFactor=1 / 1000.,  # MeV to GeV
-                                                           OutputLevel=INFO)
+
+    ecalBarrelNoiseTool = NoiseCaloCellsFromFileBarrelTool(
+        "ecalBarrelNoiseTool",
+        cellPositionsTool=cellPositionEcalBarrelToolForNoise,
+        readoutName=ecalBarrelReadoutName,
+        noiseFileName=ecalBarrelNoisePath,
+        elecNoiseRMSHistoName=ecalBarrelNoiseRMSHistName,
+        setNoiseOffset=False,
+        activeFieldName="layer",
+        addPileup=False,
+        filterNoiseThreshold=1,
+        useAbsInFilter=True,
+        numHistograms=ecalBarrelLayers,
+        scaleFactor=1 / 1000.0,  # MeV to GeV
+        OutputLevel=INFO,
+    )
 
     from Configurables import TubeLayerModuleThetaCaloTool
-    ecalBarrelGeometryTool = TubeLayerModuleThetaCaloTool("ecalBarrelGeometryTool",
-                                                          readoutName=ecalBarrelReadoutName,
-                                                          activeVolumeName="LAr_sensitive",
-                                                          activeFieldName="layer",
-                                                          activeVolumesNumber=ecalBarrelLayers,
-                                                          fieldNames=["system"],
-                                                          fieldValues=[IDs["ECAL_Barrel"]],
-                                                          OutputLevel=INFO)
+
+    ecalBarrelGeometryTool = TubeLayerModuleThetaCaloTool(
+        "ecalBarrelGeometryTool",
+        readoutName=ecalBarrelReadoutName,
+        activeVolumeName="LAr_sensitive",
+        activeFieldName="layer",
+        activeVolumesNumber=ecalBarrelLayers,
+        fieldNames=["system"],
+        fieldValues=[IDs["ECAL_Barrel"]],
+        OutputLevel=INFO,
+    )
     ecalEndcapNoisePath = "elecNoise_ecalendcap.root"
     ecalEndcapNoiseRMSHistName = "noise_endcap_wheel"
 
@@ -257,71 +408,82 @@ else:
 ecalBarrelPositionedCellsName = ecalBarrelReadoutName + "Positioned"
 ecalBarrelLinks = ecalBarrelPositionedCellsName + "SimCaloHitLinks"
 from Configurables import CreatePositionedCaloCells
-createEcalBarrelCells = CreatePositionedCaloCells("CreatePositionedECalBarrelCells",
-                                                  doCellCalibration=True,
-                                                  calibTool=calibEcalBarrel,
-                                                  positionsTool=cellPositionEcalBarrelTool,
-                                                  addCrosstalk=False,
-                                                  crosstalkTool=None,
-                                                  addCellNoise=False,
-                                                  filterCellNoise=False,
-                                                  OutputLevel=INFO,
-                                                  hits=ecalBarrelReadoutName,
-                                                  cells=ecalBarrelPositionedCellsName,
-                                                  links=ecalBarrelLinks
-                                                  )
+
+createEcalBarrelCells = CreatePositionedCaloCells(
+    "CreatePositionedECalBarrelCells",
+    doCellCalibration=True,
+    calibTool=calibEcalBarrel,
+    positionsTool=cellPositionEcalBarrelTool,
+    addCrosstalk=False,
+    crosstalkTool=None,
+    addCellNoise=False,
+    filterCellNoise=False,
+    OutputLevel=INFO,
+    hits=ecalBarrelReadoutName,
+    cells=ecalBarrelPositionedCellsName,
+    links=ecalBarrelLinks,
+)
 TopAlg += [createEcalBarrelCells]
 
 # Create cells in ECal endcap (needed if one wants to apply cell calibration,
 # which is not performed by ddsim)
 ecalEndcapPositionedCellsName = ecalEndcapReadoutName + "Positioned"
 ecalEndcapLinks = ecalEndcapPositionedCellsName + "SimCaloHitLinks"
-createEcalEndcapCells = CreatePositionedCaloCells("CreatePositionedECalEndcapCells",
-                                                  doCellCalibration=True,
-                                                  positionsTool=cellPositionEcalEndcapTool,
-                                                  calibTool=calibEcalEndcap,
-                                                  crosstalkTool=None,
-                                                  addCrosstalk=False,
-                                                  addCellNoise=False,
-                                                  filterCellNoise=False,
-                                                  OutputLevel=INFO,
-                                                  hits=ecalEndcapReadoutName,
-                                                  cells=ecalEndcapPositionedCellsName,
-                                                  links=ecalEndcapLinks)
+createEcalEndcapCells = CreatePositionedCaloCells(
+    "CreatePositionedECalEndcapCells",
+    doCellCalibration=True,
+    positionsTool=cellPositionEcalEndcapTool,
+    calibTool=calibEcalEndcap,
+    crosstalkTool=None,
+    addCrosstalk=False,
+    addCellNoise=False,
+    filterCellNoise=False,
+    OutputLevel=INFO,
+    hits=ecalEndcapReadoutName,
+    cells=ecalEndcapPositionedCellsName,
+    links=ecalEndcapLinks,
+)
 TopAlg += [createEcalEndcapCells]
 
 if addNoise:
     # cells with noise not filtered
-    ecalBarrelCellsNoiseLinks = ecalBarrelPositionedCellsName + "WithNoise" + "SimCaloHitLinks"
-    createEcalBarrelCellsNoise = CreatePositionedCaloCells("CreatePositionedECalBarrelCellsWithNoise",
-                                                           doCellCalibration=True,
-                                                           calibTool=calibEcalBarrel,
-                                                           positionsTool=cellPositionEcalBarrelTool,
-                                                           addCellNoise=True,
-                                                           filterCellNoise=False,
-                                                           noiseTool=ecalBarrelNoiseTool,
-                                                           geometryTool=ecalBarrelGeometryTool,
-                                                           OutputLevel=INFO,
-                                                           hits=ecalBarrelReadoutName,
-                                                           cells=ecalBarrelPositionedCellsName + "WithNoise",
-                                                           links=ecalBarrelCellsNoiseLinks)
+    ecalBarrelCellsNoiseLinks = (
+        ecalBarrelPositionedCellsName + "WithNoise" + "SimCaloHitLinks"
+    )
+    createEcalBarrelCellsNoise = CreatePositionedCaloCells(
+        "CreatePositionedECalBarrelCellsWithNoise",
+        doCellCalibration=True,
+        calibTool=calibEcalBarrel,
+        positionsTool=cellPositionEcalBarrelTool,
+        addCellNoise=True,
+        filterCellNoise=False,
+        noiseTool=ecalBarrelNoiseTool,
+        geometryTool=ecalBarrelGeometryTool,
+        OutputLevel=INFO,
+        hits=ecalBarrelReadoutName,
+        cells=ecalBarrelPositionedCellsName + "WithNoise",
+        links=ecalBarrelCellsNoiseLinks,
+    )
     TopAlg += [createEcalBarrelCellsNoise]
 
     # cells with noise filtered
-    ecalBarrelCellsNoiseFilteredLinks = ecalBarrelPositionedCellsName + "WithNoiseFiltered" + "SimCaloHitLinks"
-    createEcalBarrelCellsNoiseFiltered = CreatePositionedCaloCells("CreatePositionedECalBarrelCellsWithNoiseFiltered",
-                                                                   doCellCalibration=True,
-                                                                   calibTool=calibEcalBarrel,
-                                                                   positionsTool=cellPositionEcalBarrelTool,
-                                                                   addCellNoise=True,
-                                                                   filterCellNoise=True,
-                                                                   noiseTool=ecalBarrelNoiseTool,
-                                                                   geometryTool=ecalBarrelGeometryTool,
-                                                                   OutputLevel=INFO,
-                                                                   hits=ecalBarrelReadoutName,  # uncalibrated & unpositioned cells without noise
-                                                                   cells=ecalBarrelPositionedCellsName + "WithNoiseFiltered",
-                                                                   links=ecalBarrelCellsNoiseFilteredLinks
-                                                                   )
+    ecalBarrelCellsNoiseFilteredLinks = (
+        ecalBarrelPositionedCellsName + "WithNoiseFiltered" + "SimCaloHitLinks"
+    )
+    createEcalBarrelCellsNoiseFiltered = CreatePositionedCaloCells(
+        "CreatePositionedECalBarrelCellsWithNoiseFiltered",
+        doCellCalibration=True,
+        calibTool=calibEcalBarrel,
+        positionsTool=cellPositionEcalBarrelTool,
+        addCellNoise=True,
+        filterCellNoise=True,
+        noiseTool=ecalBarrelNoiseTool,
+        geometryTool=ecalBarrelGeometryTool,
+        OutputLevel=INFO,
+        hits=ecalBarrelReadoutName,  # uncalibrated & unpositioned cells without noise
+        cells=ecalBarrelPositionedCellsName + "WithNoiseFiltered",
+        links=ecalBarrelCellsNoiseFilteredLinks,
+    )
     TopAlg += [createEcalBarrelCellsNoiseFiltered]
 
     # can enable only when geometry tool for ecal endcap is implemented
@@ -362,37 +524,40 @@ if runHCal:
     # Apply calibration and positioning to cells in HCal barrel
     hcalBarrelPositionedCellsName = hcalBarrelReadoutName + "Positioned"
     hcalBarrelLinks = hcalBarrelPositionedCellsName + "SimCaloHitLinks"
-    createHCalBarrelCells = CreatePositionedCaloCells("CreatePositionedHCalBarrelCells",
-                                                      doCellCalibration=True,
-                                                      calibTool=calibHCalBarrel,
-                                                      positionsTool=cellPositionHCalBarrelTool,
-                                                      addCellNoise=False,
-                                                      filterCellNoise=False,
-                                                      hits=hcalBarrelReadoutName,
-                                                      cells=hcalBarrelPositionedCellsName,
-                                                      links=hcalBarrelLinks,
-                                                      OutputLevel=INFO)
+    createHCalBarrelCells = CreatePositionedCaloCells(
+        "CreatePositionedHCalBarrelCells",
+        doCellCalibration=True,
+        calibTool=calibHCalBarrel,
+        positionsTool=cellPositionHCalBarrelTool,
+        addCellNoise=False,
+        filterCellNoise=False,
+        hits=hcalBarrelReadoutName,
+        cells=hcalBarrelPositionedCellsName,
+        links=hcalBarrelLinks,
+        OutputLevel=INFO,
+    )
     TopAlg += [createHCalBarrelCells]
 
     # Apply calibration and positioning to cells in HCal endcap
     hcalEndcapPositionedCellsName = hcalEndcapReadoutName + "Positioned"
     hcalEndcapLinks = hcalEndcapPositionedCellsName + "SimCaloHitLinks"
-    createHCalEndcapCells = CreatePositionedCaloCells("CreatePositionedHCalEndcapCells",
-                                                      doCellCalibration=True,
-                                                      calibTool=calibHCalEndcap,
-                                                      addCellNoise=False,
-                                                      filterCellNoise=False,
-                                                      positionsTool=cellPositionHCalEndcapTool,
-                                                      OutputLevel=INFO,
-                                                      hits=hcalEndcapReadoutName,
-                                                      cells=hcalEndcapPositionedCellsName,
-                                                      links=hcalEndcapLinks)
+    createHCalEndcapCells = CreatePositionedCaloCells(
+        "CreatePositionedHCalEndcapCells",
+        doCellCalibration=True,
+        calibTool=calibHCalEndcap,
+        addCellNoise=False,
+        filterCellNoise=False,
+        positionsTool=cellPositionHCalEndcapTool,
+        OutputLevel=INFO,
+        hits=hcalEndcapReadoutName,
+        cells=hcalEndcapPositionedCellsName,
+        links=hcalEndcapLinks,
+    )
     TopAlg += [createHCalEndcapCells]
 
 
 # Configure output
-io_svc.outputCommands = ["keep *",
-                         "drop emptyCaloCells"]
+io_svc.outputCommands = ["keep *", "drop emptyCaloCells"]
 
 # drop the uncalibrated cells
 if dropUncalibratedCells:
@@ -432,9 +597,10 @@ if not saveHits or not saveCells:
 print(TopAlg)
 print(ExtSvc)
 from k4FWCore import ApplicationMgr
+
 applicationMgr = ApplicationMgr(
     TopAlg=TopAlg,
-    EvtSel='NONE',
+    EvtSel="NONE",
     EvtMax=Nevts,
     ExtSvc=ExtSvc,
     StopOnSignal=True,

--- a/RecFCCeeCalorimeter/tests/options/test_noise.sh
+++ b/RecFCCeeCalorimeter/tests/options/test_noise.sh
@@ -27,10 +27,10 @@ if ! test -f ./elecNoise_ecalBarrelFCCee_theta.root; then  # assumes that if the
 fi
 
 # run the DIGI step to add noise
-# debug
-nm -C libRecFCCeeCalorimeter.so | grep Barrel
-# end debug
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd ) # workaround to have ctests working
+# debug
+nm -C $SCRIPT_DIR/../../RecFCCeeCalorimeter/libk4RecFCCeeCalorimeterPlugins.so | grep FromFile
+# end debug
 if ! test -f noise_digi.root; then
     k4run $SCRIPT_DIR/test_noise.py --IOSvc.Input=noise_sim.root --IOSvc.Output=noise_digi.root || exit 1
 fi

--- a/RecFCCeeCalorimeter/tests/options/test_noise.sh
+++ b/RecFCCeeCalorimeter/tests/options/test_noise.sh
@@ -27,6 +27,9 @@ if ! test -f ./elecNoise_ecalBarrelFCCee_theta.root; then  # assumes that if the
 fi
 
 # run the DIGI step to add noise
+# debug
+nm -C libRecFCCeeCalorimeter.so | grep Barrel
+# end debug
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd ) # workaround to have ctests working
 if ! test -f noise_digi.root; then
     k4run $SCRIPT_DIR/test_noise.py --IOSvc.Input=noise_sim.root --IOSvc.Output=noise_digi.root || exit 1

--- a/RecFCCeeCalorimeter/tests/options/test_noise.sh
+++ b/RecFCCeeCalorimeter/tests/options/test_noise.sh
@@ -29,7 +29,7 @@ fi
 # run the DIGI step to add noise
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd ) # workaround to have ctests working
 # debug
-nm -C $SCRIPT_DIR/../../RecFCCeeCalorimeter/libk4RecFCCeeCalorimeterPlugins.so | grep FromFile
+nm -C $SCRIPT_DIR/../../install/lib/libk4RecFCCeeCalorimeterPlugins.so | grep FromFile
 # end debug
 if ! test -f noise_digi.root; then
     k4run $SCRIPT_DIR/test_noise.py --IOSvc.Input=noise_sim.root --IOSvc.Output=noise_digi.root || exit 1

--- a/RecFCCeeCalorimeter/tests/options/test_noise.sh
+++ b/RecFCCeeCalorimeter/tests/options/test_noise.sh
@@ -28,9 +28,6 @@ fi
 
 # run the DIGI step to add noise
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd ) # workaround to have ctests working
-# debug
-nm -C $SCRIPT_DIR/../../install/lib/libk4RecFCCeeCalorimeterPlugins.so | grep FromFile
-# end debug
 if ! test -f noise_digi.root; then
     k4run $SCRIPT_DIR/test_noise.py --IOSvc.Input=noise_sim.root --IOSvc.Output=noise_digi.root || exit 1
 fi

--- a/RecFCCeeCalorimeter/tests/options/test_noise.sh
+++ b/RecFCCeeCalorimeter/tests/options/test_noise.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# Define the function for downloading files
+# Attempt to download the file using wget, exit the script if wget failed
+download_file() {
+  local url="$1"
+  wget "$url" || { echo "Download failed"; exit 1; }
+}
+
+# Check that the Key4hep environment is set
+if [[ -z "${KEY4HEP_STACK}" ]]; then
+  echo "Error: Key4hep environment not set"
+  exit 1
+fi
+
+# run ddsim
+if ! test -f ./noise_sim.root; then
+    echo "Generating events and performing the Geant4 simulation with ddsim"
+    ddsim --enableGun --gun.distribution uniform --gun.momentumMin "10*GeV" --gun.momentumMax "10*GeV" --gun.thetaMin "0.5*deg" --gun.thetaMax "1.5*deg" --gun.particle geantino --numberOfEvents 1 --outputFile noise_sim.root --random.enableEventSeed --random.seed 4255 --compactFile $K4GEO/FCCee/ALLEGRO/compact/ALLEGRO_o1_v03/ALLEGRO_o1_v03.xml || exit 1
+fi
+
+# get the files needed for noise
+if ! test -f ./elecNoise_ecalBarrelFCCee_theta.root; then  # assumes that if the last file exists, all the other as well
+  echo "Downloading files needed to add noise"
+  download_file "https://fccsw.web.cern.ch/fccsw/filesForSimDigiReco/ALLEGRO/ALLEGRO_o1_v03/elecNoise_ecalendcap.root"
+  download_file "https://fccsw.web.cern.ch/fccsw/filesForSimDigiReco/ALLEGRO/ALLEGRO_o1_v03/elecNoise_ecalBarrelFCCee_theta.root"
+fi
+
+# run the DIGI step to add noise
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd ) # workaround to have ctests working
+if ! test -f noise_digi.root; then
+    k4run $SCRIPT_DIR/test_noise.py --IOSvc.Input=noise_sim.root --IOSvc.Output=noise_digi.root || exit 1
+fi


### PR DESCRIPTION

BEGINRELEASENOTES
- factorise duplicate code into a base tool
- Add a test for the noise from file tools
ENDRELEASENOTES
The recently added noise from file tool for the ecal endcap contains a lot of duplicate code of the same tool for the barrel, of which it is largely a copy/paste
This PR factorises the common code into a base tool and two new derived tools for barrel and endcap. Once merged, I will remove the superseded tools and adapt the digi/reco scripts to use the new ones 