### PR TITLE
speed up topoclustering

### DIFF
--- a/RecFCCeeCalorimeter/src/components/CaloTopoClusterFCCee.cpp
+++ b/RecFCCeeCalorimeter/src/components/CaloTopoClusterFCCee.cpp
@@ -119,372 +119,408 @@ StatusCode CaloTopoClusterFCCee::initialize() {
 
 StatusCode CaloTopoClusterFCCee::execute(const EventContext&) const {
 
-  // Create output collections
+  // create output collections
   edm4hep::ClusterCollection* outClusters = m_clusterCollection.createAndPut();
   edm4hep::CalorimeterHitCollection* outClusterCells = nullptr;
   if (m_createClusterCellCollection) {
     outClusterCells = m_clusterCellsCollection.createAndPut();
   }
 
-  // Get input collection with calorimeter cells
-  edm4hep::CalorimeterHitCollection* inCells = new edm4hep::CalorimeterHitCollection();
+  // get input collection with calorimeter cells and build flat cell cache
+  m_cellCache.clear();
+  m_cellCache.reserve(2000000);
+  std::vector<FastCell> allCells;
+  allCells.reserve(2000000);
+
   for (size_t ih = 0; ih < m_cellCollectionHandles.size(); ih++) {
-    verbose() << "Processing collection " << ih << endmsg;
-    const edm4hep::CalorimeterHitCollection* coll = m_cellCollectionHandles[ih]->get();
+
+    const auto* coll = m_cellCollectionHandles[ih]->get();
     for (const auto& hit : *coll) {
-      auto newCell = hit.clone();
-      newCell.setType(0); // topoclustering will set the type of clustered cells to 1-2-3 depending whether they are
-                          // seed/neighbours/last neighbours
-      // note that this overwrites the type information from the digitiser, which encodes calorimeter type / layout /
-      // layer
-      inCells->push_back(newCell);
+
+      // cache EDM hit
+      const uint64_t cID = hit.getCellID();
+      m_cellCache.emplace(cID, hit);
+
+      // create fast flat cell
+      float energy = hit.getEnergy();
+      auto pos = hit.getPosition();
+      auto [rms, offset] = m_noiseTool->getNoisePerCell(cID);
+      float sovern = (rms > 0.) ? (std::fabs(energy - offset) / rms) : 999999.;
+      allCells.emplace_back(FastCell{cID, energy, (float)pos.x, (float)pos.y, (float)pos.z, 0, sovern});
     }
   }
-  if (inCells->empty()) {
+
+  // skip event if no cells to cluster
+  if (allCells.empty()) {
     debug() << "No active cells, skipping event..." << endmsg;
     return StatusCode::SUCCESS;
   }
+  debug() << "Number of active cells                               : " << allCells.size() << endmsg;
 
-  debug() << "Number of active cells                               : " << inCells->size() << endmsg;
+  // find seeds (cells with S/N > seedSigma)
+  // and sort by energy in reversed order
+  std::vector<FastCell> seedCellsVec;
+  seedCellsVec.reserve(allCells.size() / 10);
 
-  // Find seeds
-  edm4hep::CalorimeterHitCollection seedCells = findSeeds(inCells);
-  debug() << "Number of seeds found                                : " << seedCells.size() << endmsg;
-
-  // Build protoclusters (find neighbouring cells)
-  std::map<uint32_t, edm4hep::CalorimeterHitCollection> protoClusters;
-  {
-    StatusCode sc = buildProtoClusters(seedCells, inCells, protoClusters);
-    if (sc.isFailure()) {
-      error() << "Unable to build the protoclusters!" << endmsg;
-      return StatusCode::FAILURE;
+  for (const auto& cell : allCells) {
+    if (cell.SoverN > m_seedSigma) {
+      seedCellsVec.push_back(cell);
     }
   }
 
-  // Build clusters
-  debug() << "Building " << protoClusters.size() << " clusters" << endmsg;
+  std::sort(seedCellsVec.begin(), seedCellsVec.end(),
+            [](const FastCell& a, const FastCell& b) { return a.energy > b.energy; });
+
+  debug() << "Number of seeds found                                : " << seedCellsVec.size() << endmsg;
+
+  // build clusters (find neighbouring cells)
+  FastClusterMap clusters;
+  clusters.reserve(seedCellsVec.size());
+
+  StatusCode sc = buildClusters(seedCellsVec, allCells, clusters);
+  if (sc.isFailure()) {
+    error() << "Unable to build clusters!" << endmsg;
+    return StatusCode::FAILURE;
+  }
+
+  // keep only clusters with sufficient energy and build EDM output clusters
+  debug() << "Building " << clusters.size() << " EDM clusters" << endmsg;
   double checkTotEnergy = 0.;
   double checkTotEnergyAboveThreshold = 0.;
   int clusterWithMixedCells = 0;
-  for (const auto& protoCluster : protoClusters) {
 
-    // calculate cluster energy and decide whether to keep it
+  for (auto& [clusterId, cluster] : clusters) {
+
     double clusterEnergy = 0.;
-    for (const auto& protoCell : protoCluster.second) {
-      clusterEnergy += protoCell.getEnergy();
+    for (const auto& c : cluster) {
+      clusterEnergy += c.energy;
     }
-    verbose() << "Cluster energy:     " << clusterEnergy << endmsg;
     checkTotEnergy += clusterEnergy;
+    verbose() << "Cluster energy:     " << clusterEnergy << endmsg;
     if (clusterEnergy < m_minClusterEnergy) {
       continue;
     }
 
     // build cluster
-    debug() << "Building cluster with ID: " << protoCluster.first << endmsg;
-    edm4hep::MutableCluster cluster;
+    debug() << "Building cluster with ID: " << clusterId << endmsg;
+    edm4hep::MutableCluster outCluster;
 
     // set cluster energy
-    cluster.setEnergy(clusterEnergy);
-    checkTotEnergyAboveThreshold += cluster.getEnergy();
+    outCluster.setEnergy(clusterEnergy);
 
     // loop over the cells attached to the cluster to calculate cluster barycenter and attach cells to cluster
-    double clusterPosX = 0.;
-    double clusterPosY = 0.;
-    double clusterPosZ = 0.;
-    double deltaR = 0.;
-    std::vector<double> cellPosPhi(protoCluster.second.size(), 0);
-    std::vector<double> cellPosTheta(protoCluster.second.size(), 0);
-    std::vector<double> cellEnergy(protoCluster.second.size(), 0);
-    double sumCellPhi = 0.;
-    double sumCellTheta = 0.;
-    std::map<int, int> system;
-    for (const auto& protoCell : protoCluster.second) {
-      // identify calo system
-      auto systemId = m_decoder->get(protoCell.getCellID(), m_indexSystem);
-      system[int(systemId)]++;
-      auto cellPos = dd4hep::Position(protoCell.getPosition().x, protoCell.getPosition().y, protoCell.getPosition().z);
+    double cx = 0, cy = 0, cz = 0;
 
-      clusterPosX += protoCell.getPosition().x * protoCell.getEnergy();
-      clusterPosY += protoCell.getPosition().y * protoCell.getEnergy();
-      clusterPosZ += protoCell.getPosition().z * protoCell.getEnergy();
-      cellPosPhi.push_back(cellPos.Phi());
-      cellPosTheta.push_back(cellPos.Theta());
-      cellEnergy.push_back(protoCell.getEnergy());
-      sumCellPhi += cellPos.Phi() * protoCell.getEnergy();
-      sumCellTheta += cellPos.Theta() * protoCell.getEnergy();
+    std::vector<double> phiVec;
+    std::vector<double> thetaVec;
+    std::vector<double> eVec;
+
+    phiVec.reserve(cluster.size());
+    thetaVec.reserve(cluster.size());
+    eVec.reserve(cluster.size());
+
+    double sumPhi = 0;
+    double sumTheta = 0;
+
+    std::map<int, int> system;
+
+    for (const auto& c : cluster) {
+
+      auto it = m_cellCache.find(c.cellID);
+      if (it == m_cellCache.end())
+        continue;
+
+      const auto& hit = it->second;
+
+      // identify calo system
+      auto sys = m_decoder->get(hit.getCellID(), m_indexSystem);
+      system[(int)sys]++;
+
+      // get position, calculate phi/theta
+      cx += c.x * c.energy;
+      cy += c.y * c.energy;
+      cz += c.z * c.energy;
+      dd4hep::Position pos(c.x, c.y, c.z);
+
+      phiVec.push_back(pos.Phi());
+      thetaVec.push_back(pos.Theta());
+      eVec.push_back(c.energy);
+
+      sumPhi += pos.Phi() * c.energy;
+      sumTheta += pos.Theta() * c.energy;
 
       if (m_createClusterCellCollection) {
-        auto cell = protoCell.clone();
-        outClusterCells->push_back(cell);
-        cluster.addToHits(cell);
+        auto edmCell = hit.clone();
+        outClusterCells->push_back(edmCell);
+        outCluster.addToHits(edmCell);
       } else {
-        for (size_t ih = 0; ih < m_cellCollectionHandles.size(); ih++) {
-          const edm4hep::CalorimeterHitCollection* coll = m_cellCollectionHandles[ih]->get();
-          for (const auto& hit : *coll) {
-            if (hit.getCellID() == protoCell.getCellID()) {
-              cluster.addToHits(hit);
-            }
-          }
-        }
+        outCluster.addToHits(hit);
       }
     }
 
-    // set cluster position (weighted barycentre of cell positions)
-    cluster.setPosition(
-        edm4hep::Vector3f(clusterPosX / clusterEnergy, clusterPosY / clusterEnergy, clusterPosZ / clusterEnergy));
+    outCluster.setPosition(edm4hep::Vector3f(cx / clusterEnergy, cy / clusterEnergy, cz / clusterEnergy));
 
-    // store deltaR of cluster in time for the moment..
-    sumCellPhi = sumCellPhi / clusterEnergy;
-    sumCellTheta = sumCellTheta / clusterEnergy;
-    for (size_t i = 0; i < cellEnergy.size(); ++i) {
-      deltaR += std::sqrt(std::pow(cellPosTheta[i] - sumCellTheta, 2) + std::pow(cellPosPhi[i] - sumCellPhi, 2)) *
-                cellEnergy[i];
+    sumPhi /= clusterEnergy;
+    sumTheta /= clusterEnergy;
+
+    double deltaR = 0.;
+    for (size_t i = 0; i < eVec.size(); i++) {
+      deltaR += std::sqrt(std::pow(thetaVec[i] - sumTheta, 2) + std::pow(phiVec[i] - sumPhi, 2)) * eVec[i];
     }
-    cluster.addToShapeParameters(deltaR / clusterEnergy);
+    outCluster.addToShapeParameters(deltaR / clusterEnergy);
 
-    outClusters->push_back(cluster);
+    outClusters->push_back(outCluster);
+
     if (system.size() > 1)
       clusterWithMixedCells++;
 
-    cellPosPhi.clear();
-    cellPosTheta.clear();
-    cellEnergy.clear();
+    checkTotEnergyAboveThreshold += clusterEnergy;
   }
 
   debug() << "Number of clusters with cells in E and HCal:        " << clusterWithMixedCells << endmsg;
   debug() << "Total energy of clusters:                           " << checkTotEnergy << endmsg;
-  debug() << "Total energy of clusters above threshold:                           " << checkTotEnergyAboveThreshold
-          << endmsg;
+  debug() << "Total energy of clusters above threshold:           " << checkTotEnergyAboveThreshold << endmsg;
   if (m_createClusterCellCollection) {
-    debug() << "Leftover cells :                                    " << inCells->size() - outClusterCells->size()
+    debug() << "Leftover cells :                                    " << allCells.size() - outClusterCells->size()
             << endmsg;
   }
 
-  delete inCells;
   return StatusCode::SUCCESS;
 }
 
-edm4hep::CalorimeterHitCollection
-CaloTopoClusterFCCee::findSeeds(const edm4hep::CalorimeterHitCollection* allCells) const {
+StatusCode CaloTopoClusterFCCee::buildClusters(const std::vector<FastCell>& seedCells,
+                                               const std::vector<FastCell>& allCells, FastClusterMap& clusters) const {
 
-  std::vector<edm4hep::CalorimeterHit> seedCellsVec;
-
-  for (const auto& cell : *allCells) {
-
-    if (this->msgLevel(MSG::VERBOSE)) {
-      verbose() << "cellID   = " << cell.getCellID() << endmsg;
-    }
-
-    // retrieve the noise const and offset assigned to cell
-    auto [rms, offset] = m_noiseTool->getNoisePerCell(cell.getCellID());
-    double threshold = offset + rms * m_seedSigma;
-
-    if (this->msgLevel(MSG::DEBUG)) {
-      debug() << "======================================" << endmsg;
-      debug() << "noise offset    = " << offset << " GeV " << endmsg;
-      debug() << "noise rms       = " << rms << " GeV " << endmsg;
-      debug() << "seed threshold  = " << threshold << " GeV " << endmsg;
-      debug() << "======================================" << endmsg;
-    }
-    if (std::fabs(cell.getEnergy()) > threshold) {
-      if (this->msgLevel(MSG::DEBUG)) {
-        debug() << "Found seed" << endmsg;
-      }
-      seedCellsVec.emplace_back(cell);
-    }
-  }
-
-  // Sort the seeds in decending order of their energy
-  std::sort(seedCellsVec.begin(), seedCellsVec.end(),
-            [](const auto& lhs, const auto& rhs) { return lhs.getEnergy() > rhs.getEnergy(); });
-
-  edm4hep::CalorimeterHitCollection seedCells;
-  seedCells.setSubsetCollection();
-  for (const auto& cell : seedCellsVec) {
-    seedCells.push_back(cell);
-  }
-
-  return seedCells;
-}
-
-StatusCode
-CaloTopoClusterFCCee::buildProtoClusters(const edm4hep::CalorimeterHitCollection& seedCells,
-                                         const edm4hep::CalorimeterHitCollection* allCells,
-                                         std::map<uint32_t, edm4hep::CalorimeterHitCollection>& protoClusters) const {
+  // will create clusters finding in allCells the neighbours of seedCells and
+  // of their own neighbours
+  // clusters will be saved in a map (clusters) of clusterId -> FastClusters
 
   verbose() << "Initial number of seeds to loop over: " << seedCells.size() << endmsg;
 
-  std::map<uint64_t, const edm4hep::CalorimeterHit> allCellsMap;
-  for (const auto& cell : *allCells) {
-    allCellsMap.emplace(cell.getCellID(), cell);
+  // build fast lookup (CellID -> FastCell)
+  std::unordered_map<uint64_t, const FastCell*> cellMap;
+  cellMap.reserve(allCells.size());
+  for (const auto& c : allCells) {
+    cellMap.emplace(c.cellID, &c);
   }
-  std::map<uint64_t, uint32_t> alreadyUsedCells;
 
-  // Loop over every seed in Calo to create first cluster
+  // initialise map of already used cells
+  std::unordered_map<uint64_t, uint32_t> used;
+  used.reserve(allCells.size());
+
+  // initialise map of clusterId -> set(cellIDs)
+  ClusterMaskMap clusterMembers;
+  clusterMembers.reserve(seedCells.size());
+
+  // loop over every seeds in calo to build a cluster (or merge with another cluster if appropriate)
   uint32_t seedCounter = 0;
-  for (const auto& seedCell : seedCells) {
-    seedCounter++;
-    verbose() << "Looking at seed: " << seedCounter << endmsg;
-    auto seedId = seedCell.getCellID();
-    auto cellInCluster = alreadyUsedCells.find(seedId);
-    if (cellInCluster != alreadyUsedCells.end()) {
-      verbose() << "Seed is already assigned to another cluster!" << endmsg;
+  for (const auto& seed : seedCells) {
+    ++seedCounter;
+    if (msgLevel() <= MSG::VERBOSE) {
+      verbose() << "Looking at seed: " << seedCounter << endmsg;
+    }
+
+    // skip already used seeds
+    if (used.count(seed.cellID)) {
+      if (msgLevel() <= MSG::VERBOSE) {
+        verbose() << "Seed is already assigned to another cluster!" << endmsg;
+      }
       continue;
     }
 
     uint32_t clusterId = seedCounter;
-    // new cluster starts with seed
-    // set cell type to 1 for seed cell
-    edm4hep::MutableCalorimeterHit clusteredCell = seedCell.clone();
-    clusteredCell.setType(1);
-    protoClusters[clusterId].push_back(clusteredCell);
-    alreadyUsedCells[seedId] = clusterId;
 
-    std::vector<std::vector<std::pair<uint64_t, uint32_t>>> nextNeighbours(100);
-    nextNeighbours[0] =
-        searchForNeighbours(seedId, clusterId, m_neighbourSigma, allCellsMap, alreadyUsedCells, protoClusters, true);
+    // create cluster
+    clusterMembers[clusterId].clear();
+    clusters[clusterId].clear();
+    clusterMembers[clusterId].reserve(256);
+    clusters[clusterId].reserve(256);
 
-    // first loop over seeds neighbours
-    verbose() << "Found " << nextNeighbours[0].size() << " neighbours.." << endmsg;
-    int it = 0;
-    while (nextNeighbours[it].size() > 0) {
-      it++;
-      nextNeighbours.emplace_back(std::vector<std::pair<uint64_t, uint>>{});
-      for (auto& id : nextNeighbours[it - 1]) {
-        if (id.first == 0) {
-          error() << "Building of cluster is stopped due to missing cell ID "
-                     "in neighbours map!"
-                  << endmsg;
-          return StatusCode::FAILURE;
+    // insert seed and set its type to 1
+    clusters[clusterId].push_back(seed);
+    clusters[clusterId].back().type = 1;
+    used[seed.cellID] = clusterId;
+    clusterMembers[clusterId].insert(seed.cellID);
+
+    // attach neighbours
+    // recursively find neighbours (nextLayer) of cells in current layer
+    std::vector<uint64_t> currentLayer;
+    std::vector<uint64_t> nextLayer;
+    currentLayer.reserve(1024);
+    nextLayer.reserve(1024);
+
+    // start with neighbours of seed
+    currentLayer.push_back(seed.cellID);
+
+    // the flag restartBFS is needed to restart the neighbour search
+    // after two clusters are merged and currentLayer is updated
+    bool restartBFS = false;
+    while (!currentLayer.empty()) {
+
+      nextLayer.clear();
+      restartBFS = false;
+
+      // loop over cells in currentLayer
+      for (uint64_t cid : currentLayer) {
+
+        if (msgLevel() <= MSG::VERBOSE) {
+          verbose() << "For cluster: " << clusterId << endmsg;
         }
-        verbose() << "Next neighbours assigned to cluster ID: " << clusterId << endmsg;
-        auto additionalNeighbours = searchForNeighbours(id.first, clusterId, m_neighbourSigma, allCellsMap,
-                                                        alreadyUsedCells, protoClusters, true);
-        nextNeighbours[it].insert(nextNeighbours[it].end(), additionalNeighbours.begin(), additionalNeighbours.end());
-      }
-      verbose() << "Found " << nextNeighbours[it].size() << " more neighbours.." << endmsg;
+
+        auto itCell = cellMap.find(cid);
+        if (itCell == cellMap.end())
+          continue;
+
+        // retrieve neighbours of cell
+        std::vector<uint64_t> neighboursVec;
+        if (m_useNeighborMap) {
+          neighboursVec = m_neighboursTool->neighbours(cid);
+        } else {
+          std::set<dd4hep::DDSegmentation::CellID> tmp;
+          m_segmentation->neighbours(cid, tmp);
+          neighboursVec.assign(tmp.begin(), tmp.end());
+        }
+        if (neighboursVec.size() == 0) {
+          error() << "No neighbours for cellID found! " << endmsg;
+          error() << "to cellID :  " << cid << endmsg;
+          error() << "in system:   " << m_decoder->get(cid, m_indexSystem) << endmsg;
+        }
+
+        // loop over neighbours
+        for (uint64_t nid : neighboursVec) {
+
+          auto itN = cellMap.find(nid);
+          if (itN == cellMap.end())
+            continue;
+
+          // check if neighbour is used
+          const FastCell& ncell = *(itN->second);
+          auto itUsed = used.find(nid);
+
+          // new cell (not used yet)
+          if (itUsed == used.end()) {
+            if (msgLevel() <= MSG::VERBOSE) {
+              verbose() << "Found neighbour with CellID: " << nid << endmsg;
+            }
+
+            bool accept = (ncell.SoverN > m_neighbourSigma) || (m_neighbourSigma == 0);
+            if (!accept)
+              continue;
+
+            used[nid] = clusterId;
+            clusters[clusterId].push_back(FastCell{nid, ncell.energy, ncell.x, ncell.y, ncell.z, 2, ncell.SoverN});
+            clusterMembers[clusterId].insert(nid);
+            nextLayer.push_back(nid);
+          } else if (itUsed->second != clusterId) {
+            // cell already used for a different cluster -> merge
+            const uint32_t source = clusterId;
+            const uint32_t target = itUsed->second;
+            auto& srcCluster = clusters[source];
+            auto& dstCluster = clusters[target];
+            auto& dstMask = clusterMembers[target];
+            if (msgLevel() <= MSG::VERBOSE) {
+              verbose() << "This neighbour was found in cluster " << target << ", cluster " << source
+                        << " will be merged!" << endmsg;
+              verbose() << "Assigning all cells ( " << srcCluster.size() << " ) to Cluster " << target << " with ( "
+                        << dstCluster.size() << " ). " << endmsg;
+            }
+
+            // move ALL cells from source -> target
+            for (const auto& c : srcCluster) {
+
+              // update global ownership FIRST
+              used[c.cellID] = target;
+
+              // avoid duplicates
+              if (!dstMask.insert(c.cellID).second)
+                continue;
+
+              dstCluster.push_back(c);
+            }
+
+            // erase source cluster completely
+            srcCluster.clear();
+            clusters.erase(source);
+            clusterMembers.erase(source);
+
+            // update current clusterId
+            clusterId = target;
+
+            // continue search from merged context
+            restartBFS = true;
+            currentLayer.clear();
+            for (const auto& c : clusters[clusterId]) {
+              currentLayer.push_back(c.cellID);
+            }
+            break; // leave neighbour loop
+          }
+        } // end of neighbour loop
+        if (msgLevel() <= MSG::VERBOSE) {
+          verbose() << "Found " << nextLayer.size() << " neighbours.." << endmsg;
+        }
+        if (restartBFS)
+          break; // leave currentLayer loop
+      } // end of currentLayer loop
+
+      if (restartBFS)
+        continue; // restart search for currentLayer since we rebuilt it after merge
+
+      // go to next layer
+      currentLayer.swap(nextLayer);
     }
 
-    // last try with different condition on neighbours
-    if (nextNeighbours[it].size() == 0) {
-      // loop over all clustered cells
-      for (const auto& cell : protoClusters[clusterId]) {
-        if (cell.getType() <= 2) {
-          verbose() << "Add neighbours of " << cell.getCellID()
-                    << " in last round with thr = " << m_lastNeighbourSigma.value() << " x sigma." << endmsg;
-          auto lastNeighours = searchForNeighbours(cell.getCellID(), clusterId, m_lastNeighbourSigma, allCellsMap,
-                                                   alreadyUsedCells, protoClusters, false);
-        }
+    // add last set of neighbours
+    // loop over the cells of the cluster
+    int lastNeighbours(0);
+    for (const auto& c : clusters[clusterId]) {
+      int lastNeighboursOfCell(0);
+
+      // skip type-3 cells (last neighbours)
+      if (c.type > 2)
+        continue;
+
+      // retrieve neighbours of cell
+      std::vector<uint64_t> lastVec;
+      if (m_useNeighborMap) {
+        lastVec = m_neighboursTool->neighbours(c.cellID);
+      } else {
+        std::set<dd4hep::DDSegmentation::CellID> tmp;
+        m_segmentation->neighbours(c.cellID, tmp);
+        lastVec.assign(tmp.begin(), tmp.end());
       }
+
+      // loop over neighbours
+      // verbose() << "Number of neighbours for cell " << c.cellID << " : " << lastVec.size() << endmsg;
+      for (uint64_t nid : lastVec) {
+        // skip already used neighbours
+        if (used.count(nid))
+          continue;
+
+        // find corresponding cell
+        auto itN = cellMap.find(nid);
+        if (itN == cellMap.end())
+          continue;
+        const FastCell& ncell = *(itN->second);
+
+        // skip cells with S/N below threshold
+        if (m_lastNeighbourSigma != 0 && ncell.SoverN < m_lastNeighbourSigma)
+          continue;
+
+        // add cell to cluster
+        used[nid] = clusterId;
+        clusters[clusterId].push_back(FastCell{nid, ncell.energy, ncell.x, ncell.y, ncell.z, 3, ncell.SoverN});
+        clusterMembers[clusterId].insert(nid);
+        lastNeighboursOfCell++;
+        lastNeighbours++;
+      }
+      // verbose() << "Added " << lastNeighboursOfCell << " last neighbours for cell " << c.cellID << endmsg;
+    }
+    if (msgLevel() <= MSG::VERBOSE) {
+      verbose() << "Found " << lastNeighbours << " last neighbours.." << endmsg;
     }
   }
 
   return StatusCode::SUCCESS;
-}
-
-std::vector<std::pair<uint64_t, uint32_t>> CaloTopoClusterFCCee::searchForNeighbours(
-    const uint64_t aCellId, uint& aClusterID, int aNumSigma,
-    std::map<uint64_t, const edm4hep::CalorimeterHit>& allCellsMap, std::map<uint64_t, uint32_t>& alreadyUsedCells,
-    std::map<uint32_t, edm4hep::CalorimeterHitCollection>& protoClusters, bool allowClusterMerge) const {
-
-  // Fill vector to be returned, next cell ids and cluster id for which
-  // neighbours are found
-  std::vector<std::pair<uint64_t, uint32_t>> additionalNeighbours;
-  std::vector<uint64_t> neighboursVec;
-
-  // Retrieve cellIDs of neighbours
-  if (m_useNeighborMap) {
-    neighboursVec = m_neighboursTool->neighbours(aCellId);
-
-    if (neighboursVec.size() == 0) {
-      error() << "No neighbours for cellID found! " << endmsg;
-      error() << "to cellID :  " << aCellId << endmsg;
-      error() << "in system:   " << m_decoder->get(aCellId, m_indexSystem) << endmsg;
-      additionalNeighbours.resize(0);
-      additionalNeighbours.push_back(std::make_pair(0, 0));
-
-      return additionalNeighbours;
-    }
-  }
-
-  if (!m_useNeighborMap) {
-    // DDSegmentation returns std::set
-    std::set<dd4hep::DDSegmentation::CellID> outputNeighbors;
-    m_segmentation->neighbours(aCellId, outputNeighbors);
-    neighboursVec = std::vector<uint64_t>(outputNeighbors.begin(), outputNeighbors.end());
-  }
-
-  verbose() << "For cluster: " << aClusterID << endmsg;
-  // loop over neighbours
-  for (const auto& neighbourID : neighboursVec) {
-    // Find the neighbour in the Calo cells list
-    auto itAllCells = allCellsMap.find(neighbourID);
-    auto itAllUsedCells = alreadyUsedCells.find(neighbourID);
-
-    // If cell is hit.. and is not assigned to a cluster
-    if (itAllCells != allCellsMap.end() && itAllUsedCells == alreadyUsedCells.end()) {
-      verbose() << "Found neighbour with CellID: " << neighbourID << endmsg;
-      auto neighbouringCellEnergy = allCellsMap[neighbourID].getEnergy();
-      bool addNeighbour = false;
-      int cellType = 2;
-      // retrieve the cell noise level [GeV]
-      auto [rms, offset] = m_noiseTool->getNoisePerCell(neighbourID);
-      double thr = offset + rms * aNumSigma;
-      if (std::fabs(neighbouringCellEnergy) > thr)
-        addNeighbour = true;
-      else
-        addNeighbour = false;
-
-      // give cell type according to threshold
-      if (aNumSigma == m_lastNeighbourSigma) {
-        cellType = 3;
-      }
-      // if threshold is 0, collect the cell independent on its energy
-      if (aNumSigma == 0) {
-        addNeighbour = true;
-      }
-      // if neighbour is validated
-      if (addNeighbour) {
-        // retrieve the cell
-        // add neighbour to cells for cluster
-        edm4hep::MutableCalorimeterHit clusteredCell = allCellsMap[neighbourID].clone();
-        clusteredCell.setType(cellType);
-        protoClusters[aClusterID].push_back(clusteredCell);
-        alreadyUsedCells[neighbourID] = aClusterID;
-        additionalNeighbours.push_back(std::make_pair(neighbourID, aClusterID));
-      }
-    }
-    // If cell is hit.. but is assigned to another cluster
-    else if (itAllUsedCells != alreadyUsedCells.end() && itAllUsedCells->second != aClusterID && allowClusterMerge) {
-      uint32_t clusterIDToMergeTo = itAllUsedCells->second;
-      if (msgLevel() <= MSG::VERBOSE) {
-        verbose() << "This neighbour was found in cluster " << clusterIDToMergeTo << ", cluster " << aClusterID
-                  << " will be merged!" << endmsg;
-        verbose() << "Assigning all cells ( " << protoClusters[aClusterID].size() << " ) to Cluster "
-                  << clusterIDToMergeTo << " with ( " << protoClusters[clusterIDToMergeTo].size() << " ). " << endmsg;
-      }
-      // Fill all cells into cluster, and assigned cells to new cluster
-      alreadyUsedCells[neighbourID] = clusterIDToMergeTo;
-      for (const auto& cell : protoClusters[aClusterID]) {
-        alreadyUsedCells[cell.getCellID()] = clusterIDToMergeTo;
-        // make sure that already assigned cells are not added
-        if (cellIdInColl(cell.getCellID(), protoClusters[clusterIDToMergeTo])) {
-          continue;
-        }
-        protoClusters[clusterIDToMergeTo].push_back(cell.clone());
-      }
-      protoClusters.erase(aClusterID);
-      // changed clusterId -> if more neighbours are found, correct assignment
-      verbose() << "Cluster Id changed to " << clusterIDToMergeTo << endmsg;
-      aClusterID = clusterIDToMergeTo;
-      // found neighbour for next search
-      additionalNeighbours.push_back(std::make_pair(neighbourID, aClusterID));
-      // end loop to ensure correct cluster assignment
-      break;
-    }
-  }
-
-  return additionalNeighbours;
 }
 
 StatusCode CaloTopoClusterFCCee::finalize() {
@@ -493,14 +529,4 @@ StatusCode CaloTopoClusterFCCee::finalize() {
     delete m_cellCollectionHandles[ih];
 
   return Gaudi::Algorithm::finalize();
-}
-
-inline bool CaloTopoClusterFCCee::cellIdInColl(const uint64_t cellId,
-                                               const edm4hep::CalorimeterHitCollection& coll) const {
-  for (const auto& cell : coll) {
-    if (cell.getCellID() == cellId) {
-      return true;
-    }
-  }
-  return false;
 }

--- a/RecFCCeeCalorimeter/src/components/CaloTopoClusterFCCee.cpp
+++ b/RecFCCeeCalorimeter/src/components/CaloTopoClusterFCCee.cpp
@@ -65,13 +65,11 @@ StatusCode CaloTopoClusterFCCee::initialize() {
     if (!m_geoSvc) {
       error() << "Unable to locate Geometry Service. "
               << "Make sure you have GeoSvc in the configuration." << endmsg;
-
       return StatusCode::FAILURE;
     }
 
     if (m_geoSvc->getDetector()->readouts().find(m_readoutName) == m_geoSvc->getDetector()->readouts().end()) {
       error() << "Readout <<" << m_readoutName << ">> does not exist." << endmsg;
-
       return StatusCode::FAILURE;
     }
 
@@ -126,27 +124,25 @@ StatusCode CaloTopoClusterFCCee::execute(const EventContext&) const {
     outClusterCells = m_clusterCellsCollection.createAndPut();
   }
 
-  // get input collection with calorimeter cells and build flat cell cache
-  m_cellCache.clear();
-  m_cellCache.reserve(2000000);
-  std::vector<FastCell> allCells;
+  // get input collection with calorimeter cells and build cell cache and flat cell map
+  std::unordered_map<uint64_t, const edm4hep::CalorimeterHit> allCellsMap;
+  allCellsMap.reserve(2000000);
+  std::unordered_map<uint64_t, FastCell> allCells;
   allCells.reserve(2000000);
 
-  for (size_t ih = 0; ih < m_cellCollectionHandles.size(); ih++) {
-
-    const auto* coll = m_cellCollectionHandles[ih]->get();
+  for (auto& hdl : m_cellCollectionHandles) {
+    const auto* coll = hdl->get();
     for (const auto& hit : *coll) {
-
       // cache EDM hit
       const uint64_t cID = hit.getCellID();
-      m_cellCache.emplace(cID, hit);
+      allCellsMap.emplace(cID, hit);
 
       // create fast flat cell
       float energy = hit.getEnergy();
       auto pos = hit.getPosition();
       auto [rms, offset] = m_noiseTool->getNoisePerCell(cID);
       float sovern = (rms > 0.) ? (std::fabs(energy - offset) / rms) : 999999.;
-      allCells.emplace_back(FastCell{cID, energy, (float)pos.x, (float)pos.y, (float)pos.z, 0, sovern});
+      allCells.emplace(cID, FastCell{cID, energy, (float)pos.x, (float)pos.y, (float)pos.z, 0, sovern});
     }
   }
 
@@ -161,42 +157,55 @@ StatusCode CaloTopoClusterFCCee::execute(const EventContext&) const {
   // and sort by energy in reversed order
   std::vector<FastCell> seedCellsVec;
   seedCellsVec.reserve(allCells.size() / 10);
-
-  for (const auto& cell : allCells) {
+  for (const auto& [cID, cell] : allCells) {
+    if (msgLevel() <= MSG::VERBOSE)
+      verbose() << "cellID   = " << cID << endmsg;
     if (cell.SoverN > m_seedSigma) {
+      if (msgLevel() <= MSG::VERBOSE)
+        verbose() << "Found seed" << endmsg;
       seedCellsVec.push_back(cell);
     }
   }
-
   std::sort(seedCellsVec.begin(), seedCellsVec.end(),
             [](const FastCell& a, const FastCell& b) { return a.energy > b.energy; });
 
   debug() << "Number of seeds found                                : " << seedCellsVec.size() << endmsg;
 
   // build clusters (find neighbouring cells)
-  FastClusterMap clusters;
-  clusters.reserve(seedCellsVec.size());
+  // cluster maps clusterID to a FastCluster (vector of FastCells)
+  debug() << "Building clusters" << endmsg;
 
+  FastClusterMap clusters;
   StatusCode sc = buildClusters(seedCellsVec, allCells, clusters);
+
   if (sc.isFailure()) {
-    error() << "Unable to build clusters!" << endmsg;
+    error() << "Unable to build the clusters!" << endmsg;
     return StatusCode::FAILURE;
   }
 
   // keep only clusters with sufficient energy and build EDM output clusters
-  debug() << "Building " << clusters.size() << " EDM clusters" << endmsg;
+  debug() << "Building EDM clusters from " << clusters.size() << " clusters" << endmsg;
+
   double checkTotEnergy = 0.;
   double checkTotEnergyAboveThreshold = 0.;
   int clusterWithMixedCells = 0;
 
-  for (auto& [clusterId, cluster] : clusters) {
+  for (const auto& [clusterId, cluster] : clusters) {
 
     double clusterEnergy = 0.;
-    for (const auto& c : cluster) {
-      clusterEnergy += c.energy;
+    std::unordered_map<int, int> system;
+    system.reserve(4);
+
+    for (const auto& fastcell : cluster) {
+
+      clusterEnergy += fastcell.energy;
+      auto systemId = m_decoder->get(fastcell.cellID, m_indexSystem);
+      system[int(systemId)]++;
     }
+
     checkTotEnergy += clusterEnergy;
-    verbose() << "Cluster energy:     " << clusterEnergy << endmsg;
+    if (msgLevel() <= MSG::VERBOSE)
+      verbose() << "Cluster energy: " << clusterEnergy << endmsg;
     if (clusterEnergy < m_minClusterEnergy) {
       continue;
     }
@@ -207,320 +216,283 @@ StatusCode CaloTopoClusterFCCee::execute(const EventContext&) const {
 
     // set cluster energy
     outCluster.setEnergy(clusterEnergy);
+    checkTotEnergyAboveThreshold += clusterEnergy;
 
     // loop over the cells attached to the cluster to calculate cluster barycenter and attach cells to cluster
-    double cx = 0, cy = 0, cz = 0;
+    double clusterPosX = 0.;
+    double clusterPosY = 0.;
+    double clusterPosZ = 0.;
 
-    std::vector<double> phiVec;
-    std::vector<double> thetaVec;
-    std::vector<double> eVec;
+    double sumCellPhi = 0.;
+    double sumCellTheta = 0.;
 
-    phiVec.reserve(cluster.size());
-    thetaVec.reserve(cluster.size());
-    eVec.reserve(cluster.size());
+    double deltaR = 0.;
 
-    double sumPhi = 0;
-    double sumTheta = 0;
+    std::vector<double> cellPhi;
+    std::vector<double> cellTheta;
+    std::vector<double> cellEnergy;
 
-    std::map<int, int> system;
+    cellPhi.reserve(cluster.size());
+    cellTheta.reserve(cluster.size());
+    cellEnergy.reserve(cluster.size());
 
-    for (const auto& c : cluster) {
+    for (const auto& fastcell : cluster) {
 
-      auto it = m_cellCache.find(c.cellID);
-      if (it == m_cellCache.end())
-        continue;
+      const auto& cell = allCellsMap.at(fastcell.cellID);
 
-      const auto& hit = it->second;
+      double energy = fastcell.energy;
 
-      // identify calo system
-      auto sys = m_decoder->get(hit.getCellID(), m_indexSystem);
-      system[(int)sys]++;
+      clusterPosX += fastcell.x * energy;
+      clusterPosY += fastcell.y * energy;
+      clusterPosZ += fastcell.z * energy;
 
-      // get position, calculate phi/theta
-      cx += c.x * c.energy;
-      cy += c.y * c.energy;
-      cz += c.z * c.energy;
-      dd4hep::Position pos(c.x, c.y, c.z);
+      double phi = std::atan2(fastcell.y, fastcell.x);
+      double theta = std::atan2(std::hypot(fastcell.x, fastcell.y), fastcell.z);
 
-      phiVec.push_back(pos.Phi());
-      thetaVec.push_back(pos.Theta());
-      eVec.push_back(c.energy);
+      cellPhi.push_back(phi);
+      cellTheta.push_back(theta);
+      cellEnergy.push_back(energy);
 
-      sumPhi += pos.Phi() * c.energy;
-      sumTheta += pos.Theta() * c.energy;
+      sumCellPhi += phi * energy;
+      sumCellTheta += theta * energy;
 
+      // attach cell
       if (m_createClusterCellCollection) {
-        auto edmCell = hit.clone();
-        outClusterCells->push_back(edmCell);
-        outCluster.addToHits(edmCell);
+
+        auto newcell = cell.clone();
+        newcell.setType(fastcell.type);
+        outClusterCells->push_back(newcell);
+        outCluster.addToHits(newcell);
+
       } else {
-        outCluster.addToHits(hit);
+        outCluster.addToHits(cell);
       }
     }
 
-    outCluster.setPosition(edm4hep::Vector3f(cx / clusterEnergy, cy / clusterEnergy, cz / clusterEnergy));
+    // calculate cluster barycenter
+    if (clusterEnergy > 0.0) {
+      outCluster.setPosition(
+          edm4hep::Vector3f(clusterPosX / clusterEnergy, clusterPosY / clusterEnergy, clusterPosZ / clusterEnergy));
 
-    sumPhi /= clusterEnergy;
-    sumTheta /= clusterEnergy;
+      sumCellPhi /= clusterEnergy;
+      sumCellTheta /= clusterEnergy;
 
-    double deltaR = 0.;
-    for (size_t i = 0; i < eVec.size(); i++) {
-      deltaR += std::sqrt(std::pow(thetaVec[i] - sumTheta, 2) + std::pow(phiVec[i] - sumPhi, 2)) * eVec[i];
+      for (size_t i = 0; i < cellEnergy.size(); ++i) {
+        deltaR +=
+            std::sqrt(std::pow(cellTheta[i] - sumCellTheta, 2) + std::pow(cellPhi[i] - sumCellPhi, 2)) * cellEnergy[i];
+      }
+      outCluster.addToShapeParameters(deltaR / clusterEnergy);
+    } else {
+      outCluster.setPosition(edm4hep::Vector3f(0., 0., 0.));
+      outCluster.addToShapeParameters(0.0);
     }
-    outCluster.addToShapeParameters(deltaR / clusterEnergy);
 
     outClusters->push_back(outCluster);
 
     if (system.size() > 1)
       clusterWithMixedCells++;
-
-    checkTotEnergyAboveThreshold += clusterEnergy;
   }
 
-  debug() << "Number of clusters with cells in E and HCal:        " << clusterWithMixedCells << endmsg;
-  debug() << "Total energy of clusters:                           " << checkTotEnergy << endmsg;
-  debug() << "Total energy of clusters above threshold:           " << checkTotEnergyAboveThreshold << endmsg;
-  if (m_createClusterCellCollection) {
-    debug() << "Leftover cells :                                    " << allCells.size() - outClusterCells->size()
-            << endmsg;
+  if (msgLevel() <= MSG::DEBUG) {
+    debug() << "Number of clusters:                                 " << outClusters->size() << endmsg;
+    debug() << "Number of clusters with cells in multiple systems:  " << clusterWithMixedCells << endmsg;
+    debug() << "Total energy of clusters:                           " << checkTotEnergy << endmsg;
+    debug() << "Total energy of clusters above threshold:           " << checkTotEnergyAboveThreshold << endmsg;
+    if (m_createClusterCellCollection) {
+      debug() << "Leftover cells :                                    " << allCells.size() - outClusterCells->size()
+              << endmsg;
+    }
   }
 
   return StatusCode::SUCCESS;
 }
 
 StatusCode CaloTopoClusterFCCee::buildClusters(const std::vector<FastCell>& seedCells,
-                                               const std::vector<FastCell>& allCells, FastClusterMap& clusters) const {
+                                               const std::unordered_map<uint64_t, FastCell>& allCells,
+                                               FastClusterMap& clusters) const {
 
-  // will create clusters finding in allCells the neighbours of seedCells and
-  // of their own neighbours
-  // clusters will be saved in a map (clusters) of clusterId -> FastClusters
+  if (msgLevel() <= MSG::VERBOSE)
+    verbose() << "Initial number of seeds to loop over: " << seedCells.size() << endmsg;
 
-  verbose() << "Initial number of seeds to loop over: " << seedCells.size() << endmsg;
+  std::unordered_map<uint64_t, uint32_t> usedCells;
+  usedCells.reserve(allCells.size());
 
-  // build fast lookup (CellID -> FastCell)
-  std::unordered_map<uint64_t, const FastCell*> cellMap;
-  cellMap.reserve(allCells.size());
-  for (const auto& c : allCells) {
-    cellMap.emplace(c.cellID, &c);
-  }
-
-  // initialise map of already used cells
-  std::unordered_map<uint64_t, uint32_t> used;
-  used.reserve(allCells.size());
-
-  // initialise map of clusterId -> set(cellIDs)
-  ClusterMaskMap clusterMembers;
+  std::unordered_map<uint32_t, std::unordered_set<uint64_t>> clusterMembers;
   clusterMembers.reserve(seedCells.size());
 
   // loop over every seeds in calo to build a cluster (or merge with another cluster if appropriate)
   uint32_t seedCounter = 0;
-  for (const auto& seed : seedCells) {
-    ++seedCounter;
-    if (msgLevel() <= MSG::VERBOSE) {
+  for (const auto& seedCell : seedCells) {
+    seedCounter++;
+    if (msgLevel() <= MSG::VERBOSE)
       verbose() << "Looking at seed: " << seedCounter << endmsg;
-    }
 
-    // skip already used seeds
-    if (used.count(seed.cellID)) {
-      if (msgLevel() <= MSG::VERBOSE) {
-        verbose() << "Seed is already assigned to another cluster!" << endmsg;
-      }
+    auto seedId = seedCell.cellID;
+    if (usedCells.find(seedId) != usedCells.end()) {
+      if (msgLevel() <= MSG::VERBOSE)
+        verbose() << "Seed already assigned to another cluster" << endmsg;
       continue;
     }
 
     uint32_t clusterId = seedCounter;
 
-    // create cluster
-    clusterMembers[clusterId].clear();
-    clusters[clusterId].clear();
-    clusterMembers[clusterId].reserve(256);
-    clusters[clusterId].reserve(256);
+    // seed insertion (type = 1)
+    auto& cluster = clusters[clusterId];
+    cluster.reserve(128);
+    cluster.push_back(seedCell);
+    cluster.back().type = 1;
+    usedCells[seedId] = clusterId;
+    clusterMembers[clusterId].insert(seedId);
 
-    // insert seed and set its type to 1
-    clusters[clusterId].push_back(seed);
-    clusters[clusterId].back().type = 1;
-    used[seed.cellID] = clusterId;
-    clusterMembers[clusterId].insert(seed.cellID);
+    std::vector<std::vector<uint64_t>> nextNeighbours(100);
+    nextNeighbours[0] =
+        searchForNeighbours(seedId, clusterId, m_neighbourSigma, allCells, usedCells, clusters, clusterMembers, true);
+    if (msgLevel() <= MSG::VERBOSE)
+      verbose() << "Found " << nextNeighbours[0].size() << " neighbours.." << endmsg;
 
-    // attach neighbours
-    // recursively find neighbours (nextLayer) of cells in current layer
-    std::vector<uint64_t> currentLayer;
-    std::vector<uint64_t> nextLayer;
-    currentLayer.reserve(1024);
-    nextLayer.reserve(1024);
-
-    // start with neighbours of seed
-    currentLayer.push_back(seed.cellID);
-
-    // the flag restartBFS is needed to restart the neighbour search
-    // after two clusters are merged and currentLayer is updated
-    bool restartBFS = false;
-    while (!currentLayer.empty()) {
-
-      nextLayer.clear();
-      restartBFS = false;
-
-      // loop over cells in currentLayer
-      for (uint64_t cid : currentLayer) {
-
-        if (msgLevel() <= MSG::VERBOSE) {
-          verbose() << "For cluster: " << clusterId << endmsg;
+    // first loop over seeds neighbours
+    int it = 0;
+    while (nextNeighbours[it].size() > 0) {
+      it++;
+      if (msgLevel() <= MSG::VERBOSE)
+        verbose() << "it: " << it << endmsg;
+      nextNeighbours.emplace_back(std::vector<uint64_t>{});
+      for (auto& id : nextNeighbours[it - 1]) {
+        if (id == 0) {
+          error() << "Building of cluster is stopped due to missing cell ID "
+                     "in neighbours map!"
+                  << endmsg;
+          return StatusCode::FAILURE;
         }
-
-        auto itCell = cellMap.find(cid);
-        if (itCell == cellMap.end())
-          continue;
-
-        // retrieve neighbours of cell
-        std::vector<uint64_t> neighboursVec;
-        if (m_useNeighborMap) {
-          neighboursVec = m_neighboursTool->neighbours(cid);
-        } else {
-          std::set<dd4hep::DDSegmentation::CellID> tmp;
-          m_segmentation->neighbours(cid, tmp);
-          neighboursVec.assign(tmp.begin(), tmp.end());
-        }
-        if (neighboursVec.size() == 0) {
-          error() << "No neighbours for cellID found! " << endmsg;
-          error() << "to cellID :  " << cid << endmsg;
-          error() << "in system:   " << m_decoder->get(cid, m_indexSystem) << endmsg;
-        }
-
-        // loop over neighbours
-        for (uint64_t nid : neighboursVec) {
-
-          auto itN = cellMap.find(nid);
-          if (itN == cellMap.end())
-            continue;
-
-          // check if neighbour is used
-          const FastCell& ncell = *(itN->second);
-          auto itUsed = used.find(nid);
-
-          // new cell (not used yet)
-          if (itUsed == used.end()) {
-            if (msgLevel() <= MSG::VERBOSE) {
-              verbose() << "Found neighbour with CellID: " << nid << endmsg;
-            }
-
-            bool accept = (ncell.SoverN > m_neighbourSigma) || (m_neighbourSigma == 0);
-            if (!accept)
-              continue;
-
-            used[nid] = clusterId;
-            clusters[clusterId].push_back(FastCell{nid, ncell.energy, ncell.x, ncell.y, ncell.z, 2, ncell.SoverN});
-            clusterMembers[clusterId].insert(nid);
-            nextLayer.push_back(nid);
-          } else if (itUsed->second != clusterId) {
-            // cell already used for a different cluster -> merge
-            const uint32_t source = clusterId;
-            const uint32_t target = itUsed->second;
-            auto& srcCluster = clusters[source];
-            auto& dstCluster = clusters[target];
-            auto& dstMask = clusterMembers[target];
-            if (msgLevel() <= MSG::VERBOSE) {
-              verbose() << "This neighbour was found in cluster " << target << ", cluster " << source
-                        << " will be merged!" << endmsg;
-              verbose() << "Assigning all cells ( " << srcCluster.size() << " ) to Cluster " << target << " with ( "
-                        << dstCluster.size() << " ). " << endmsg;
-            }
-
-            // move ALL cells from source -> target
-            for (const auto& c : srcCluster) {
-
-              // update global ownership FIRST
-              used[c.cellID] = target;
-
-              // avoid duplicates
-              if (!dstMask.insert(c.cellID).second)
-                continue;
-
-              dstCluster.push_back(c);
-            }
-
-            // erase source cluster completely
-            srcCluster.clear();
-            clusters.erase(source);
-            clusterMembers.erase(source);
-
-            // update current clusterId
-            clusterId = target;
-
-            // continue search from merged context
-            restartBFS = true;
-            currentLayer.clear();
-            for (const auto& c : clusters[clusterId]) {
-              currentLayer.push_back(c.cellID);
-            }
-            break; // leave neighbour loop
-          }
-        } // end of neighbour loop
-        if (msgLevel() <= MSG::VERBOSE) {
-          verbose() << "Found " << nextLayer.size() << " neighbours.." << endmsg;
-        }
-        if (restartBFS)
-          break; // leave currentLayer loop
-      } // end of currentLayer loop
-
-      if (restartBFS)
-        continue; // restart search for currentLayer since we rebuilt it after merge
-
-      // go to next layer
-      currentLayer.swap(nextLayer);
+        if (msgLevel() <= MSG::VERBOSE)
+          verbose() << "Next neighbours assigned to cluster ID: " << clusterId << endmsg;
+        auto additionalNeighbours =
+            searchForNeighbours(id, clusterId, m_neighbourSigma, allCells, usedCells, clusters, clusterMembers, true);
+        nextNeighbours[it].insert(nextNeighbours[it].end(), additionalNeighbours.begin(), additionalNeighbours.end());
+      }
+      if (msgLevel() <= MSG::VERBOSE)
+        verbose() << "Found " << nextNeighbours[it].size() << " more neighbours.." << endmsg;
     }
 
-    // add last set of neighbours
-    // loop over the cells of the cluster
-    int lastNeighbours(0);
-    for (const auto& c : clusters[clusterId]) {
-      int lastNeighboursOfCell(0);
-
-      // skip type-3 cells (last neighbours)
-      if (c.type > 2)
-        continue;
-
-      // retrieve neighbours of cell
-      std::vector<uint64_t> lastVec;
-      if (m_useNeighborMap) {
-        lastVec = m_neighboursTool->neighbours(c.cellID);
-      } else {
-        std::set<dd4hep::DDSegmentation::CellID> tmp;
-        m_segmentation->neighbours(c.cellID, tmp);
-        lastVec.assign(tmp.begin(), tmp.end());
+    // last try with different condition on neighbours
+    if (nextNeighbours[it].size() == 0) {
+      // loop over all clustered cells
+      auto& aCluster = clusters[clusterId];
+      for (size_t i = 0; i < aCluster.size(); ++i) {
+        const auto& cell = aCluster[i];
+        if (cell.type <= 2) {
+          uint64_t cID = cell.cellID;
+          if (msgLevel() <= MSG::VERBOSE)
+            verbose() << "Add neighbours of " << cID << " in last round with thr = " << m_lastNeighbourSigma.value()
+                      << " x sigma." << endmsg;
+          auto lastNeighbours = searchForNeighbours(cID, clusterId, m_lastNeighbourSigma, allCells, usedCells, clusters,
+                                                    clusterMembers, false);
+        }
       }
-
-      // loop over neighbours
-      // verbose() << "Number of neighbours for cell " << c.cellID << " : " << lastVec.size() << endmsg;
-      for (uint64_t nid : lastVec) {
-        // skip already used neighbours
-        if (used.count(nid))
-          continue;
-
-        // find corresponding cell
-        auto itN = cellMap.find(nid);
-        if (itN == cellMap.end())
-          continue;
-        const FastCell& ncell = *(itN->second);
-
-        // skip cells with S/N below threshold
-        if (m_lastNeighbourSigma != 0 && ncell.SoverN < m_lastNeighbourSigma)
-          continue;
-
-        // add cell to cluster
-        used[nid] = clusterId;
-        clusters[clusterId].push_back(FastCell{nid, ncell.energy, ncell.x, ncell.y, ncell.z, 3, ncell.SoverN});
-        clusterMembers[clusterId].insert(nid);
-        lastNeighboursOfCell++;
-        lastNeighbours++;
-      }
-      // verbose() << "Added " << lastNeighboursOfCell << " last neighbours for cell " << c.cellID << endmsg;
-    }
-    if (msgLevel() <= MSG::VERBOSE) {
-      verbose() << "Found " << lastNeighbours << " last neighbours.." << endmsg;
     }
   }
 
   return StatusCode::SUCCESS;
+}
+
+std::vector<uint64_t> CaloTopoClusterFCCee::searchForNeighbours(
+    const uint64_t cellID, uint& clusterID, int nSigma, const std::unordered_map<uint64_t, FastCell>& allCells,
+    std::unordered_map<uint64_t, uint32_t>& usedCells, FastClusterMap& clusters,
+    std::unordered_map<uint32_t, std::unordered_set<uint64_t>>& clusterMembers, bool allowClusterMerge) const {
+
+  std::vector<uint64_t> additionalNeighbours;
+
+  assert(allCells.find(cellID) != allCells.end());
+
+  // retrieve neighbours
+  std::vector<uint64_t> neighboursVec;
+  if (m_useNeighborMap) {
+
+    neighboursVec = m_neighboursTool->neighbours(cellID);
+
+  } else {
+
+    std::set<dd4hep::DDSegmentation::CellID> outputNeighbors;
+    m_segmentation->neighbours(cellID, outputNeighbors);
+    neighboursVec.assign(outputNeighbors.begin(), outputNeighbors.end());
+  }
+
+  if (neighboursVec.empty()) {
+    error() << "No neighbours for cellID " << cellID << endmsg;
+    return {0};
+  }
+
+  // loop over neighbours
+  if (msgLevel() <= MSG::VERBOSE)
+    verbose() << "For cluster: " << clusterID << " , cell " << cellID << endmsg;
+  for (const auto& neighbourID : neighboursVec) {
+
+    auto itCell = allCells.find(neighbourID);
+    auto itUsed = usedCells.find(neighbourID);
+
+    // CASE 1: unused cell -> candidate addition
+    if (itCell != allCells.end() && itUsed == usedCells.end()) {
+      if (msgLevel() <= MSG::VERBOSE)
+        verbose() << "Found neighbour with CellID: " << neighbourID << endmsg;
+
+      // const auto& hit = *(itCell->second);
+      const auto& hit = (itCell->second);
+      bool addNeighbour = (hit.SoverN > nSigma) || (nSigma == 0);
+
+      if (addNeighbour) {
+        if (msgLevel() <= MSG::VERBOSE)
+          verbose() << "Neighbour kept, hit = " << hit.cellID << endmsg;
+        int cellType = (nSigma == m_lastNeighbourSigma) ? 3 : 2;
+        auto& cluster = clusters[clusterID];
+        cluster.push_back(hit);
+        cluster.back().type = cellType;
+        usedCells[neighbourID] = clusterID;
+        clusterMembers[clusterID].insert(neighbourID);
+        additionalNeighbours.emplace_back(neighbourID);
+      } else {
+        if (msgLevel() <= MSG::VERBOSE)
+          verbose() << "Neighbour NOT kept, hit = " << hit.cellID << endmsg;
+      }
+    }
+
+    // CASE 2: already used -> possible merge
+    else if (itUsed != usedCells.end() && itUsed->second != clusterID && allowClusterMerge) {
+
+      uint32_t targetCluster = itUsed->second;
+
+      auto& src = clusters[clusterID];
+      auto& dst = clusters[targetCluster];
+      auto& dstMembers = clusterMembers[targetCluster];
+
+      if (msgLevel() <= MSG::VERBOSE) {
+        verbose() << "Neighbour " << neighbourID << " was found in cluster " << targetCluster << ", cluster "
+                  << clusterID << " will be merged!" << endmsg;
+        verbose() << "Assigning all cells ( " << clusters[clusterID].size() << " ) to Cluster " << targetCluster
+                  << " with ( " << clusters[targetCluster].size() << " ). " << endmsg;
+      }
+
+      // merge all cells
+      for (const auto& c : src) {
+
+        usedCells[c.cellID] = targetCluster;
+
+        if (dstMembers.insert(c.cellID).second) {
+          dst.push_back(c);
+        }
+      }
+
+      clusters.erase(clusterID);
+      clusterMembers.erase(clusterID);
+      // changed clusterId -> if more neighbours are found, correct assignment
+      clusterID = targetCluster;
+      // found neighbour for next search
+      additionalNeighbours.emplace_back(neighbourID);
+      // end loop to ensure correct cluster assignment
+      break;
+    }
+  }
+
+  return additionalNeighbours;
 }
 
 StatusCode CaloTopoClusterFCCee::finalize() {

--- a/RecFCCeeCalorimeter/src/components/CaloTopoClusterFCCee.h
+++ b/RecFCCeeCalorimeter/src/components/CaloTopoClusterFCCee.h
@@ -46,8 +46,22 @@ namespace DDSegmentation {
  * clusters are merged and assigned to the "older" clusterID, this is the one originating from a higher seed energy. The
  * iteration over neighburing cellIDs is continued.
  *  @author Coralie Neubueser
- *  @author Giovanni Marchiori, based on code from Juraj Smiesko
+ *  @author Giovanni Marchiori - algorithm rewritten for significant speed-up
  */
+
+/// internal cell representation used for clustering, to avoid cloning EDM objects repeatedly
+struct FastCell {
+  uint64_t cellID;
+  float energy;
+  float x;
+  float y;
+  float z;
+  uint8_t type; // 0=unused,1=seed,2=neighbour,3=lastNeighbour
+  float SoverN;
+};
+using FastCluster = std::vector<FastCell>;
+using FastClusterMap = std::unordered_map<uint32_t, FastCluster>;
+using ClusterMaskMap = std::unordered_map<uint32_t, std::unordered_set<uint64_t>>;
 
 class CaloTopoClusterFCCee : public Gaudi::Algorithm {
 public:
@@ -58,42 +72,17 @@ public:
    */
   StatusCode initialize();
 
-  /**  Find cells with a signal to noise ratio > m_seedSigma.
-   *   @param[in] allCells, the map of all cells.
-   *   @param[out] the collection of seed cells to build proto-clusters.
-   */
-  edm4hep::CalorimeterHitCollection findSeeds(const edm4hep::CalorimeterHitCollection* allCells) const;
-
-  /** Build proto-clusters from the found seeds.
-   * First the function initialises a cluster in the preClusterCollection for the seed cells,
-   * then it calls the CaloTopoClusterFCCee::searchForNeighbours function to retrieve the vector of next cellIDs to add
-   * and loop over to find neighbours. The iteration of search for neighbours is continued until no more neihgbours are
-   * found. Then a last round of adding neighbouring cells to the cluster is run where the parameter lastNeighbourSigma
-   * is applied.
+  /** Build clusters from seed cells (cells with S/N > seedSigma)
+   * The function searches for neighbour cells with S/N > neighbourSigma
+   * iteratively, until no more neighbours are found. Then a last round
+   * of adding neighbouring cells to the cluster is run where the parameter
+   * lastNeighbourSigma is applied.
    *   @param[in] seedCells, collection of seeding cells.
    *   @param[in] allCells, collection of all cells.
-   *   @param[in] protoClusters, map that is filled with clusterID pointing to the associated cells, in a pair of
-   * clsuter index and cell collection
+   *   @param[in] clusters, map of clusterID -> FastCluster (will be filled by the algorithm)
    */
-  StatusCode buildProtoClusters(const edm4hep::CalorimeterHitCollection& seedCells,
-                                const edm4hep::CalorimeterHitCollection* allCells,
-                                std::map<uint32_t, edm4hep::CalorimeterHitCollection>& protoClusters) const;
-  /** Search for neighbours and add them to preClusterCollection
-   * The
-   *   @param[in] aCellId, the cell ID for which to find the neighbours.
-   *   @param[in] aClusterID, the current cluster ID.
-   *   @param[in] aNumSigma, the signal/noise ratio to be exceeded by the neighbouring cell to be added to cluster.
-   *   @param[in] aCellsMap, map of all cells (CellID, cell pointer).
-   *   @param[in] aClusterOfCell, map of cellID to clusterID.
-   *   @param[in] protoClusters, map that is filled with clusterID pointing to the associated cells, in a pair of
-   * cluster index and cell collection.
-   *   @param[in] allowClusterMerge, bool to allow for clusters to be merged, set to false in case of last iteration in
-   * CaloTopoClusterFCCee::buildingProtoCluster. return vector of pairs with cellID and energy of found neighbours.
-   */
-  std::vector<std::pair<uint64_t, uint32_t>> searchForNeighbours(
-      const uint64_t aCellId, uint32_t& aClusterID, const int aNumSigma,
-      std::map<uint64_t, const edm4hep::CalorimeterHit>& aCellsMap, std::map<uint64_t, uint32_t>& aClusterOfCell,
-      std::map<uint32_t, edm4hep::CalorimeterHitCollection>& protoClusters, const bool aAllowClusterMerge) const;
+  StatusCode buildClusters(const std::vector<FastCell>& seedCells, const std::vector<FastCell>& allCells,
+                           FastClusterMap& clusters) const;
 
   StatusCode execute(const EventContext&) const;
 
@@ -103,26 +92,27 @@ private:
   /// List of input cell collections
   Gaudi::Property<std::vector<std::string>> m_cellCollections{
       this, "cells", {}, "Names of CalorimeterHit collections to read"};
-  /// the vector of input k4FWCore::DataHandles for the input cell collections
+  /// Vector of input k4FWCore::DataHandles for the input cell collections
   std::vector<k4FWCore::DataHandle<edm4hep::CalorimeterHitCollection>*> m_cellCollectionHandles;
-  // Cluster collection (output)
+  /// Output cluster collection
   mutable k4FWCore::DataHandle<edm4hep::ClusterCollection> m_clusterCollection{"clusters", Gaudi::DataHandle::Writer,
                                                                                this};
-  // Cluster cells in collection (output)
+  /// Output collection of clustered cells
   mutable k4FWCore::DataHandle<edm4hep::CalorimeterHitCollection> m_clusterCellsCollection{
       "clusterCells", Gaudi::DataHandle::Writer, this};
 
+  /// List of systemIDs for the cells being clustered
   Gaudi::Property<std::vector<int>> m_caloIDs{this, "calorimeterIDs", {}, "Corresponding list of calorimeter IDs"};
 
   /// Handle for the cells noise tool
   mutable ToolHandle<k4::recCalo::INoiseConstTool> m_noiseTool{"TopoCaloNoisyCells", this};
   /// Handle for neighbours tool
   mutable ToolHandle<k4::recCalo::ICaloReadNeighboursMap> m_neighboursTool{"TopoCaloNeighbours", this};
-  // flag to use a pre-calculated neighbor map
+  /// flag to use a pre-calculated neighbor map
   Gaudi::Property<bool> m_useNeighborMap{this, "useNeighborMap", true, "use pre-calculated neighbor map"};
-  // use GeoSvc when the neighbor map is not present
+  /// use GeoSvc when the neighbor map is not present
   SmartIF<IGeoSvc> m_geoSvc;
-  // name of the readout: only needed if useNeighborMap is set to false
+  /// name of the readout: only needed if useNeighborMap is set to false
   Gaudi::Property<std::string> m_readoutName{this, "readoutName", "",
                                              "name of the readout (needed if useNeighborMap=false)"};
   // pointer to the segmentation object
@@ -147,7 +137,7 @@ private:
   dd4hep::DDSegmentation::BitFieldCoder* m_decoder;
   int m_indexSystem;
 
-  // Utility functions
-  inline bool cellIdInColl(const uint64_t cellId, const edm4hep::CalorimeterHitCollection& coll) const;
+  /// internal cache cID -> EDM cell
+  mutable std::unordered_map<uint64_t, edm4hep::CalorimeterHit> m_cellCache;
 };
 #endif /* RECFCCEECALORIMETER_CALOTOPOCLUSTERFCCEE_H */

--- a/RecFCCeeCalorimeter/src/components/CaloTopoClusterFCCee.h
+++ b/RecFCCeeCalorimeter/src/components/CaloTopoClusterFCCee.h
@@ -5,6 +5,7 @@
 #include <cstdint>
 #include <map>
 #include <sys/types.h>
+#include <utility>
 #include <vector>
 
 // Gaudi
@@ -45,6 +46,7 @@ namespace DDSegmentation {
  * "lastNeighbourSigma". In case that a neighbour is found that has already been assigned to another cluster, both
  * clusters are merged and assigned to the "older" clusterID, this is the one originating from a higher seed energy. The
  * iteration over neighburing cellIDs is continued.
+ *
  *  @author Coralie Neubueser
  *  @author Giovanni Marchiori - algorithm rewritten for significant speed-up
  */
@@ -60,8 +62,7 @@ struct FastCell {
   float SoverN;
 };
 using FastCluster = std::vector<FastCell>;
-using FastClusterMap = std::unordered_map<uint32_t, FastCluster>;
-using ClusterMaskMap = std::unordered_map<uint32_t, std::unordered_set<uint64_t>>;
+using FastClusterMap = std::map<uint32_t, FastCluster>; // TODO make it unordered or a vector
 
 class CaloTopoClusterFCCee : public Gaudi::Algorithm {
 public:
@@ -72,17 +73,36 @@ public:
    */
   StatusCode initialize();
 
-  /** Build clusters from seed cells (cells with S/N > seedSigma)
-   * The function searches for neighbour cells with S/N > neighbourSigma
-   * iteratively, until no more neighbours are found. Then a last round
-   * of adding neighbouring cells to the cluster is run where the parameter
-   * lastNeighbourSigma is applied.
-   *   @param[in] seedCells, collection of seeding cells.
-   *   @param[in] allCells, collection of all cells.
-   *   @param[in] clusters, map of clusterID -> FastCluster (will be filled by the algorithm)
+  /** Build clusters from the found seeds.
+   * First the function initialises a cluster in the preClusterCollection for the seed cells,
+   * then it calls the CaloTopoClusterFCCee::searchForNeighbours function to retrieve the vector of next cellIDs to add
+   * and loop over to find neighbours. The iteration of search for neighbours is continued until no more neihgbours are
+   * found. Then a last round of adding neighbouring cells to the cluster is run where the parameter lastNeighbourSigma
+   * is applied.
+   *   @param[in] seedCells, collection of seeding cells (vector of fastcells)
+   *   @param[in] allCells, collection of all cells (map cellID -> fastcell)
+   *   @param[in] clusters, collection of clusters to be filled by the algorithm (map of clusterID -> FastCluster)
    */
-  StatusCode buildClusters(const std::vector<FastCell>& seedCells, const std::vector<FastCell>& allCells,
-                           FastClusterMap& clusters) const;
+  StatusCode buildClusters(const std::vector<FastCell>& seedCells,
+                           const std::unordered_map<uint64_t, FastCell>& allCells, FastClusterMap& clusters) const;
+  /** Search for neighbours and add them to cluster collection
+   *   @param[in] cellID, the cell ID for which to find the neighbours
+   *   @param[in] clusterID, the current cluster ID
+   *   @param[in] nSigma, the signal/noise ratio to be exceeded by the neighbouring cell to be added to cluster
+   *   @param[in] allCells, map of all cells (CellID -> FastCell)
+   *   @param[in] usedCells, map of used cells (CellID -> cluster ID)
+   *   @param[in] clusters, map that is filled with clusterID pointing to the associated cells, in a pair of
+   *              cluster index and cell collection
+   *   @param[in] clusterMembers, map (cluster ID -> set of CellIDs) that is filled by the algorithm to keep track of
+   * clustered cells
+   *   @param[in] allowClusterMerge, bool to allow for clusters to be merged
+   *   return vector of cellID of found neighbours
+   */
+  std::vector<uint64_t> searchForNeighbours(const uint64_t cellID, uint& clusterID, int nSigma,
+                                            const std::unordered_map<uint64_t, FastCell>& allCells,
+                                            std::unordered_map<uint64_t, uint32_t>& usedCells, FastClusterMap& clusters,
+                                            std::unordered_map<uint32_t, std::unordered_set<uint64_t>>& clusterMembers,
+                                            bool allowClusterMerge) const;
 
   StatusCode execute(const EventContext&) const;
 
@@ -92,27 +112,26 @@ private:
   /// List of input cell collections
   Gaudi::Property<std::vector<std::string>> m_cellCollections{
       this, "cells", {}, "Names of CalorimeterHit collections to read"};
-  /// Vector of input k4FWCore::DataHandles for the input cell collections
+  /// the vector of input k4FWCore::DataHandles for the input cell collections
   std::vector<k4FWCore::DataHandle<edm4hep::CalorimeterHitCollection>*> m_cellCollectionHandles;
-  /// Output cluster collection
+  // Cluster collection (output)
   mutable k4FWCore::DataHandle<edm4hep::ClusterCollection> m_clusterCollection{"clusters", Gaudi::DataHandle::Writer,
                                                                                this};
-  /// Output collection of clustered cells
+  // Cluster cells in collection (output)
   mutable k4FWCore::DataHandle<edm4hep::CalorimeterHitCollection> m_clusterCellsCollection{
       "clusterCells", Gaudi::DataHandle::Writer, this};
 
-  /// List of systemIDs for the cells being clustered
   Gaudi::Property<std::vector<int>> m_caloIDs{this, "calorimeterIDs", {}, "Corresponding list of calorimeter IDs"};
 
   /// Handle for the cells noise tool
   mutable ToolHandle<k4::recCalo::INoiseConstTool> m_noiseTool{"TopoCaloNoisyCells", this};
   /// Handle for neighbours tool
   mutable ToolHandle<k4::recCalo::ICaloReadNeighboursMap> m_neighboursTool{"TopoCaloNeighbours", this};
-  /// flag to use a pre-calculated neighbor map
+  // flag to use a pre-calculated neighbor map
   Gaudi::Property<bool> m_useNeighborMap{this, "useNeighborMap", true, "use pre-calculated neighbor map"};
-  /// use GeoSvc when the neighbor map is not present
+  // use GeoSvc when the neighbor map is not present
   SmartIF<IGeoSvc> m_geoSvc;
-  /// name of the readout: only needed if useNeighborMap is set to false
+  // name of the readout: only needed if useNeighborMap is set to false
   Gaudi::Property<std::string> m_readoutName{this, "readoutName", "",
                                              "name of the readout (needed if useNeighborMap=false)"};
   // pointer to the segmentation object
@@ -136,8 +155,5 @@ private:
   /// positions tool to use
   dd4hep::DDSegmentation::BitFieldCoder* m_decoder;
   int m_indexSystem;
-
-  /// internal cache cID -> EDM cell
-  mutable std::unordered_map<uint64_t, edm4hep::CalorimeterHit> m_cellCache;
 };
 #endif /* RECFCCEECALORIMETER_CALOTOPOCLUSTERFCCEE_H */


### PR DESCRIPTION

BEGINRELEASENOTES
- Speed up topoclustering code:
ENDRELEASENOTES

Includes several changes such as
1. std::unordered_maps instead of maps
2. use cache of flat cell representation instead of cloning EDM objects multiple times (now clone happens only once)
3. avoid O(N2) cellIdInColl
4. cached S/N
...

With these changes I can run over 10 events in the ecal endcap  with noise in 2-3 minutes instead of 20800 seconds (note: the reconstruction of ALLEGRO ecal endcap with noise takes ages because the expected noise RMS in some cells at the moment is 0 or negative and thus there are a lot of seeds).

With the latest commit I was able to make the code flow as in the previous version of the algorithm, obtaining identical  results

@scott-snyder it'd be great if you could have a look at this PR, thanks!

Below a couple of plots of reconstructed topocluster energy for 100 photons of p=10 GeV theta between 15 and 165 degrees with code in main and in this PR (produced with: python run.py -p gamma -n 200 --pmin 10 --pmax 10 --thmin 15 --thmax 165)

code in main
EMB topoclusters
[old_emb.pdf](https://github.com/user-attachments/files/29865696/old_emb.pdf)

EMEC topoclusters
[old_emec.pdf](https://github.com/user-attachments/files/29865704/old_emec.pdf)

code in PR
EMB topoclusters
[new_emb.pdf](https://github.com/user-attachments/files/29865780/new_emb.pdf)

EMEC topoclusters
[new_emec.pdf](https://github.com/user-attachments/files/29865758/new_emec.pdf)



