### PR TITLE
Ship cluster metadata to output collections

### DIFF
--- a/RecCalorimeter/src/components/PairCaloClustersPi0.cpp
+++ b/RecCalorimeter/src/components/PairCaloClustersPi0.cpp
@@ -24,15 +24,15 @@ StatusCode PairCaloClustersPi0::initialize() {
   }
 
   // If there are shapeParameters metadata in the input cluster collection, ship them to the output cluster collections
-auto shapeParameterNames = k4FWCore::getCollectionParameter<std::vector<std::string>>(
+  auto shapeParameterNames = k4FWCore::getCollectionParameter<std::vector<std::string>>(
                              m_inClusters.objKey(), edm4hep::labels::ShapeParameterNames, this)
                              .value_or(std::vector<std::string>{});
-if (shapeParameterNames.size()>0) {
-  k4FWCore::putCollectionParameter(m_pairedClusters.objKey(), edm4hep::labels::ShapeParameterNames,
+  if (shapeParameterNames.size() > 0) {
+    k4FWCore::putCollectionParameter(m_pairedClusters.objKey(), edm4hep::labels::ShapeParameterNames,
                                      shapeParameterNames, this);
-  k4FWCore::putCollectionParameter(m_unpairedClusters.objKey(), edm4hep::labels::ShapeParameterNames,
+    k4FWCore::putCollectionParameter(m_unpairedClusters.objKey(), edm4hep::labels::ShapeParameterNames,
                                      shapeParameterNames, this);
-}
+  }
   // print pi0 mass window
   info() << "pi0 mass window for cluster pairing: [" << m_massLow << "," << m_massHigh << "] GeV, peak= " << m_massPeak
          << " GeV" << endmsg;

--- a/RecCalorimeter/src/components/PairCaloClustersPi0.cpp
+++ b/RecCalorimeter/src/components/PairCaloClustersPi0.cpp
@@ -29,8 +29,10 @@ StatusCode PairCaloClustersPi0::initialize() {
   if (shapeParametersLabels.has_value()) {
     info() << "Found " << shapeParametersLabels->size() << " shape parameters labels" << endmsg;
     std::vector<std::string> shapeParameterNames = shapeParametersLabels.value_or(std::vector<std::string>{});
-    k4FWCore::putCollectionParameter(m_pairedClusters.objKey(), edm4hep::labels::ShapeParameterNames, shapeParameterNames, this);
-    k4FWCore::putCollectionParameter(m_unpairedClusters.objKey(), edm4hep::labels::ShapeParameterNames, shapeParameterNames, this);
+    k4FWCore::putCollectionParameter(m_pairedClusters.objKey(), edm4hep::labels::ShapeParameterNames,
+                                     shapeParameterNames, this);
+    k4FWCore::putCollectionParameter(m_unpairedClusters.objKey(), edm4hep::labels::ShapeParameterNames,
+                                     shapeParameterNames, this);
   } else {
     info() << "No shapeParameters metadata in the input cluster collection" << endmsg;
   }

--- a/RecCalorimeter/src/components/PairCaloClustersPi0.cpp
+++ b/RecCalorimeter/src/components/PairCaloClustersPi0.cpp
@@ -1,4 +1,6 @@
 #include "PairCaloClustersPi0.h"
+// Key4HEP
+#include "k4FWCore/MetadataUtils.h"
 
 // Include the <cmath> header for sqrt, pow
 #include <cmath>
@@ -19,6 +21,18 @@ StatusCode PairCaloClustersPi0::initialize() {
     if (sc.isFailure()) {
       return sc;
     }
+  }
+
+  // If there are shapeParameters metadata in the input cluster collection, ship them to the output cluster collections
+  auto shapeParametersLabels = k4FWCore::getCollectionParameter<std::vector<std::string>>(
+      m_inClusters.objKey(), edm4hep::labels::ShapeParameterNames, this);
+  if (shapeParametersLabels.has_value()) {
+    info() << "Found " << shapeParametersLabels->size() << " shape parameters labels" << endmsg;
+    std::vector<std::string> shapeParameterNames = shapeParametersLabels.value_or(std::vector<std::string>{});
+    k4FWCore::putCollectionParameter(m_pairedClusters.objKey(), edm4hep::labels::ShapeParameterNames, shapeParameterNames, this);
+    k4FWCore::putCollectionParameter(m_unpairedClusters.objKey(), edm4hep::labels::ShapeParameterNames, shapeParameterNames, this);
+  } else {
+    info() << "No shapeParameters metadata in the input cluster collection" << endmsg;
   }
 
   // print pi0 mass window

--- a/RecCalorimeter/src/components/PairCaloClustersPi0.cpp
+++ b/RecCalorimeter/src/components/PairCaloClustersPi0.cpp
@@ -25,8 +25,8 @@ StatusCode PairCaloClustersPi0::initialize() {
 
   // If there are shapeParameters metadata in the input cluster collection, ship them to the output cluster collections
   auto shapeParameterNames = k4FWCore::getCollectionParameter<std::vector<std::string>>(
-                             m_inClusters.objKey(), edm4hep::labels::ShapeParameterNames, this)
-                             .value_or(std::vector<std::string>{});
+                                 m_inClusters.objKey(), edm4hep::labels::ShapeParameterNames, this)
+                                 .value_or(std::vector<std::string>{});
   if (shapeParameterNames.size() > 0) {
     k4FWCore::putCollectionParameter(m_pairedClusters.objKey(), edm4hep::labels::ShapeParameterNames,
                                      shapeParameterNames, this);

--- a/RecCalorimeter/src/components/PairCaloClustersPi0.cpp
+++ b/RecCalorimeter/src/components/PairCaloClustersPi0.cpp
@@ -24,19 +24,15 @@ StatusCode PairCaloClustersPi0::initialize() {
   }
 
   // If there are shapeParameters metadata in the input cluster collection, ship them to the output cluster collections
-  auto shapeParametersLabels = k4FWCore::getCollectionParameter<std::vector<std::string>>(
-      m_inClusters.objKey(), edm4hep::labels::ShapeParameterNames, this);
-  if (shapeParametersLabels.has_value()) {
-    info() << "Found " << shapeParametersLabels->size() << " shape parameters labels" << endmsg;
-    std::vector<std::string> shapeParameterNames = shapeParametersLabels.value_or(std::vector<std::string>{});
-    k4FWCore::putCollectionParameter(m_pairedClusters.objKey(), edm4hep::labels::ShapeParameterNames,
+auto shapeParameterNames = k4FWCore::getCollectionParameter<std::vector<std::string>>(
+                             m_inClusters.objKey(), edm4hep::labels::ShapeParameterNames, this)
+                             .value_or(std::vector<std::string>{});
+if (shapeParameterNames.size()>0) {
+  k4FWCore::putCollectionParameter(m_pairedClusters.objKey(), edm4hep::labels::ShapeParameterNames,
                                      shapeParameterNames, this);
-    k4FWCore::putCollectionParameter(m_unpairedClusters.objKey(), edm4hep::labels::ShapeParameterNames,
+  k4FWCore::putCollectionParameter(m_unpairedClusters.objKey(), edm4hep::labels::ShapeParameterNames,
                                      shapeParameterNames, this);
-  } else {
-    info() << "No shapeParameters metadata in the input cluster collection" << endmsg;
-  }
-
+}
   // print pi0 mass window
   info() << "pi0 mass window for cluster pairing: [" << m_massLow << "," << m_massHigh << "] GeV, peak= " << m_massPeak
          << " GeV" << endmsg;


### PR DESCRIPTION

BEGINRELEASENOTES
- Modified `PairCaloClustersPi0` to add cluster metadata (e.g. showerShapes' names) to the output clusters

ENDRELEASENOTES
