### PR TITLE
IDEA o2 seeded ECAL clustering algorithms

### DIFF
--- a/RecCalorimeter/src/components/CreateOpticalCaloCells.cpp
+++ b/RecCalorimeter/src/components/CreateOpticalCaloCells.cpp
@@ -1,0 +1,90 @@
+#include "CreateOpticalCaloCells.h"
+
+// EDM4hep
+#include "edm4hep/CalorimeterHit.h"
+
+// k4FWCore
+#include <k4FWCore/MetadataUtils.h>
+
+// DD4hep
+#include "DDSegmentation/BitFieldCoder.h"
+
+// STL
+#include <stdexcept>
+#include <unordered_map>
+
+DECLARE_COMPONENT(CreateOpticalCaloCells)
+
+CreateOpticalCaloCells::CreateOpticalCaloCells(const std::string& name, ISvcLocator* svcLoc)
+    : MultiTransformer(name, svcLoc,
+                       {KeyValue("OpticalHits", "SimCalorimeterHitCollection"),
+                        KeyValue("TruthHits", "SimCalorimeterHitCollection")},
+                       {KeyValue("OutputCollection", "CalorimeterHitCollection"),
+                        KeyValue("OutputLinks", "CaloHitSimCaloHitLinkCollection")}) {}
+
+StatusCode CreateOpticalCaloCells::initialize() {
+  info() << name() << ": calibration constant = " << m_calibConst.value() << endmsg;
+
+  if (m_maskCherenkov.value()) {
+    // Locate the 'cherenkov' field in the input cellID encoding to build its mask
+    const std::string opticalKey = inputLocations("OpticalHits")[0];
+    auto encoding = k4FWCore::getCellIDEncoding(opticalKey, this);
+    if (!encoding.has_value()) {
+      error() << "maskCherenkovForTruthLink is set but the cellID encoding of '" << opticalKey
+              << "' could not be retrieved" << endmsg;
+      return StatusCode::FAILURE;
+    }
+    dd4hep::DDSegmentation::BitFieldCoder decoder(encoding.value());
+    try {
+      m_cherenkovMask = decoder[m_cherenkovField.value()].mask();
+    } catch (const std::exception& e) {
+      error() << "cellID field '" << m_cherenkovField.value() << "' not found in encoding '" << encoding.value()
+              << "': " << e.what() << endmsg;
+      return StatusCode::FAILURE;
+    }
+    info() << "Cherenkov masking enabled: optical->truth match ignores field '" << m_cherenkovField.value()
+           << "' (mask 0x" << std::hex << m_cherenkovMask << std::dec << ")" << endmsg;
+  }
+  return StatusCode::SUCCESS;
+}
+
+uint64_t CreateOpticalCaloCells::truthKey(uint64_t cellID) const {
+  return m_maskCherenkov.value() ? (cellID & ~m_cherenkovMask) : cellID;
+}
+
+std::tuple<edm4hep::CalorimeterHitCollection, edm4hep::CaloHitSimCaloHitLinkCollection>
+CreateOpticalCaloCells::operator()(const edm4hep::SimCalorimeterHitCollection& opticalHits,
+                                   const edm4hep::SimCalorimeterHitCollection& truthHits) const {
+  edm4hep::CalorimeterHitCollection outputHits;
+  edm4hep::CaloHitSimCaloHitLinkCollection outputLinks;
+
+  // Index the truth (energy-deposit) hits by their (optionally cherenkov-masked) cellID
+  std::unordered_map<uint64_t, edm4hep::SimCalorimeterHit> truthHitMap;
+  truthHitMap.reserve(truthHits.size());
+  for (const auto& truthHit : truthHits) {
+    truthHitMap[truthKey(truthHit.getCellID())] = truthHit;
+  }
+
+  // Digitize the optical hits and link each cell to its truth deposit
+  for (const auto& opticalHit : opticalHits) {
+    if (opticalHit.getEnergy() <= 0) {
+      continue; // skip cells with no signal
+    }
+    auto caloHit = outputHits.create();
+    caloHit.setCellID(opticalHit.getCellID());
+    caloHit.setPosition(opticalHit.getPosition());
+    caloHit.setEnergy(opticalHit.getEnergy() * m_calibConst.value());
+
+    auto truthIt = truthHitMap.find(truthKey(opticalHit.getCellID()));
+    if (truthIt != truthHitMap.end()) {
+      auto hitLink = outputLinks.create();
+      hitLink.setFrom(caloHit);
+      hitLink.setTo(truthIt->second);
+    }
+  }
+
+  debug() << "Digitized " << opticalHits.size() << " optical hits -> " << outputHits.size() << " cells with "
+          << outputLinks.size() << " truth links" << endmsg;
+
+  return std::make_tuple(std::move(outputHits), std::move(outputLinks));
+}

--- a/RecCalorimeter/src/components/CreateOpticalCaloCells.h
+++ b/RecCalorimeter/src/components/CreateOpticalCaloCells.h
@@ -1,0 +1,65 @@
+#ifndef RECCALORIMETER_CREATEOPTICALCALOCELLS_H
+#define RECCALORIMETER_CREATEOPTICALCALOCELLS_H
+
+// k4FWCore
+#include "k4FWCore/Transformer.h"
+
+// EDM4hep
+#include "edm4hep/CaloHitSimCaloHitLinkCollection.h"
+#include "edm4hep/CalorimeterHitCollection.h"
+#include "edm4hep/SimCalorimeterHitCollection.h"
+
+#include <cstdint>
+#include <string>
+#include <tuple>
+
+/** @class CreateOpticalCaloCells
+ *
+ *  Digitizer for optical-readout calorimeters. Turns the optical-photon SimCalorimeterHits into
+ *  CalorimeterHits (energy = signal * calibrationConstant, position taken from
+ *  the SimHit) and links each cell to the truth (energy-deposit)
+ *  SimCalorimeterHit at the same cellID.
+ *
+ *  Inputs:
+ *   - OpticalHits : optical-photon SimCalorimeterHits, provide the cell signal
+ *   - TruthHits   : energy-deposit SimCalorimeterHits, the link targets
+ *
+ *  The optical->truth match uses the full cellID by default. When the scint and
+ *  Cherenkov signals of one physical cell share a cellID that differs only in
+ *  the 'cherenkov' field - as in the crystal ECAL, where both readings come from
+ *  the same energy deposit - set maskCherenkovForTruthLink=true to drop that
+ *  field from the match, so both readings link to the same truth hit. In the
+ *  HCAL the scint and Cherenkov fibres are distinct cells, so the
+ *  full-cellID default already links them to their own deposits.
+ */
+
+class CreateOpticalCaloCells final
+    : public k4FWCore::MultiTransformer<std::tuple<edm4hep::CalorimeterHitCollection,
+                                                   edm4hep::CaloHitSimCaloHitLinkCollection>(
+          const edm4hep::SimCalorimeterHitCollection&, const edm4hep::SimCalorimeterHitCollection&)> {
+public:
+  CreateOpticalCaloCells(const std::string& name, ISvcLocator* svcLoc);
+
+  StatusCode initialize() override;
+
+  std::tuple<edm4hep::CalorimeterHitCollection, edm4hep::CaloHitSimCaloHitLinkCollection>
+  operator()(const edm4hep::SimCalorimeterHitCollection& opticalHits,
+             const edm4hep::SimCalorimeterHitCollection& truthHits) const override;
+
+private:
+  /// cellID key used to match an optical hit to a truth hit (optionally cherenkov-masked)
+  uint64_t truthKey(uint64_t cellID) const;
+
+  Gaudi::Property<float> m_calibConst{this, "calibrationConstant", 1.,
+                                      "Multiplicative calibration from optical signal to cell energy"};
+  Gaudi::Property<bool> m_maskCherenkov{this, "maskCherenkovForTruthLink", false,
+                                        "Ignore the 'cherenkov' cellID field when matching optical hits to truth hits"};
+  Gaudi::Property<std::string> m_cherenkovField{
+      this, "cherenkovFieldName", "cherenkov",
+      "Name of the cellID field flagging the Cherenkov readout (used only when maskCherenkovForTruthLink=true)"};
+
+  /// mask of the cherenkov field, filled in initialize() when masking is enabled
+  uint64_t m_cherenkovMask{0};
+};
+
+#endif /* RECCALORIMETER_CREATEOPTICALCALOCELLS_H */

--- a/RecCalorimeter/src/components/CreateOpticalCaloCells.h
+++ b/RecCalorimeter/src/components/CreateOpticalCaloCells.h
@@ -34,9 +34,9 @@
  */
 
 class CreateOpticalCaloCells final
-    : public k4FWCore::MultiTransformer<std::tuple<edm4hep::CalorimeterHitCollection,
-                                                   edm4hep::CaloHitSimCaloHitLinkCollection>(
-          const edm4hep::SimCalorimeterHitCollection&, const edm4hep::SimCalorimeterHitCollection&)> {
+    : public k4FWCore::MultiTransformer<
+          std::tuple<edm4hep::CalorimeterHitCollection, edm4hep::CaloHitSimCaloHitLinkCollection>(
+              const edm4hep::SimCalorimeterHitCollection&, const edm4hep::SimCalorimeterHitCollection&)> {
 public:
   CreateOpticalCaloCells(const std::string& name, ISvcLocator* svcLoc);
 

--- a/RecFCCeeCalorimeter/CMakeLists.txt
+++ b/RecFCCeeCalorimeter/CMakeLists.txt
@@ -67,6 +67,14 @@ add_test(NAME IDEA_o1_v03_reco
 set_test_env(IDEA_o1_v03_reco)
 set_tests_properties(IDEA_o1_v03_reco PROPERTIES DEPENDS simulateSiPM)
 
+add_test(NAME IDEA_o2_v01_reco
+         COMMAND sh ${PROJECT_SOURCE_DIR}/RecFCCeeCalorimeter/tests/options/test_IDEAo2_reco.sh
+         WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/Testing/Temporary
+)
+set_test_env(IDEA_o2_v01_reco)
+# ddsim of the wedge peaks ~7 GB -> run alone to avoid OOM from parallel stacking
+set_tests_properties(IDEA_o2_v01_reco PROPERTIES RUN_SERIAL TRUE TIMEOUT 1800)
+
 add_test(NAME FCCeeCalo_DigitizationWhiteningFilter
          COMMAND k4run ${PROJECT_SOURCE_DIR}/RecFCCeeCalorimeter/tests/options/runDigitizationAndMatchedFilter.py
          WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/Testing/Temporary

--- a/RecFCCeeCalorimeter/src/components/CaloDrivenClusterSeeding.cpp
+++ b/RecFCCeeCalorimeter/src/components/CaloDrivenClusterSeeding.cpp
@@ -1,0 +1,174 @@
+#include "CaloDrivenClusterSeeding.h"
+
+#include "edm4hep/CalorimeterHit.h"
+#include "edm4hep/MutableCluster.h"
+
+#include "DD4hep/Detector.h"
+#include "DDSegmentation/Segmentation.h"
+
+#include "ClusterSeedMerging.h" // for enum
+
+#include <unordered_map>
+#include <vector>
+#include <queue>
+#include <cstdint>
+
+// ============================================================
+//  CaloDrivenClusterSeeding
+// ============================================================
+
+CaloDrivenClusterSeeding::CaloDrivenClusterSeeding(const std::string& name,
+                                                   ISvcLocator*      svcLoc)
+    : ClusterSeedingBase(name, svcLoc,
+                       {KeyValues("InputCaloHitCollections", {})},
+                       {KeyValue("OutputSeedsA", "CaloDrivenSeedsA"),
+                        KeyValue("OutputSeedsB", "CaloDrivenSeedsB")}) {}
+
+StatusCode CaloDrivenClusterSeeding::initialize() {
+  return ClusterSeedingBase::initialize();
+}
+
+// ------------------------------------------------------------
+
+std::tuple<edm4hep::ClusterCollection, edm4hep::ClusterCollection>
+CaloDrivenClusterSeeding::operator()(
+    const std::vector<const edm4hep::CalorimeterHitCollection*>& caloHitColls) const {
+
+  edm4hep::ClusterCollection seedsA;
+  edm4hep::ClusterCollection seedsB;
+
+  const float thrA = m_seedEnergyThresholdA.value();
+  const float thrB = m_seedEnergyThresholdB.value();
+
+  // ------------------------------------------------------------------
+  // Step 1: Accumulate ECAL scintillation depth-0 energy per cellID.
+  //         Also keep a representative CalorimeterHit per cellID so we
+  //         can attach it to the output cluster.
+  // ------------------------------------------------------------------
+  std::unordered_map<uint64_t, float> energyMap;
+  ClusterSeedingBase::Hitmap hitMap;
+
+  // create lookup maps by looping over all input collections and hits
+  for (const auto* coll : caloHitColls) {
+    if (!coll)
+      continue;
+
+    for (const auto& hit : *coll) {
+      const uint64_t cellID = hit.getCellID();
+
+      if (!passSelection(cellID))
+        continue;
+
+      energyMap[cellID] = hit.getEnergy();
+      hitMap.try_emplace(cellID, hit);
+    }
+  }
+
+  // ------------------------------------------------------------------
+  // Step 2: For each above-threshold crystal, check seeding conditions.
+  // ------------------------------------------------------------------
+
+  auto isLocalMax = [&energyMap,this](const uint64_t cellID,
+                             const float energy,
+                             const std::set<uint64_t>& nbrs) -> bool {
+    for (const uint64_t nb : nbrs) {
+      if (nb == cellID)
+        continue;
+
+      auto it = energyMap.find(nb);
+      if (it != energyMap.end() && it->second > energy) {
+        return false;
+      }
+    }
+
+    return true;
+  }; // lambda isLocalMax
+
+  struct SeedCandidate {
+    uint64_t cellID;
+    std::set<uint64_t> neighbors;
+  };
+
+  std::vector<SeedCandidate> seedsTypeA, seedsTypeB; // store cellIDs of seeds
+
+  for (const auto& [cellID, energy] : energyMap) {
+    if (!passSelection(cellID))
+        continue;
+
+    // --- Type A ---
+    // the seed crystal exceeds the threshold
+    // and is a local maximum within its Von Neumann neighbourhood
+    if (energy >= thrA) {
+      const auto nbrs = vonNeumannNeighbors(cellID, m_vnDistance.value());
+
+      if (isLocalMax(cellID, energy, nbrs))
+        seedsTypeA.push_back({cellID, nbrs}); // store the whole neighborhood as a seed
+    } // end Type A
+
+    // --- Type B ---
+    // the seed crystal exceeds the threshold
+    // in the same VN neighbourhood, all above-threshold neighbours are connected
+    // and the seed is a local maximum within the neighbourhood
+    if (energy >= thrB) {
+      const auto nbrs = vonNeumannNeighbors(cellID, m_vnDistance.value());
+
+      // Collect above-threshold neighbours (including self)
+      std::set<uint64_t> aboveThresh;
+      for (const uint64_t nb : nbrs) {
+        auto it = energyMap.find(nb);
+        if (it != energyMap.end() && it->second >= thrB) {
+          aboveThresh.insert(nb);
+        }
+      } // loop over neighbours
+
+      // check above threshold neighbour count
+      // and connectivity of above-threshold neighbours
+      if (aboveThresh.size() >= m_minAboveThresholdNeighbours.value() && isConnected(aboveThresh)) {
+        // Local maximum
+        if (isLocalMax(cellID, energy, nbrs))
+          seedsTypeB.push_back({cellID, nbrs}); // store the whole neighborhood as a seed
+      } // end if neighbor count and connectivity
+    } // end Type B
+  } // loop over energyMap
+
+  // ------------------------------------------------------------------
+  // Step 3: Create output clusters for the seeds
+  for (const auto& seed : seedsTypeA) {
+    if (seed.neighbors.empty())
+      continue;
+
+    auto cluster = seedsA.create();
+    cluster.setType(static_cast<int>(ClusterSeeding::SeedType::CaloDrivenA)); // Type A seed
+    // use the seed hit position as the cluster position
+    cluster.setPosition(hitMap[seed.cellID].getPosition());
+    // attach only hits that have actual energy deposits
+    for (const auto& cellID : seed.neighbors) {
+      auto it = hitMap.find(cellID);
+      if (it != hitMap.end())
+        cluster.addToHits(it->second);
+    }
+  } // loop over seedsTypeA
+
+  for (const auto& seed : seedsTypeB) {
+    if (seed.neighbors.empty())
+      continue;
+
+    auto cluster = seedsB.create();
+    cluster.setType(static_cast<int>(ClusterSeeding::SeedType::CaloDrivenB)); // Type B seed
+    // use the seed hit position as the cluster position
+    cluster.setPosition(hitMap[seed.cellID].getPosition());
+    // attach only hits that have actual energy deposits
+    for (const auto& cellID : seed.neighbors) {
+      auto it = hitMap.find(cellID);
+      if (it != hitMap.end())
+        cluster.addToHits(it->second);
+    }
+  } // loop over seedsTypeB
+
+  debug() << "CaloDrivenClusterSeeding: found " << seedsTypeA.size()
+          << " Type-A seeds and " << seedsTypeB.size() << " Type-B seeds." << endmsg;
+
+  return std::make_tuple(std::move(seedsA), std::move(seedsB));
+} // operator()
+
+DECLARE_COMPONENT(CaloDrivenClusterSeeding)

--- a/RecFCCeeCalorimeter/src/components/CaloDrivenClusterSeeding.cpp
+++ b/RecFCCeeCalorimeter/src/components/CaloDrivenClusterSeeding.cpp
@@ -8,31 +8,26 @@
 
 #include "ClusterSeedMerging.h" // for enum
 
+#include <cstdint>
+#include <queue>
 #include <unordered_map>
 #include <vector>
-#include <queue>
-#include <cstdint>
 
 // ============================================================
 //  CaloDrivenClusterSeeding
 // ============================================================
 
-CaloDrivenClusterSeeding::CaloDrivenClusterSeeding(const std::string& name,
-                                                   ISvcLocator*      svcLoc)
-    : ClusterSeedingBase(name, svcLoc,
-                       {KeyValues("InputCaloHitCollections", {})},
-                       {KeyValue("OutputSeedsA", "CaloDrivenSeedsA"),
-                        KeyValue("OutputSeedsB", "CaloDrivenSeedsB")}) {}
-
-StatusCode CaloDrivenClusterSeeding::initialize() {
-  return ClusterSeedingBase::initialize();
+CaloDrivenClusterSeeding::CaloDrivenClusterSeeding(const std::string& name, ISvcLocator* svcLoc)
+    : ClusterSeedingBase(name, svcLoc, {KeyValues("InputCaloHitCollections", {})},
+                         {KeyValue("OutputSeedsA", "CaloDrivenSeedsA"), KeyValue("OutputSeedsB", "CaloDrivenSeedsB")}) {
 }
+
+StatusCode CaloDrivenClusterSeeding::initialize() { return ClusterSeedingBase::initialize(); }
 
 // ------------------------------------------------------------
 
 std::tuple<edm4hep::ClusterCollection, edm4hep::ClusterCollection>
-CaloDrivenClusterSeeding::operator()(
-    const std::vector<const edm4hep::CalorimeterHitCollection*>& caloHitColls) const {
+CaloDrivenClusterSeeding::operator()(const std::vector<const edm4hep::CalorimeterHitCollection*>& caloHitColls) const {
 
   edm4hep::ClusterCollection seedsA;
   edm4hep::ClusterCollection seedsB;
@@ -68,9 +63,8 @@ CaloDrivenClusterSeeding::operator()(
   // Step 2: For each above-threshold crystal, check seeding conditions.
   // ------------------------------------------------------------------
 
-  auto isLocalMax = [&energyMap,this](const uint64_t cellID,
-                             const float energy,
-                             const std::set<uint64_t>& nbrs) -> bool {
+  auto isLocalMax = [&energyMap, this](const uint64_t cellID, const float energy,
+                                       const std::set<uint64_t>& nbrs) -> bool {
     for (const uint64_t nb : nbrs) {
       if (nb == cellID)
         continue;
@@ -93,7 +87,7 @@ CaloDrivenClusterSeeding::operator()(
 
   for (const auto& [cellID, energy] : energyMap) {
     if (!passSelection(cellID))
-        continue;
+      continue;
 
     // --- Type A ---
     // the seed crystal exceeds the threshold
@@ -165,8 +159,8 @@ CaloDrivenClusterSeeding::operator()(
     }
   } // loop over seedsTypeB
 
-  debug() << "CaloDrivenClusterSeeding: found " << seedsTypeA.size()
-          << " Type-A seeds and " << seedsTypeB.size() << " Type-B seeds." << endmsg;
+  debug() << "CaloDrivenClusterSeeding: found " << seedsTypeA.size() << " Type-A seeds and " << seedsTypeB.size()
+          << " Type-B seeds." << endmsg;
 
   return std::make_tuple(std::move(seedsA), std::move(seedsB));
 } // operator()

--- a/RecFCCeeCalorimeter/src/components/CaloDrivenClusterSeeding.h
+++ b/RecFCCeeCalorimeter/src/components/CaloDrivenClusterSeeding.h
@@ -31,8 +31,8 @@
 #include "edm4hep/CalorimeterHitCollection.h"
 #include "edm4hep/ClusterCollection.h"
 
-#include "k4FWCore/Transformer.h"
 #include "Gaudi/Property.h"
+#include "k4FWCore/Transformer.h"
 
 #include "ClusterSeedingBase.h"
 
@@ -40,9 +40,8 @@
 #include <vector>
 
 struct CaloDrivenClusterSeeding final
-    : ClusterSeedingBase<
-          std::tuple<edm4hep::ClusterCollection, edm4hep::ClusterCollection>(
-              const std::vector<const edm4hep::CalorimeterHitCollection*>&)> {
+    : ClusterSeedingBase<std::tuple<edm4hep::ClusterCollection, edm4hep::ClusterCollection>(
+          const std::vector<const edm4hep::CalorimeterHitCollection*>&)> {
 
   CaloDrivenClusterSeeding(const std::string& name, ISvcLocator* svcLoc);
 
@@ -63,7 +62,7 @@ struct CaloDrivenClusterSeeding final
       this, "MinAboveThresholdNeighbours", 2,
       "Minimum number of above-threshold neighbours (including seed) for a Type-B seed"};
   Gaudi::Property<int> m_vnDistance{this, "VonNeumannDistance", 2,
-      "Von Neumann distance for neighbourhood definition (applies to both seed types)"};
+                                    "Von Neumann distance for neighbourhood definition (applies to both seed types)"};
 };
 
 #endif // CaloDrivenClusterSeeding_h

--- a/RecFCCeeCalorimeter/src/components/CaloDrivenClusterSeeding.h
+++ b/RecFCCeeCalorimeter/src/components/CaloDrivenClusterSeeding.h
@@ -1,0 +1,69 @@
+#ifndef CaloDrivenClusterSeeding_h
+#define CaloDrivenClusterSeeding_h 1
+
+/*
+ * CaloDrivenClusterSeeding
+ *
+ * Gaudi MultiTransformer that identifies ECAL cluster seeds purely from
+ * calorimeter hit energy deposits (no tracking information).
+ *
+ * Input
+ * -----
+ *   std::vector<const edm4hep::CalorimeterHitCollection*>
+ *       All digitised calorimeter hit collections.  The algorithm filters
+ *       internally for (ECAL) depth-0 hits
+ *
+ * Output  std::tuple<seedsA, seedsB>
+ * ------
+ *   seedsA  (edm4hep::ClusterCollection)
+ *       Type-A seeds: crystals with E > SeedEnergyThresholdA that are a
+ *       local maximum within their Von Neumann distance-k neighbourhood.
+ *
+ *   seedsB  (edm4hep::ClusterCollection)
+ *       Type-B seeds: crystals with E > SeedEnergyThresholdB that are a
+ *       local maximum within their Von Neumann distance-k neighbourhood,
+ *       have at least MinAboveThresholdNeighbours (including self) above the
+ *       above-threshold neighbours in that neighbourhood, AND all
+ *       above-threshold crystals in the neighbourhood are topologically
+ *       connected via VN-d1 adjacency.
+ */
+
+#include "edm4hep/CalorimeterHitCollection.h"
+#include "edm4hep/ClusterCollection.h"
+
+#include "k4FWCore/Transformer.h"
+#include "Gaudi/Property.h"
+
+#include "ClusterSeedingBase.h"
+
+#include <tuple>
+#include <vector>
+
+struct CaloDrivenClusterSeeding final
+    : ClusterSeedingBase<
+          std::tuple<edm4hep::ClusterCollection, edm4hep::ClusterCollection>(
+              const std::vector<const edm4hep::CalorimeterHitCollection*>&)> {
+
+  CaloDrivenClusterSeeding(const std::string& name, ISvcLocator* svcLoc);
+
+  StatusCode initialize() override;
+  StatusCode finalize() override { return StatusCode::SUCCESS; }
+
+  std::tuple<edm4hep::ClusterCollection, edm4hep::ClusterCollection>
+  operator()(const std::vector<const edm4hep::CalorimeterHitCollection*>& caloHitColls) const override;
+
+  // ---- Configurable parameters ----
+  Gaudi::Property<float> m_seedEnergyThresholdA{
+      this, "SeedEnergyThresholdA", 0.040f,
+      "Minimum crystal energy [GeV] for a Type-A seed (local max, Von Neumann neighbourhood)"};
+  Gaudi::Property<float> m_seedEnergyThresholdB{
+      this, "SeedEnergyThresholdB", 0.020f,
+      "Minimum crystal energy [GeV] for a Type-B seed (local max + connectivity)"};
+  Gaudi::Property<unsigned int> m_minAboveThresholdNeighbours{
+      this, "MinAboveThresholdNeighbours", 2,
+      "Minimum number of above-threshold neighbours (including seed) for a Type-B seed"};
+  Gaudi::Property<int> m_vnDistance{this, "VonNeumannDistance", 2,
+      "Von Neumann distance for neighbourhood definition (applies to both seed types)"};
+};
+
+#endif // CaloDrivenClusterSeeding_h

--- a/RecFCCeeCalorimeter/src/components/ClusterSeedGrower.cpp
+++ b/RecFCCeeCalorimeter/src/components/ClusterSeedGrower.cpp
@@ -1,0 +1,624 @@
+#include "ClusterSeedGrower.h"
+#include "ClusterSeedMerging.h" // for enum
+
+#include "edm4hep/CalorimeterHit.h"
+#include "edm4hep/MutableCluster.h"
+
+#include "DD4hep/Detector.h"
+#include "DDSegmentation/Segmentation.h"
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+#include <numeric>
+#include <set>
+#include <unordered_map>
+#include <unordered_set>
+#include <queue>
+#include <vector>
+
+// ============================================================
+//  ClusterSeedGrower
+// ============================================================
+
+ClusterSeedGrower::ClusterSeedGrower(const std::string& name, ISvcLocator* svcLoc)
+    : ClusterSeedingBase(name, svcLoc,
+                       {KeyValues("InputSeeds", {}),
+                        KeyValues("InputHits",  {})},
+                       {KeyValue("OutputClusters", "TopoGrownClusters")}) {}
+
+// ------------------------------------------------------------
+
+StatusCode ClusterSeedGrower::initialize() {
+  if (ClusterSeedingBase::initialize().isFailure())
+    return StatusCode::FAILURE;
+
+  if (m_fieldStringsToInclude.size() != m_fieldValuesToInclude.size()) {
+    error() << "ClusterSeedGrower: FieldStringsToInclude and FieldValuesToInclude must have the same number of entries "
+            << "(got " << m_fieldStringsToInclude.size() << " vs " << m_fieldValuesToInclude.size() << ")." << endmsg;
+    return StatusCode::FAILURE;
+  }
+
+  try {
+    for (const auto& field : m_fieldStringsToInclude.value())
+      m_decoder->index(field); // check field existence
+  } catch (const std::exception& ex) {
+    error() << "ClusterSeedGrower: Error in cell ID filtering configuration: " << ex.what() << endmsg;
+    return StatusCode::FAILURE;
+  }
+
+  if (m_hardThreshold.value() > m_growThreshold.value()) {
+    warning() << "ClusterSeedGrower: HardThreshold (" << m_hardThreshold.value()
+              << " GeV) > GrowThreshold (" << m_growThreshold.value()
+              << " GeV). No isolated hits will ever be assigned in the post-BFS phase." << endmsg;
+  }
+
+  return StatusCode::SUCCESS;
+}
+
+// ------------------------------------------------------------
+
+auto ClusterSeedGrower::connectedSeeds(const Hitmap& pool,
+                                       unsigned int  vnDist,
+                                       float         threshold,
+                                       unsigned int  minHits) const
+    -> std::vector<Hitmap> {
+  // visited tracks which cells in *pool* have already been consumed
+  // into a component.  Only cells present in *pool* are ever visited.
+  std::unordered_map<uint64_t, bool> visited;
+  visited.reserve(pool.size());
+  for (const auto& [cid, hit] : pool)
+    visited[cid] = false;
+
+  std::vector<ClusterSeedingBase::Hitmap> result;
+
+  for (const auto& [startCID, startHit] : pool) {
+    if (visited[startCID])
+      continue; // already consumed into a previous component
+    if (startHit.getEnergy() < threshold)
+      continue; // below seeding threshold
+
+    // BFS: grow one connected component from startCID.
+    // Only cells inside *pool* with E >= threshold are traversed.
+    ClusterSeedingBase::Hitmap component;
+    std::queue<uint64_t> bfsQueue;
+    bfsQueue.push(startCID);
+
+    while (!bfsQueue.empty()) {
+      const uint64_t cur = bfsQueue.front();
+      bfsQueue.pop();
+
+      if (visited[cur])
+        continue;
+      visited[cur] = true;
+
+      const auto& curHit = pool.at(cur);
+      if (curHit.getEnergy() < threshold)
+        continue; // below threshold - do not include
+
+      component.emplace(cur, curHit);
+
+      // Expand via VN distance vnDist.  vonNeumannNeighbors already
+      // applies passSelection, so only geometrically valid neighbours
+      // are returned.
+      const std::set<uint64_t> vnn = vonNeumannNeighbors(cur, vnDist);
+      for (const uint64_t nb : vnn) {
+        if (nb == cur)
+          continue;
+        const auto vit = visited.find(nb);
+        if (vit == visited.end() || vit->second)
+          continue; // not in pool, or already visited
+        if (pool.at(nb).getEnergy() >= threshold)
+          bfsQueue.push(nb);
+      }
+    } // BFS
+
+    if (component.size() >= minHits)
+      result.push_back(std::move(component));
+  } // loop over pool cells
+
+  return result;
+} // connectedSeeds
+
+// ------------------------------------------------------------
+
+auto ClusterSeedGrower::grow(ContestStrategy         strategy,
+                             const Hitmap&           pool,
+                             const std::vector<Hitmap>& seeds,
+                             unsigned int            vnDist,
+                             float                   growThreshold) const
+    -> std::vector<Hitmap> {
+  const int n = static_cast<int>(seeds.size());
+  if (n == 0) return {};
+
+  // Working copy: starts identical to seeds and accumulates new hits layer by layer.
+  // Returned to the caller when done (possibly with fewer entries for MergeClusters).
+  std::vector<ClusterSeedingBase::Hitmap> clusters(seeds);
+
+  // --- O(1) "is this cell already assigned?" bookkeeping ---
+  std::unordered_set<uint64_t> assigned;
+  assigned.reserve(pool.size());
+  for (const auto& hm : clusters)
+    for (const auto& [cid, h] : hm)
+      assigned.insert(cid);
+
+  // --- Per-cluster BFS frontier: the cells added in the last layer. ---
+  // In each new layer we expand outward from these cells.
+  std::vector<std::set<uint64_t>> frontier(n);
+  for (int i = 0; i < n; ++i)
+    for (const auto& [cid, h] : clusters[i])
+      frontier[i].insert(cid);
+
+  // --- ResolveByDist: barycenter state per cluster, kept up-to-date each layer ---
+  std::vector<ClusterState> states;
+  if (strategy == ContestStrategy::ResolveByDist) {
+    states.resize(n);
+    for (int i = 0; i < n; ++i)
+      states[i] = calcBarycenter(clusters[i]);
+  }
+
+  // --- Union-find for MergeClusters strategy ---
+  // rep[i] is the "representative" of cluster i's group.
+  // Initially every cluster is its own representative: rep[i] = i.
+  //
+  //   findRep(i): walk up the rep[] chain to the root (representative) of i's
+  //               group. Uses path-halving (rep[x] = rep[rep[x]] each step) to
+  //               keep chains short without extra storage.
+  //
+  //   mergeReps(a,b): make the two groups one by pointing b's representative
+  //                   to a's representative.
+  //
+  // Two cluster indices that share the same representative after some merges
+  // belong to the same logical cluster and will be folded together at the end.
+  std::vector<int> rep(n);
+  std::iota(rep.begin(), rep.end(), 0);
+  auto findRep = [&](int x) {
+    while (rep[x] != x) {
+      rep[x] = rep[rep[x]];
+      x = rep[x];
+    }
+
+    return x;
+  };
+  auto mergeReps = [&](int a, int b) {
+    a = findRep(a);
+    b = findRep(b);
+    if (a != b)
+      rep[b] = a;
+  };
+
+  // --- Helper shared by both strategy branches ---
+  // Returns all cells in pool that neighbour fid (within vnDist), are not yet
+  // assigned to any cluster, and are above growThreshold.
+  auto eligibleNeighbors = [&](uint64_t fid) {
+    std::vector<uint64_t> result;
+    for (const uint64_t nb : vonNeumannNeighbors(fid, vnDist)) {
+      if (nb == fid || assigned.count(nb))
+        continue;
+
+      const auto it = pool.find(nb);
+      if (it == pool.end() || it->second.getEnergy() < growThreshold)
+        continue;
+
+      result.push_back(nb);
+    }
+
+    return result;
+  };
+
+  // --- Layer-by-layer BFS ---
+  bool anyAdded = true;
+  while (anyAdded) {
+    anyAdded = false;
+
+    if (strategy == ContestStrategy::ResolveByDist) {
+
+      // Collect candidates: cellID -> list of claiming cluster indices.
+      // A cluster may appear multiple times (via different frontier cells),
+      // so we deduplicate before resolving.
+      std::unordered_map<uint64_t, std::vector<int>> candidates;
+      for (int i = 0; i < n; ++i)
+        for (const uint64_t fid : frontier[i])
+          for (const uint64_t nb : eligibleNeighbors(fid))
+            candidates[nb].push_back(i);
+
+      for (auto& [cid, claimers] : candidates) {
+        std::sort(claimers.begin(), claimers.end());
+        claimers.erase(std::unique(claimers.begin(), claimers.end()), claimers.end());
+      }
+
+      // Assign: winner is the cluster with the smallest distance.
+      // All other claimers get nothing this layer.
+      std::vector<std::set<uint64_t>> newFrontier(n);
+      std::vector<bool> gained(n, false);
+      for (const auto& [cid, claimers] : candidates) {
+        const auto& hit = pool.at(cid);
+        const auto& pos = hit.getPosition();
+        int winner = claimers[0];
+        if (claimers.size() > 1) {
+          float best = std::numeric_limits<float>::max();
+          for (const int i : claimers) {
+            const float d = openingAngleDist(states[i], pos.x, pos.y, pos.z);
+            if (d < best) {
+              best = d;
+              winner = i;
+            }
+          } // loop over claimers to find winner
+        } // if multiple claimers
+
+        assigned.insert(cid);
+        clusters[winner].emplace(cid, hit);
+        newFrontier[winner].insert(cid);
+        gained[winner] = true;
+        anyAdded = true;
+      } // loop over candidates
+
+      frontier = std::move(newFrontier);
+      // Update barycenters for clusters that received new hits this layer.
+      for (int i = 0; i < n; ++i) {
+        if (gained[i])
+          states[i] = calcBarycenter(clusters[i]);
+      } // loop over clusters to update states
+    } else { // MergeClusters
+      // Several cluster indices may now share the same representative (after
+      // earlier merges). Collapse their individual frontiers into one combined
+      // frontier per representative so we grow from the full merged boundary.
+      std::unordered_map<int, std::set<uint64_t>> repFrontier;
+      for (int i = 0; i < n; ++i) {
+        const int r = findRep(i);
+        for (const uint64_t cid : frontier[i])
+          repFrontier[r].insert(cid);
+      }
+
+      // Collect candidates: cellID -> set of representative indices that can reach it.
+      std::unordered_map<uint64_t, std::set<int>> candidates;
+      for (const auto& [r, fr] : repFrontier)
+        for (const uint64_t fid : fr)
+          for (const uint64_t nb : eligibleNeighbors(fid))
+            candidates[nb].insert(r);
+
+      // Assign the hit to the (merged) representative.
+      // If multiple representatives can reach the same cell, merge them all
+      // into one group — the cell then belongs to that merged cluster.
+      std::unordered_map<int, std::set<uint64_t>> newFrontier;
+      for (const auto& [cid, reps] : candidates) {
+        const auto& hit = pool.at(cid);
+        auto it = reps.begin();
+        int winner = findRep(*it++);
+        // If multiple representatives claim this cell, merge their clusters.
+        for (; it != reps.end(); ++it)
+          mergeReps(winner, findRep(*it));
+
+        const int r = findRep(winner);
+        assigned.insert(cid);
+        clusters[r].emplace(cid, hit);
+        newFrontier[r].insert(cid);
+        anyAdded = true;
+      } // loop over candidates
+
+      // Propagate the new frontier back to per-index structures for next layer.
+      for (int i = 0; i < n; ++i) {
+        const int r = findRep(i);
+        const auto it = newFrontier.find(r);
+        frontier[i] = (it != newFrontier.end()) ? it->second : std::set<uint64_t>{};
+      } // loop over clusters to update frontiers
+    } // if MergeClusters strategy
+  } // while anyAdded
+
+  // For MergeClusters: fold every non-representative cluster into its
+  // representative, then erase the now-empty entries.  The caller receives
+  // exactly one Hitmap per surviving (representative) cluster.
+  if (strategy == ContestStrategy::MergeClusters) {
+    for (int i = 0; i < n; ++i) {
+      const int r = findRep(i);
+      if (r == i)
+        continue;
+
+      // representative r gets all of i's hits
+      // i becomes empty and will be erased.
+      for (auto& [cid, h] : clusters[i])
+        clusters[r].emplace(cid, h);
+
+      clusters[i].clear();
+    }
+
+    // Erase empty absorbed clusters.
+    clusters.erase(std::remove_if(clusters.begin(), clusters.end(),
+                                  [](const ClusterSeedingBase::Hitmap& hm) { return hm.empty(); }),
+                   clusters.end());
+  } // if MergeClusters
+
+  return clusters;
+} // grow
+
+// ------------------------------------------------------------
+
+void ClusterSeedGrower::attachIsolatedHits(const ClusterSeedingBase::Hitmap& pool,
+                                          std::vector<ClusterSeedingBase::Hitmap>& seededClusters,
+                                          std::vector<ClusterSeedingBase::Hitmap>& unseededClusters) const {
+  // --- Snapshot barycenters for all clusters (seeded + unseeded) ---
+  const int nSeeded   = static_cast<int>(seededClusters.size());
+  const int nUnseeded = static_cast<int>(unseededClusters.size());
+  const int nTotal    = nSeeded + nUnseeded;
+
+  // for i < nSeeded   -> seededClusters[i]
+  // for i >= nSeeded  -> unseededClusters[i - nSeeded]
+  std::vector<ClusterState> statesBeforeAttach;
+  statesBeforeAttach.reserve(nTotal);
+  for (const auto& hm : seededClusters)
+    statesBeforeAttach.push_back(calcBarycenter(hm));
+  for (const auto& hm : unseededClusters)
+    statesBeforeAttach.push_back(calcBarycenter(hm));
+
+  const float cosGate = std::cos(m_maxOpeningAngle.value());
+
+  // Build the set of already-owned hitPool cells.
+  std::unordered_set<uint64_t> ownedCells;
+  ownedCells.reserve(pool.size());
+  for (const auto& hm : seededClusters)
+    for (const auto& [cid, h] : hm)
+      ownedCells.insert(cid);
+  for (const auto& hm : unseededClusters)
+    for (const auto& [cid, h] : hm)
+      ownedCells.insert(cid);
+
+  int nAttached = 0;
+  for (const auto& [cid, hit] : pool) {
+    if (ownedCells.count(cid))
+      continue; // already in a cluster
+
+    const auto& pos  = hit.getPosition();
+    const float rh   = std::sqrt(pos.x*pos.x + pos.y*pos.y + pos.z*pos.z);
+    if (rh < std::numeric_limits<float>::epsilon())
+      continue; // degenerate hit position
+
+    int   bestIdx = -1;
+    float bestDist  = std::numeric_limits<float>::max();
+
+    for (int i = 0; i < nTotal; ++i) {
+      const ClusterState& cs = statesBeforeAttach[i];
+      const float rc = std::sqrt(cs.x*cs.x + cs.y*cs.y + cs.z*cs.z);
+      if (rc < std::numeric_limits<float>::epsilon())
+        continue;
+
+      // Opening-angle preselection: cosine of angle between cluster
+      // barycenter direction and hit direction.
+      const float cosAngle = (cs.x*pos.x + cs.y*pos.y + cs.z*pos.z) / (rc * rh);
+      if (cosAngle < cosGate)
+        continue; // opening angle > MaxOpeningAngle
+
+      const float dist = openingAngleDist(cs, pos.x, pos.y, pos.z);
+      if (dist < bestDist) {
+        bestDist  = dist;
+        bestIdx = i;
+      }
+    } // loop over all clusters
+
+    if (bestIdx < 0)
+      continue; // no cluster within angle gate
+
+    // Attach hit to the winning cluster.
+    if (bestIdx < nSeeded)
+      seededClusters[bestIdx].emplace(cid, hit);
+    else
+      unseededClusters[bestIdx - nSeeded].emplace(cid, hit);
+
+    ++nAttached;
+  } // loop over hitPool cells
+
+  debug() << "ClusterSeedGrower: Step 5 attached " << nAttached
+          << " previously unowned hit(s) to existing clusters "
+          << "(MaxOpeningAngle = " << m_maxOpeningAngle.value() << " rad)." << endmsg;
+} // attachIsolatedHits
+
+// ------------------------------------------------------------
+
+std::tuple<edm4hep::ClusterCollection>
+ClusterSeedGrower::operator()(
+    const std::vector<const edm4hep::ClusterCollection*>& seedColls,
+    const std::vector<const edm4hep::CalorimeterHitCollection*>& hitColls) const {
+
+  edm4hep::ClusterCollection output;
+
+  // ------------------------------------------------------------------
+  // Step 1: Build unified hit pool: cellID -> CalorimeterHit.
+  //   Contains only hits that pass field selection AND E >= HardThreshold.
+  //   (Hits with HardThreshold <= E < GrowThreshold block BFS propagation
+  //    but are eligible for isolated-hit assignment in Step 4.)
+  // ------------------------------------------------------------------
+  ClusterSeedingBase::Hitmap hitPool;
+  ClusterSeedingBase::Hitmap leftoverHits;
+  for (const auto* coll : hitColls) {
+    if (!coll)
+      continue;
+
+    for (const auto& hit : *coll) {
+      if (passSelection(hit.getCellID()) && hit.getEnergy() >= m_hardThreshold.value())
+        hitPool.emplace(hit.getCellID(), hit);
+      else if (hit.getEnergy() >= m_hardThreshold.value())
+        leftoverHits.emplace(hit.getCellID(), hit);
+    }
+  } // loop over input hit collections
+
+  // ------------------------------------------------------------------
+  // Step 2: Count total clusters; initialise per-cluster data.
+  // ------------------------------------------------------------------
+  int nClusters = 0;
+  for (const auto* coll : seedColls) {
+    if (coll)
+      nClusters += static_cast<int>(coll->size());
+  }
+
+  if (nClusters == 0) {
+    warning() << "ClusterSeedGrower: no input seeds — returning empty collection." << endmsg;
+    return std::make_tuple(std::move(output));
+  }
+
+  // Per-cluster hit maps (cellID → hit); initial frontier is the seed hits.
+  // seedTypes records each input seed's type so Step 6 can reproduce it.
+  // A temporary flat set handles shared seed hits: first seed wins.
+  std::vector<ClusterSeedingBase::Hitmap> initClusterHits(nClusters);
+  std::vector<int32_t>                    seedTypes(nClusters);
+  {
+    std::unordered_set<uint64_t> initAssigned;
+    initAssigned.reserve(hitPool.size());
+    int ci = 0;
+    for (const auto* coll : seedColls) {
+      if (!coll)
+        continue;
+
+      for (const auto& seed : *coll) {
+        seedTypes[ci] = seed.getType();
+        for (const auto& hit : seed.getHits()) {
+          const uint64_t cid = hit.getCellID();
+          if (!initAssigned.insert(cid).second)
+            continue; // shared hit: first seed wins
+                      // should have been resolved by ClusterSeedMerging upstream (if used)
+          initClusterHits[ci].emplace(cid, hit);
+        }
+        ++ci;
+      } // loop over seeds in this collection
+    } // loop over seed collections
+  } // wrapper scope for initAssigned and ci
+
+  // ------------------------------------------------------------------
+  // Step 3: BFS growth of seeded clusters (opening-angle distance contest resolution).
+  // ------------------------------------------------------------------
+  auto seededClusters = grow(ContestStrategy::ResolveByDist,
+                             hitPool,
+                             initClusterHits,
+                             m_vnDistSeeded.value(),
+                             m_growThreshold.value());
+
+  // ------------------------------------------------------------------
+  // Step 4: Unseeded cluster formation from unassigned hits.
+  //
+  //   a) Collect all hitPool cells not yet assigned to any seeded cluster.
+  //   b) connectedSeeds finds groups of >= MinUnseededHits connected cells
+  //      all above UnseededThreshold within VN distance VNDistUnseeded.
+  //   c) grow() grows them (E >= GrowThreshold,
+  //      VN distance VNDistUnseeded); a contested hit fully merges the
+  //      two competing clusters (union-find).
+  // ------------------------------------------------------------------
+  const unsigned int vnUnseeded  = m_vnDistUnseeded.value();
+  const float        unseededThr = m_unseededThreshold.value();
+  const unsigned int minUHits    = m_minUnseededHits.value();
+
+  // Build unowned pool: hitPool cells not assigned to any seeded cluster.
+  std::unordered_set<uint64_t> seededOwned;
+  seededOwned.reserve(hitPool.size());
+  for (const auto& hm : seededClusters)
+    for (const auto& [cid, h] : hm)
+      seededOwned.insert(cid);
+
+  ClusterSeedingBase::Hitmap unownedPool;
+  for (const auto& [cid, hit] : hitPool) {
+    if (!seededOwned.count(cid))
+      unownedPool.emplace(cid, hit);
+  }
+
+  const int nUnownedAfterSeeded = static_cast<int>(unownedPool.size());
+
+  // Find connected seed groups, then grow them (merging on contest).
+  auto unseededClusters =
+      grow(ContestStrategy::MergeClusters,
+           unownedPool,
+           connectedSeeds(unownedPool, vnUnseeded, unseededThr, minUHits),
+           vnUnseeded,
+           m_growThreshold.value());
+
+  // Count discarded hits (in unownedPool but not in any unseeded cluster)
+  int nAssignedUnseeded = 0;
+  for (const auto& hm : unseededClusters)
+    nAssignedUnseeded += static_cast<int>(hm.size());
+
+  const int nDiscarded = nUnownedAfterSeeded - nAssignedUnseeded;
+  debug() << "ClusterSeedGrower: " << nUnownedAfterSeeded
+          << " unowned hits after seeded BFS; "
+          << unseededClusters.size() << " unseeded cluster(s) formed; "
+          << nDiscarded << " hit(s) discarded after unseeded BFS." << endmsg;
+
+  // ------------------------------------------------------------------
+  // Step 5 (optional): Attach remaining unowned hitPool cells to the nearest cluster.
+  //
+  //   For every hitPool cell that belongs to neither seededClusters nor
+  //   unseededClusters:
+  //     1. Preselect clusters whose barycenter opening angle to the hit is
+  //        < MaxOpeningAngle (snapshot barycenters computed once here; NOT
+  //        updated between individual hit attachments).
+  //     2. Among the preselected clusters, the one with the smallest
+  //        opening-angle distance wins and the hit is appended to it.
+  //   Hits for which no cluster passes the angle gate are left unassigned.
+  // ------------------------------------------------------------------
+  if (m_attachIsolatedHits.value())
+    attachIsolatedHits(hitPool, seededClusters, unseededClusters);
+
+  // ------------------------------------------------------------------
+  // Step 6: Add companion hits (FieldStringsToInclude) to ALL clusters
+  //   (seeded and unseeded).  e.g. Cherenkov hits that correspond to the
+  //   same crystal but were excluded by the field selection filter.
+  // ------------------------------------------------------------------
+  auto addCompanions = [&](ClusterSeedingBase::Hitmap& hm) {
+    for (unsigned int idx = 0; idx < m_fieldStringsToInclude.size(); ++idx) {
+      const std::string& field = m_fieldStringsToInclude.value()[idx];
+      const int64_t      value = m_fieldValuesToInclude.value()[idx];
+      // Snapshot before the loop so we don't re-process companions just added.
+      const ClusterSeedingBase::Hitmap snapshot = hm;
+      for (const auto& [origCid, hit] : snapshot) {
+        uint64_t companionCid = origCid;
+        m_decoder->set(companionCid, field, value); // derive the companion cellID
+        const auto it = leftoverHits.find(companionCid);
+        if (it != leftoverHits.end()) {
+          hm.emplace(companionCid, it->second);
+          leftoverHits.erase(it); // avoid duplicates — first come first served
+        }
+      } // loop over (original) hits
+    } // loop over fields to include
+  }; // lambda addCompanions
+
+  // ------------------------------------------------------------------
+  // Step 7: Build output ClusterCollection.
+  //   Seeded clusters first (one per input seed, preserving seed type),
+  //   then unseeded clusters.
+  // ------------------------------------------------------------------
+  for (int ci = 0; ci < static_cast<int>(seededClusters.size()); ++ci) {
+    auto& hm = seededClusters[ci];
+    addCompanions(hm);
+
+    auto out = output.create();
+    out.setType(seedTypes[ci]);
+
+    const ClusterState finalState = calcBarycenter(hm);
+    out.setPosition({finalState.x, finalState.y, finalState.z});
+    out.setEnergy(finalState.energy);
+
+    for (const auto& [cid, hit] : hm)
+      out.addToHits(hit);
+  } // loop over seeded clusters
+
+  int nUnseededOut = 0;
+  for (auto& hm : unseededClusters) {
+    addCompanions(hm);
+
+    auto out = output.create();
+    out.setType(static_cast<int32_t>(ClusterSeeding::SeedType::Unseeded)); // unseeded cluster
+
+    const ClusterState finalState = calcBarycenter(hm);
+    out.setPosition({finalState.x, finalState.y, finalState.z});
+    out.setEnergy(finalState.energy);
+
+    for (const auto& [cid, hit] : hm)
+      out.addToHits(hit);
+
+    ++nUnseededOut;
+  } // loop over unseeded clusters
+
+  debug() << "ClusterSeedGrower: produced " << output.size() << " clusters total ("
+          << (output.size() - nUnseededOut) << " seeded + "
+          << nUnseededOut << " unseeded) from a hit pool of "
+          << hitPool.size() << " cells." << endmsg;
+
+  return std::make_tuple(std::move(output));
+}
+
+DECLARE_COMPONENT(ClusterSeedGrower)

--- a/RecFCCeeCalorimeter/src/components/ClusterSeedGrower.cpp
+++ b/RecFCCeeCalorimeter/src/components/ClusterSeedGrower.cpp
@@ -11,10 +11,10 @@
 #include <cmath>
 #include <limits>
 #include <numeric>
+#include <queue>
 #include <set>
 #include <unordered_map>
 #include <unordered_set>
-#include <queue>
 #include <vector>
 
 // ============================================================
@@ -22,10 +22,8 @@
 // ============================================================
 
 ClusterSeedGrower::ClusterSeedGrower(const std::string& name, ISvcLocator* svcLoc)
-    : ClusterSeedingBase(name, svcLoc,
-                       {KeyValues("InputSeeds", {}),
-                        KeyValues("InputHits",  {})},
-                       {KeyValue("OutputClusters", "TopoGrownClusters")}) {}
+    : ClusterSeedingBase(name, svcLoc, {KeyValues("InputSeeds", {}), KeyValues("InputHits", {})},
+                         {KeyValue("OutputClusters", "TopoGrownClusters")}) {}
 
 // ------------------------------------------------------------
 
@@ -48,9 +46,9 @@ StatusCode ClusterSeedGrower::initialize() {
   }
 
   if (m_hardThreshold.value() > m_growThreshold.value()) {
-    warning() << "ClusterSeedGrower: HardThreshold (" << m_hardThreshold.value()
-              << " GeV) > GrowThreshold (" << m_growThreshold.value()
-              << " GeV). No isolated hits will ever be assigned in the post-BFS phase." << endmsg;
+    warning() << "ClusterSeedGrower: HardThreshold (" << m_hardThreshold.value() << " GeV) > GrowThreshold ("
+              << m_growThreshold.value() << " GeV). No isolated hits will ever be assigned in the post-BFS phase."
+              << endmsg;
   }
 
   return StatusCode::SUCCESS;
@@ -58,11 +56,8 @@ StatusCode ClusterSeedGrower::initialize() {
 
 // ------------------------------------------------------------
 
-auto ClusterSeedGrower::connectedSeeds(const Hitmap& pool,
-                                       unsigned int  vnDist,
-                                       float         threshold,
-                                       unsigned int  minHits) const
-    -> std::vector<Hitmap> {
+auto ClusterSeedGrower::connectedSeeds(const Hitmap& pool, unsigned int vnDist, float threshold,
+                                       unsigned int minHits) const -> std::vector<Hitmap> {
   // visited tracks which cells in *pool* have already been consumed
   // into a component.  Only cells present in *pool* are ever visited.
   std::unordered_map<uint64_t, bool> visited;
@@ -122,14 +117,11 @@ auto ClusterSeedGrower::connectedSeeds(const Hitmap& pool,
 
 // ------------------------------------------------------------
 
-auto ClusterSeedGrower::grow(ContestStrategy         strategy,
-                             const Hitmap&           pool,
-                             const std::vector<Hitmap>& seeds,
-                             unsigned int            vnDist,
-                             float                   growThreshold) const
-    -> std::vector<Hitmap> {
+auto ClusterSeedGrower::grow(ContestStrategy strategy, const Hitmap& pool, const std::vector<Hitmap>& seeds,
+                             unsigned int vnDist, float growThreshold) const -> std::vector<Hitmap> {
   const int n = static_cast<int>(seeds.size());
-  if (n == 0) return {};
+  if (n == 0)
+    return {};
 
   // Working copy: starts identical to seeds and accumulates new hits layer by layer.
   // Returned to the caller when done (possibly with fewer entries for MergeClusters).
@@ -334,12 +326,12 @@ auto ClusterSeedGrower::grow(ContestStrategy         strategy,
 // ------------------------------------------------------------
 
 void ClusterSeedGrower::attachIsolatedHits(const ClusterSeedingBase::Hitmap& pool,
-                                          std::vector<ClusterSeedingBase::Hitmap>& seededClusters,
-                                          std::vector<ClusterSeedingBase::Hitmap>& unseededClusters) const {
+                                           std::vector<ClusterSeedingBase::Hitmap>& seededClusters,
+                                           std::vector<ClusterSeedingBase::Hitmap>& unseededClusters) const {
   // --- Snapshot barycenters for all clusters (seeded + unseeded) ---
-  const int nSeeded   = static_cast<int>(seededClusters.size());
+  const int nSeeded = static_cast<int>(seededClusters.size());
   const int nUnseeded = static_cast<int>(unseededClusters.size());
-  const int nTotal    = nSeeded + nUnseeded;
+  const int nTotal = nSeeded + nUnseeded;
 
   // for i < nSeeded   -> seededClusters[i]
   // for i >= nSeeded  -> unseededClusters[i - nSeeded]
@@ -367,29 +359,29 @@ void ClusterSeedGrower::attachIsolatedHits(const ClusterSeedingBase::Hitmap& poo
     if (ownedCells.count(cid))
       continue; // already in a cluster
 
-    const auto& pos  = hit.getPosition();
-    const float rh   = std::sqrt(pos.x*pos.x + pos.y*pos.y + pos.z*pos.z);
+    const auto& pos = hit.getPosition();
+    const float rh = std::sqrt(pos.x * pos.x + pos.y * pos.y + pos.z * pos.z);
     if (rh < std::numeric_limits<float>::epsilon())
       continue; // degenerate hit position
 
-    int   bestIdx = -1;
-    float bestDist  = std::numeric_limits<float>::max();
+    int bestIdx = -1;
+    float bestDist = std::numeric_limits<float>::max();
 
     for (int i = 0; i < nTotal; ++i) {
       const ClusterState& cs = statesBeforeAttach[i];
-      const float rc = std::sqrt(cs.x*cs.x + cs.y*cs.y + cs.z*cs.z);
+      const float rc = std::sqrt(cs.x * cs.x + cs.y * cs.y + cs.z * cs.z);
       if (rc < std::numeric_limits<float>::epsilon())
         continue;
 
       // Opening-angle preselection: cosine of angle between cluster
       // barycenter direction and hit direction.
-      const float cosAngle = (cs.x*pos.x + cs.y*pos.y + cs.z*pos.z) / (rc * rh);
+      const float cosAngle = (cs.x * pos.x + cs.y * pos.y + cs.z * pos.z) / (rc * rh);
       if (cosAngle < cosGate)
         continue; // opening angle > MaxOpeningAngle
 
       const float dist = openingAngleDist(cs, pos.x, pos.y, pos.z);
       if (dist < bestDist) {
-        bestDist  = dist;
+        bestDist = dist;
         bestIdx = i;
       }
     } // loop over all clusters
@@ -406,17 +398,15 @@ void ClusterSeedGrower::attachIsolatedHits(const ClusterSeedingBase::Hitmap& poo
     ++nAttached;
   } // loop over hitPool cells
 
-  debug() << "ClusterSeedGrower: Step 5 attached " << nAttached
-          << " previously unowned hit(s) to existing clusters "
+  debug() << "ClusterSeedGrower: Step 5 attached " << nAttached << " previously unowned hit(s) to existing clusters "
           << "(MaxOpeningAngle = " << m_maxOpeningAngle.value() << " rad)." << endmsg;
 } // attachIsolatedHits
 
 // ------------------------------------------------------------
 
 std::tuple<edm4hep::ClusterCollection>
-ClusterSeedGrower::operator()(
-    const std::vector<const edm4hep::ClusterCollection*>& seedColls,
-    const std::vector<const edm4hep::CalorimeterHitCollection*>& hitColls) const {
+ClusterSeedGrower::operator()(const std::vector<const edm4hep::ClusterCollection*>& seedColls,
+                              const std::vector<const edm4hep::CalorimeterHitCollection*>& hitColls) const {
 
   edm4hep::ClusterCollection output;
 
@@ -458,7 +448,7 @@ ClusterSeedGrower::operator()(
   // seedTypes records each input seed's type so Step 6 can reproduce it.
   // A temporary flat set handles shared seed hits: first seed wins.
   std::vector<ClusterSeedingBase::Hitmap> initClusterHits(nClusters);
-  std::vector<int32_t>                    seedTypes(nClusters);
+  std::vector<int32_t> seedTypes(nClusters);
   {
     std::unordered_set<uint64_t> initAssigned;
     initAssigned.reserve(hitPool.size());
@@ -484,11 +474,8 @@ ClusterSeedGrower::operator()(
   // ------------------------------------------------------------------
   // Step 3: BFS growth of seeded clusters (opening-angle distance contest resolution).
   // ------------------------------------------------------------------
-  auto seededClusters = grow(ContestStrategy::ResolveByDist,
-                             hitPool,
-                             initClusterHits,
-                             m_vnDistSeeded.value(),
-                             m_growThreshold.value());
+  auto seededClusters =
+      grow(ContestStrategy::ResolveByDist, hitPool, initClusterHits, m_vnDistSeeded.value(), m_growThreshold.value());
 
   // ------------------------------------------------------------------
   // Step 4: Unseeded cluster formation from unassigned hits.
@@ -500,9 +487,9 @@ ClusterSeedGrower::operator()(
   //      VN distance VNDistUnseeded); a contested hit fully merges the
   //      two competing clusters (union-find).
   // ------------------------------------------------------------------
-  const unsigned int vnUnseeded  = m_vnDistUnseeded.value();
-  const float        unseededThr = m_unseededThreshold.value();
-  const unsigned int minUHits    = m_minUnseededHits.value();
+  const unsigned int vnUnseeded = m_vnDistUnseeded.value();
+  const float unseededThr = m_unseededThreshold.value();
+  const unsigned int minUHits = m_minUnseededHits.value();
 
   // Build unowned pool: hitPool cells not assigned to any seeded cluster.
   std::unordered_set<uint64_t> seededOwned;
@@ -521,11 +508,8 @@ ClusterSeedGrower::operator()(
 
   // Find connected seed groups, then grow them (merging on contest).
   auto unseededClusters =
-      grow(ContestStrategy::MergeClusters,
-           unownedPool,
-           connectedSeeds(unownedPool, vnUnseeded, unseededThr, minUHits),
-           vnUnseeded,
-           m_growThreshold.value());
+      grow(ContestStrategy::MergeClusters, unownedPool, connectedSeeds(unownedPool, vnUnseeded, unseededThr, minUHits),
+           vnUnseeded, m_growThreshold.value());
 
   // Count discarded hits (in unownedPool but not in any unseeded cluster)
   int nAssignedUnseeded = 0;
@@ -533,10 +517,9 @@ ClusterSeedGrower::operator()(
     nAssignedUnseeded += static_cast<int>(hm.size());
 
   const int nDiscarded = nUnownedAfterSeeded - nAssignedUnseeded;
-  debug() << "ClusterSeedGrower: " << nUnownedAfterSeeded
-          << " unowned hits after seeded BFS; "
-          << unseededClusters.size() << " unseeded cluster(s) formed; "
-          << nDiscarded << " hit(s) discarded after unseeded BFS." << endmsg;
+  debug() << "ClusterSeedGrower: " << nUnownedAfterSeeded << " unowned hits after seeded BFS; "
+          << unseededClusters.size() << " unseeded cluster(s) formed; " << nDiscarded
+          << " hit(s) discarded after unseeded BFS." << endmsg;
 
   // ------------------------------------------------------------------
   // Step 5 (optional): Attach remaining unowned hitPool cells to the nearest cluster.
@@ -561,7 +544,7 @@ ClusterSeedGrower::operator()(
   auto addCompanions = [&](ClusterSeedingBase::Hitmap& hm) {
     for (unsigned int idx = 0; idx < m_fieldStringsToInclude.size(); ++idx) {
       const std::string& field = m_fieldStringsToInclude.value()[idx];
-      const int64_t      value = m_fieldValuesToInclude.value()[idx];
+      const int64_t value = m_fieldValuesToInclude.value()[idx];
       // Snapshot before the loop so we don't re-process companions just added.
       const ClusterSeedingBase::Hitmap snapshot = hm;
       for (const auto& [origCid, hit] : snapshot) {
@@ -613,10 +596,8 @@ ClusterSeedGrower::operator()(
     ++nUnseededOut;
   } // loop over unseeded clusters
 
-  debug() << "ClusterSeedGrower: produced " << output.size() << " clusters total ("
-          << (output.size() - nUnseededOut) << " seeded + "
-          << nUnseededOut << " unseeded) from a hit pool of "
-          << hitPool.size() << " cells." << endmsg;
+  debug() << "ClusterSeedGrower: produced " << output.size() << " clusters total (" << (output.size() - nUnseededOut)
+          << " seeded + " << nUnseededOut << " unseeded) from a hit pool of " << hitPool.size() << " cells." << endmsg;
 
   return std::make_tuple(std::move(output));
 }

--- a/RecFCCeeCalorimeter/src/components/ClusterSeedGrower.h
+++ b/RecFCCeeCalorimeter/src/components/ClusterSeedGrower.h
@@ -51,20 +51,17 @@
 #include "edm4hep/CalorimeterHitCollection.h"
 #include "edm4hep/ClusterCollection.h"
 
-#include "k4FWCore/Transformer.h"
 #include "Gaudi/Property.h"
+#include "k4FWCore/Transformer.h"
 
 #include "ClusterSeedingBase.h"
 
 #include <tuple>
 #include <vector>
 
-struct ClusterSeedGrower final
-    : ClusterSeedingBase<
-          std::tuple<edm4hep::ClusterCollection>(
-              const std::vector<const edm4hep::ClusterCollection*>&,
-              const std::vector<const edm4hep::CalorimeterHitCollection*>&)>
-{
+struct ClusterSeedGrower final : ClusterSeedingBase<std::tuple<edm4hep::ClusterCollection>(
+                                     const std::vector<const edm4hep::ClusterCollection*>&,
+                                     const std::vector<const edm4hep::CalorimeterHitCollection*>&)> {
   ClusterSeedGrower(const std::string& name, ISvcLocator* svcLoc);
 
   StatusCode initialize() override;
@@ -77,18 +74,16 @@ struct ClusterSeedGrower final
 private:
   // Contest resolution strategy for grow().
   enum class ContestStrategy {
-    ResolveByDist,   // closest cluster by opening-angle distance keeps hit; others get nothing
-    MergeClusters    // contested hit fully merges the two clusters (union-find)
+    ResolveByDist, // closest cluster by opening-angle distance keeps hit; others get nothing
+    MergeClusters  // contested hit fully merges the two clusters (union-find)
   };
 
   // Find all connected components in *pool* where every member has
   // E >= threshold, using VN neighbourhood distance vnDist.
   // Returns one Hitmap per component; components with fewer than
   // minHits members are already filtered out before returning.
-  std::vector<ClusterSeedingBase::Hitmap> connectedSeeds(const ClusterSeedingBase::Hitmap& pool,
-                                                         unsigned int vnDist,
-                                                         float threshold,
-                                                         unsigned int minHits) const;
+  std::vector<ClusterSeedingBase::Hitmap> connectedSeeds(const ClusterSeedingBase::Hitmap& pool, unsigned int vnDist,
+                                                         float threshold, unsigned int minHits) const;
 
   // Layer-by-layer BFS growth of *seeds* into *pool* hits above *growThreshold*.
   // Seeds are moved in; the fully-grown Hitmaps are returned.
@@ -97,12 +92,9 @@ private:
   //   MergeClusters:  contested hits cause a full union-find merge of the
   //                   two competing clusters; output contains one Hitmap
   //                   per surviving (root) cluster.
-  std::vector<ClusterSeedingBase::Hitmap>
-  grow(ContestStrategy                         strategy,
-       const ClusterSeedingBase::Hitmap&       pool,
-       const std::vector<ClusterSeedingBase::Hitmap>& seeds,
-       unsigned int                            vnDist,
-       float                                   growThreshold) const;
+  std::vector<ClusterSeedingBase::Hitmap> grow(ContestStrategy strategy, const ClusterSeedingBase::Hitmap& pool,
+                                               const std::vector<ClusterSeedingBase::Hitmap>& seeds,
+                                               unsigned int vnDist, float growThreshold) const;
 
   // Attach isolated hits above HardThreshold to the nearest cluster by opening-angle distance
   void attachIsolatedHits(const ClusterSeedingBase::Hitmap& pool,
@@ -111,26 +103,21 @@ private:
 
   // ---- Cell-ID inclusion (daughter-specific) ----
   Gaudi::Property<std::vector<std::string>> m_fieldStringsToInclude{
-      this, "FieldStringsToInclude", {},
-      "BitField names used to include hits (e.g. 'cherenkov', 'layer')"};
+      this, "FieldStringsToInclude", {}, "BitField names used to include hits (e.g. 'cherenkov', 'layer')"};
   Gaudi::Property<std::vector<int>> m_fieldValuesToInclude{
-      this, "FieldValuesToInclude", {},
-      "Values corresponding to FieldStringsToInclude for hit selection"};
+      this, "FieldValuesToInclude", {}, "Values corresponding to FieldStringsToInclude for hit selection"};
 
   // ---- Energy thresholds ----
-  Gaudi::Property<float> m_growThreshold{
-      this, "GrowThreshold", 0.01f,
-      "Minimum hit energy [GeV] for BFS propagation. "
-      "Hits below this threshold block further topological growth."};
-  Gaudi::Property<float> m_hardThreshold{
-      this, "HardThreshold", 0.01f,
-      "Absolute minimum hit energy [GeV]. Hits below this are never attached "
-      "to any cluster (HardThreshold <= GrowThreshold is expected)."};
-  Gaudi::Property<float> m_unseededThreshold{
-      this, "UnseededThreshold", 0.04f,
-      "Minimum hit energy [GeV] required to seed an unseeded cluster candidate. "
-      "A group of >= MinUnseededHits connected hits all above this threshold "
-      "forms one unseeded cluster seed."};
+  Gaudi::Property<float> m_growThreshold{this, "GrowThreshold", 0.01f,
+                                         "Minimum hit energy [GeV] for BFS propagation. "
+                                         "Hits below this threshold block further topological growth."};
+  Gaudi::Property<float> m_hardThreshold{this, "HardThreshold", 0.01f,
+                                         "Absolute minimum hit energy [GeV]. Hits below this are never attached "
+                                         "to any cluster (HardThreshold <= GrowThreshold is expected)."};
+  Gaudi::Property<float> m_unseededThreshold{this, "UnseededThreshold", 0.04f,
+                                             "Minimum hit energy [GeV] required to seed an unseeded cluster candidate. "
+                                             "A group of >= MinUnseededHits connected hits all above this threshold "
+                                             "forms one unseeded cluster seed."};
 
   // ---- Neighbourhood distances ----
   Gaudi::Property<unsigned int> m_vnDistSeeded{

--- a/RecFCCeeCalorimeter/src/components/ClusterSeedGrower.h
+++ b/RecFCCeeCalorimeter/src/components/ClusterSeedGrower.h
@@ -1,0 +1,162 @@
+#ifndef ClusterSeedGrower_h
+#define ClusterSeedGrower_h 1
+
+/*
+ * ClusterSeedGrower
+ *
+ * Gaudi MultiTransformer that grows pre-formed cluster seeds topologically
+ * into full clusters by expanding outward via segmentation neighbours.
+ *
+ * Growth strategy
+ * ---------------
+ *   Layer-by-layer BFS: in each layer all seeds simultaneously claim their
+ *   reachable neighbours within Von Neumann distance VNDistSeeded.
+ *   A neighbour is eligible for growth only when its energy exceeds
+ *   GrowThreshold; hits below this threshold block further propagation.
+ *   Hits below HardThreshold are discarded entirely.
+ *
+ *   Contested hits (claimed by two or more seeds at the same BFS layer) are
+ *   resolved with the opening angle distance:
+ *       d = 1 - cos(angle)
+ *   where angle is the opening angle between the cluster log-weighted
+ *   barycenter and the hit position.  The cluster with the smaller distance wins.
+ *   Cluster energy / barycenter are updated at the end of each layer (not
+ *   mid-layer) so that contest resolution within one layer is reproducible.
+ *
+ *   After seeded BFS, remaining unassigned hitPool cells are used to form
+ *   "unseeded" cluster candidates.  A candidate requires at least
+ *   MinUnseededHits connected hits all above UnseededThreshold within VN
+ *   distance VNDistUnseeded.  Unseeded clusters are then grown topologically
+ *   (E >= GrowThreshold, VN distance VNDistUnseeded); contested hits between
+ *   two unseeded clusters cause a full merge of the two clusters.
+ *
+ * Inputs
+ * ------
+ *   InputSeeds  (std::vector<const edm4hep::ClusterCollection*>)
+ *       Seed clusters with pre-attached hits (e.g. from ClusterSeedMerging).
+ *       These hits form the initial BFS frontier.
+ *
+ *   InputHits   (std::vector<const edm4hep::CalorimeterHitCollection*>)
+ *       All digitised calorimeter hit collections to grow into.
+ *       Treated as a single unified pool; filtered by FieldStrings/FieldValues.
+ *
+ * Output
+ * ------
+ *   OutputClusters  (edm4hep::ClusterCollection)
+ *       Grown seeded clusters followed by unseeded clusters.
+ *       Position = log-weighted barycenter; energy = total energy of all
+ *       attached hits.
+ */
+
+#include "edm4hep/CalorimeterHitCollection.h"
+#include "edm4hep/ClusterCollection.h"
+
+#include "k4FWCore/Transformer.h"
+#include "Gaudi/Property.h"
+
+#include "ClusterSeedingBase.h"
+
+#include <tuple>
+#include <vector>
+
+struct ClusterSeedGrower final
+    : ClusterSeedingBase<
+          std::tuple<edm4hep::ClusterCollection>(
+              const std::vector<const edm4hep::ClusterCollection*>&,
+              const std::vector<const edm4hep::CalorimeterHitCollection*>&)>
+{
+  ClusterSeedGrower(const std::string& name, ISvcLocator* svcLoc);
+
+  StatusCode initialize() override;
+  StatusCode finalize() override { return StatusCode::SUCCESS; }
+
+  std::tuple<edm4hep::ClusterCollection>
+  operator()(const std::vector<const edm4hep::ClusterCollection*>& seedColls,
+             const std::vector<const edm4hep::CalorimeterHitCollection*>& hitColls) const override;
+
+private:
+  // Contest resolution strategy for grow().
+  enum class ContestStrategy {
+    ResolveByDist,   // closest cluster by opening-angle distance keeps hit; others get nothing
+    MergeClusters    // contested hit fully merges the two clusters (union-find)
+  };
+
+  // Find all connected components in *pool* where every member has
+  // E >= threshold, using VN neighbourhood distance vnDist.
+  // Returns one Hitmap per component; components with fewer than
+  // minHits members are already filtered out before returning.
+  std::vector<ClusterSeedingBase::Hitmap> connectedSeeds(const ClusterSeedingBase::Hitmap& pool,
+                                                         unsigned int vnDist,
+                                                         float threshold,
+                                                         unsigned int minHits) const;
+
+  // Layer-by-layer BFS growth of *seeds* into *pool* hits above *growThreshold*.
+  // Seeds are moved in; the fully-grown Hitmaps are returned.
+  //   ResolveByDist:  contested hits are awarded to the closest cluster by
+  //                   opening-angle distance; states are updated after each layer.
+  //   MergeClusters:  contested hits cause a full union-find merge of the
+  //                   two competing clusters; output contains one Hitmap
+  //                   per surviving (root) cluster.
+  std::vector<ClusterSeedingBase::Hitmap>
+  grow(ContestStrategy                         strategy,
+       const ClusterSeedingBase::Hitmap&       pool,
+       const std::vector<ClusterSeedingBase::Hitmap>& seeds,
+       unsigned int                            vnDist,
+       float                                   growThreshold) const;
+
+  // Attach isolated hits above HardThreshold to the nearest cluster by opening-angle distance
+  void attachIsolatedHits(const ClusterSeedingBase::Hitmap& pool,
+                          std::vector<ClusterSeedingBase::Hitmap>& seededClusters,
+                          std::vector<ClusterSeedingBase::Hitmap>& unseededClusters) const;
+
+  // ---- Cell-ID inclusion (daughter-specific) ----
+  Gaudi::Property<std::vector<std::string>> m_fieldStringsToInclude{
+      this, "FieldStringsToInclude", {},
+      "BitField names used to include hits (e.g. 'cherenkov', 'layer')"};
+  Gaudi::Property<std::vector<int>> m_fieldValuesToInclude{
+      this, "FieldValuesToInclude", {},
+      "Values corresponding to FieldStringsToInclude for hit selection"};
+
+  // ---- Energy thresholds ----
+  Gaudi::Property<float> m_growThreshold{
+      this, "GrowThreshold", 0.01f,
+      "Minimum hit energy [GeV] for BFS propagation. "
+      "Hits below this threshold block further topological growth."};
+  Gaudi::Property<float> m_hardThreshold{
+      this, "HardThreshold", 0.01f,
+      "Absolute minimum hit energy [GeV]. Hits below this are never attached "
+      "to any cluster (HardThreshold <= GrowThreshold is expected)."};
+  Gaudi::Property<float> m_unseededThreshold{
+      this, "UnseededThreshold", 0.04f,
+      "Minimum hit energy [GeV] required to seed an unseeded cluster candidate. "
+      "A group of >= MinUnseededHits connected hits all above this threshold "
+      "forms one unseeded cluster seed."};
+
+  // ---- Neighbourhood distances ----
+  Gaudi::Property<unsigned int> m_vnDistSeeded{
+      this, "VNDistSeeded", 2u,
+      "Von Neumann neighbour distance used for BFS growth of seeded clusters. "
+      "Distance 1 means only direct face-sharing neighbours; distance 2 allows "
+      "one jump between the frontier and the candidate hit."};
+  Gaudi::Property<unsigned int> m_vnDistUnseeded{
+      this, "VNDistUnseeded", 2u,
+      "Von Neumann neighbour distance used both for seeding and BFS growth of "
+      "unseeded clusters."};
+  Gaudi::Property<unsigned int> m_minUnseededHits{
+      this, "MinUnseededHits", 2u,
+      "Minimum number of connected above-UnseededThreshold hits required to "
+      "form an unseeded cluster seed."};
+
+  // ---- Barycenter / distance parameters ----
+  Gaudi::Property<float> m_maxOpeningAngle{
+      this, "MaxOpeningAngle", 0.3f,
+      "Maximum opening angle [rad] between a cluster barycenter and an unowned hit "
+      "for the hit to be considered for attachment in Step 5. "
+      "Only clusters within this angle are compared by opening-angle distance."};
+  Gaudi::Property<bool> m_attachIsolatedHits{
+      this, "AttachIsolatedHits", false,
+      "Whether to attach remaining unassigned hitPool cells to the nearest cluster "
+      "after BFS growth. Only hits above HardThreshold are eligible for attachment."};
+};
+
+#endif // ClusterSeedGrower_h

--- a/RecFCCeeCalorimeter/src/components/ClusterSeedMerging.cpp
+++ b/RecFCCeeCalorimeter/src/components/ClusterSeedMerging.cpp
@@ -15,12 +15,11 @@
 //  ClusterSeedMerging
 // ============================================================
 
-ClusterSeedMerging::ClusterSeedMerging(const std::string& name,
-                                       ISvcLocator*      svcLoc)
+ClusterSeedMerging::ClusterSeedMerging(const std::string& name, ISvcLocator* svcLoc)
     : ClusterSeedingBase(name, svcLoc,
-                       {KeyValues("CaloDrivenSeeds", {}), // allow multiple input collections to be merged together
-                        KeyValues("TrackDrivenSeeds", {})},
-                       {KeyValue("OutputMergedSeeds", "MergedSeeds")}) {}
+                         {KeyValues("CaloDrivenSeeds", {}), // allow multiple input collections to be merged together
+                          KeyValues("TrackDrivenSeeds", {})},
+                         {KeyValue("OutputMergedSeeds", "MergedSeeds")}) {}
 
 // ------------------------------------------------------------
 
@@ -33,9 +32,8 @@ StatusCode ClusterSeedMerging::initialize() {
 // ------------------------------------------------------------
 
 std::tuple<edm4hep::ClusterCollection>
-ClusterSeedMerging::operator()(
-    const std::vector<const edm4hep::ClusterCollection*>& caloSeeds,
-    const std::vector<const edm4hep::ClusterCollection*>& trackSeeds) const {
+ClusterSeedMerging::operator()(const std::vector<const edm4hep::ClusterCollection*>& caloSeeds,
+                               const std::vector<const edm4hep::ClusterCollection*>& trackSeeds) const {
 
   edm4hep::ClusterCollection mergedOut;
 
@@ -44,9 +42,9 @@ ClusterSeedMerging::operator()(
   //         theta, phi).
   // ------------------------------------------------------------------
   struct Node {
-    int   type; // seed types: 1 = calo-driven A, 2 = calo-driven B, 4 = track-driven C
-    int   collIdx; // index of the source collection in the input vector
-    int   srcIdx; // index in the source collection
+    int type;      // seed types: 1 = calo-driven A, 2 = calo-driven B, 4 = track-driven C
+    int collIdx;   // index of the source collection in the input vector
+    int srcIdx;    // index in the source collection
     float x, y, z; // position of the seed (mm)
   };
 
@@ -61,7 +59,7 @@ ClusterSeedMerging::operator()(
   auto addNodes = [&nodes](const edm4hep::ClusterCollection* coll, int collIdx) {
     for (int i = 0; i < static_cast<int>(coll->size()); ++i) {
       const auto& cl = (*coll)[i];
-      const auto& p  = cl.getPosition();
+      const auto& p = cl.getPosition();
       const int type = cl.getType();
       nodes.push_back({type, collIdx, i, p.x, p.y, p.z});
     }
@@ -93,18 +91,18 @@ ClusterSeedMerging::operator()(
   auto adjacent = [&nodes, mergeDist](int i, int j) -> bool {
     const Node& ni = nodes[i];
     const Node& nj = nodes[j];
-    const float r2i = ni.x*ni.x + ni.y*ni.y + ni.z*ni.z;
-    const float r2j = nj.x*nj.x + nj.y*nj.y + nj.z*nj.z;
+    const float r2i = ni.x * ni.x + ni.y * ni.y + ni.z * ni.z;
+    const float r2j = nj.x * nj.x + nj.y * nj.y + nj.z * nj.z;
     if (r2i <= 0.f || r2j <= 0.f)
       return false;
 
-    const float dotij = ni.x*nj.x + ni.y*nj.y + ni.z*nj.z;
+    const float dotij = ni.x * nj.x + ni.y * nj.y + ni.z * nj.z;
     if (dotij <= 0.f)
       return false; // opposite hemisphere - never adjacent
 
     // opening angle between the two position vectors
     const float cosAlpha = dotij / std::sqrt(r2i * r2j);
-    const float alpha    = std::acos(std::max(-1.f, std::min(1.f, cosAlpha)));
+    const float alpha = std::acos(std::max(-1.f, std::min(1.f, cosAlpha)));
 
     return alpha < std::atan2(mergeDist, std::sqrt(r2i));
   }; // lambda adjacent
@@ -128,7 +126,8 @@ ClusterSeedMerging::operator()(
     q.push(i);
 
     while (!q.empty()) {
-      const int cur = q.front(); q.pop();
+      const int cur = q.front();
+      q.pop();
       if (visited[cur])
         continue;
 
@@ -219,8 +218,7 @@ ClusterSeedMerging::operator()(
   } // while anyAbsorbed
 
   debug() << "ClusterSeedMerging: " << std::count(absorbed.begin(), absorbed.end(), -1)
-          << " output components after absorbing "
-          << (nComp - std::count(absorbed.begin(), absorbed.end(), -1))
+          << " output components after absorbing " << (nComp - std::count(absorbed.begin(), absorbed.end(), -1))
           << " fully-overlapping components." << endmsg;
 
   // ------------------------------------------------------------------
@@ -279,7 +277,7 @@ ClusterSeedMerging::operator()(
 
       if (d < bestDist) {
         bestDist = d;
-        winner   = ci;
+        winner = ci;
       }
     } // loop over owners to find winner
 
@@ -292,8 +290,8 @@ ClusterSeedMerging::operator()(
     } // loop over owners to remove losers
   } // loop over contested hits
 
-  debug() << "ClusterSeedMerging: redistributed " << nRedistributed
-          << " contested hits via opening-angle distance." << endmsg;
+  debug() << "ClusterSeedMerging: redistributed " << nRedistributed << " contested hits via opening-angle distance."
+          << endmsg;
 
   // ------------------------------------------------------------------
   // Step 6: Build output collections.
@@ -320,8 +318,7 @@ ClusterSeedMerging::operator()(
       merged.addToHits(hit);
   } // loop over components
 
-  debug() << "ClusterSeedMerging: "
-          << mergedOut.size()  << " merged groups." << endmsg;
+  debug() << "ClusterSeedMerging: " << mergedOut.size() << " merged groups." << endmsg;
 
   return std::make_tuple(std::move(mergedOut));
 }

--- a/RecFCCeeCalorimeter/src/components/ClusterSeedMerging.cpp
+++ b/RecFCCeeCalorimeter/src/components/ClusterSeedMerging.cpp
@@ -1,0 +1,329 @@
+#include "ClusterSeedMerging.h"
+
+#include "edm4hep/Cluster.h"
+#include "edm4hep/MutableCluster.h"
+
+#include <cmath>
+#include <limits>
+#include <numeric>
+#include <queue>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+// ============================================================
+//  ClusterSeedMerging
+// ============================================================
+
+ClusterSeedMerging::ClusterSeedMerging(const std::string& name,
+                                       ISvcLocator*      svcLoc)
+    : ClusterSeedingBase(name, svcLoc,
+                       {KeyValues("CaloDrivenSeeds", {}), // allow multiple input collections to be merged together
+                        KeyValues("TrackDrivenSeeds", {})},
+                       {KeyValue("OutputMergedSeeds", "MergedSeeds")}) {}
+
+// ------------------------------------------------------------
+
+StatusCode ClusterSeedMerging::initialize() {
+  info() << "ClusterSeedMerging: MergeDistance = " << m_mergeDistance.value() << " mm" << endmsg;
+
+  return StatusCode::SUCCESS;
+} // initialize
+
+// ------------------------------------------------------------
+
+std::tuple<edm4hep::ClusterCollection>
+ClusterSeedMerging::operator()(
+    const std::vector<const edm4hep::ClusterCollection*>& caloSeeds,
+    const std::vector<const edm4hep::ClusterCollection*>& trackSeeds) const {
+
+  edm4hep::ClusterCollection mergedOut;
+
+  // ------------------------------------------------------------------
+  // Step 1: Build a flat list of nodes: (type, original cluster index,
+  //         theta, phi).
+  // ------------------------------------------------------------------
+  struct Node {
+    int   type; // seed types: 1 = calo-driven A, 2 = calo-driven B, 4 = track-driven C
+    int   collIdx; // index of the source collection in the input vector
+    int   srcIdx; // index in the source collection
+    float x, y, z; // position of the seed (mm)
+  };
+
+  std::vector<Node> nodes;
+  size_t total = 0;
+  for (const auto* c : caloSeeds)
+    total += c->size();
+  for (const auto* c : trackSeeds)
+    total += c->size();
+  nodes.reserve(total);
+
+  auto addNodes = [&nodes](const edm4hep::ClusterCollection* coll, int collIdx) {
+    for (int i = 0; i < static_cast<int>(coll->size()); ++i) {
+      const auto& cl = (*coll)[i];
+      const auto& p  = cl.getPosition();
+      const int type = cl.getType();
+      nodes.push_back({type, collIdx, i, p.x, p.y, p.z});
+    }
+  }; // lambda addNodes
+
+  for (size_t i = 0; i < caloSeeds.size(); ++i)
+    addNodes(caloSeeds[i], i);
+
+  for (size_t i = 0; i < trackSeeds.size(); ++i)
+    addNodes(trackSeeds[i], i + caloSeeds.size()); // track seeds come after calo seeds
+
+  const int n = static_cast<int>(nodes.size());
+  if (n == 0) {
+    debug() << "ClusterSeedMerging: no input seeds - returning empty collections." << endmsg;
+    return std::make_tuple(std::move(mergedOut));
+  }
+
+  // ------------------------------------------------------------------
+  // Step 2: Adjacency predicate.
+  //   Two seeds i and j are adjacent when the opening angle between their
+  //   position vectors is less than arctan(MergeDistance / |pos_i|):
+  //
+  //     alpha(i,j) < arctan(d / r_i)
+  //
+  //   The C+C rule is enforced later in BFS.
+  // ------------------------------------------------------------------
+  const float mergeDist = m_mergeDistance.value();
+
+  auto adjacent = [&nodes, mergeDist](int i, int j) -> bool {
+    const Node& ni = nodes[i];
+    const Node& nj = nodes[j];
+    const float r2i = ni.x*ni.x + ni.y*ni.y + ni.z*ni.z;
+    const float r2j = nj.x*nj.x + nj.y*nj.y + nj.z*nj.z;
+    if (r2i <= 0.f || r2j <= 0.f)
+      return false;
+
+    const float dotij = ni.x*nj.x + ni.y*nj.y + ni.z*nj.z;
+    if (dotij <= 0.f)
+      return false; // opposite hemisphere - never adjacent
+
+    // opening angle between the two position vectors
+    const float cosAlpha = dotij / std::sqrt(r2i * r2j);
+    const float alpha    = std::acos(std::max(-1.f, std::min(1.f, cosAlpha)));
+
+    return alpha < std::atan2(mergeDist, std::sqrt(r2i));
+  }; // lambda adjacent
+
+  // ------------------------------------------------------------------
+  // Step 3: BFS to find connected components.
+  //   Invariant: each component holds AT MOST ONE Type-C node.
+  //   If a second C node is encountered while growing a component, it is
+  //   skipped (left unvisited) so it will seed its own component later.
+  // ------------------------------------------------------------------
+  std::vector<std::vector<int>> components;
+  std::vector<bool> visited(n, false);
+
+  for (int i = 0; i < n; ++i) {
+    if (visited[i])
+      continue;
+
+    std::vector<int> comp;
+    bool compHasC = false;
+    std::queue<int> q;
+    q.push(i);
+
+    while (!q.empty()) {
+      const int cur = q.front(); q.pop();
+      if (visited[cur])
+        continue;
+
+      // Enforce at-most-one-C rule
+      if (nodes[cur].type == static_cast<int>(ClusterSeeding::SeedType::TrackDrivenC)) {
+        if (compHasC)
+          continue; // defer this C node to its own component
+
+        compHasC = true;
+      }
+
+      visited[cur] = true;
+      comp.push_back(cur);
+
+      // add all adjacent nodes to the queue
+      for (int j = 0; j < n; ++j) {
+        if (!visited[j] && adjacent(cur, j))
+          q.push(j);
+      }
+    } // while queue not empty
+
+    components.push_back(std::move(comp));
+  } // loop over nodes
+
+  // ------------------------------------------------------------------
+  // Step 4: Absorb completely-overlapping components.
+  //   If every hit of component i is already present in component j (i ⊆ j),
+  //   then i is absorbed into j: its node type bits are merged into j and it
+  //   produces no independent output cluster.  We iterate until stable to
+  //   handle transitive chains of subset relations.
+  // ------------------------------------------------------------------
+  const int nComp = static_cast<int>(components.size());
+
+  // Helper: resolve source collection from collIdx
+  auto retrieveSrcColl = [&](int collIdx) -> const edm4hep::ClusterCollection* {
+    if (collIdx < static_cast<int>(caloSeeds.size()))
+      return caloSeeds[collIdx];
+
+    return trackSeeds[collIdx - static_cast<int>(caloSeeds.size())];
+  };
+
+  // Build per-component cellID sets for subset testing
+  std::vector<std::unordered_set<uint64_t>> compCellIDs(nComp);
+  for (int ci = 0; ci < nComp; ++ci) {
+    for (const int idx : components[ci]) {
+      const Node& nd = nodes[idx];
+      for (const auto& hit : (*retrieveSrcColl(nd.collIdx))[nd.srcIdx].getHits())
+        compCellIDs[ci].insert(hit.getCellID());
+    }
+  }
+
+  // absorbed[i] = j means component i is swallowed by component j
+  std::vector<int> absorbed(nComp, -1);
+
+  bool anyAbsorbed = true;
+  while (anyAbsorbed) {
+    anyAbsorbed = false;
+    for (int i = 0; i < nComp; ++i) {
+      if (absorbed[i] >= 0 || compCellIDs[i].empty())
+        continue;
+
+      for (int j = 0; j < nComp; ++j) {
+        if (i == j || absorbed[j] >= 0)
+          continue;
+        if (compCellIDs[j].size() < compCellIDs[i].size())
+          continue; // j must be at least as large as i
+
+        // Test i ⊆ j
+        bool isSubset = true;
+        for (const uint64_t cid : compCellIDs[i]) {
+          if (!compCellIDs[j].count(cid)) {
+            isSubset = false;
+            break;
+          }
+        }
+
+        if (isSubset) {
+          absorbed[i] = j;
+          // Merge i's nodes into j so the type bitmask is collected in Step 6
+          for (const int idx : components[i])
+            components[j].push_back(idx);
+
+          anyAbsorbed = true;
+          break;
+        }
+      } // loop over j
+    } // loop over i
+  } // while anyAbsorbed
+
+  debug() << "ClusterSeedMerging: " << std::count(absorbed.begin(), absorbed.end(), -1)
+          << " output components after absorbing "
+          << (nComp - std::count(absorbed.begin(), absorbed.end(), -1))
+          << " fully-overlapping components." << endmsg;
+
+  // ------------------------------------------------------------------
+  // Step 5: Partial-overlap hit redistribution via opening-angle distance.
+  //   For every cellID that appears in two or more non-absorbed components,
+  //   assign it exclusively to the component with the smallest opening-angle
+  //   distance:  d = 1 - cos(angle)
+  //   E_clus and the cluster direction come from the cluster state
+  //   *before* redistribution (frozen snapshot).
+  // ------------------------------------------------------------------
+
+  // Build per-component deduplicated hit maps, frozen cluster states, and
+  // the cellOwners index (reused in Step 7).
+  std::vector<ClusterState> frozenState(nComp, {0.f, 0.f, 0.f, 0.f});
+  std::vector<ClusterSeedingBase::Hitmap> compHitMaps(nComp);
+  std::vector<int> compTypes(nComp, 0);
+  std::unordered_map<uint64_t, std::vector<int>> cellOwners;
+
+  for (int ci = 0; ci < nComp; ++ci) {
+    if (absorbed[ci] >= 0)
+      continue;
+
+    for (const int idx : components[ci]) {
+      const Node& nd = nodes[idx];
+      compTypes[ci] |= nd.type;
+
+      for (const auto& hit : (*retrieveSrcColl(nd.collIdx))[nd.srcIdx].getHits())
+        compHitMaps[ci].try_emplace(hit.getCellID(), hit);
+    } // loop over nodes in component to build hit map
+
+    if (!compHitMaps[ci].empty()) {
+      auto bary = calcBarycenter(compHitMaps[ci]);
+      frozenState[ci] = {bary.x, bary.y, bary.z, bary.energy};
+
+      for (const auto& [cellID, hit] : compHitMaps[ci])
+        cellOwners[cellID].push_back(ci);
+    } // if component has any hits
+  } // loop over components
+
+  // Resolve each contested hit
+  int nRedistributed = 0;
+  for (auto& [cellID, owners] : cellOwners) {
+    if (owners.size() < 2)
+      continue; // not contested
+
+    // Retrieve the hit from the first owner (all copies are identical)
+    const edm4hep::CalorimeterHit& hit = compHitMaps[owners[0]].at(cellID);
+    const edm4hep::Vector3f& hpos = hit.getPosition();
+
+    int winner = owners[0];
+    float bestDist = std::numeric_limits<float>::max();
+
+    for (const int ci : owners) {
+      const ClusterState& cs = frozenState[ci];
+      const float d = openingAngleDist(cs, hpos.x, hpos.y, hpos.z);
+
+      if (d < bestDist) {
+        bestDist = d;
+        winner   = ci;
+      }
+    } // loop over owners to find winner
+
+    // Remove from all losers
+    for (const int ci : owners) {
+      if (ci != winner) {
+        compHitMaps[ci].erase(cellID);
+        ++nRedistributed;
+      }
+    } // loop over owners to remove losers
+  } // loop over contested hits
+
+  debug() << "ClusterSeedMerging: redistributed " << nRedistributed
+          << " contested hits via opening-angle distance." << endmsg;
+
+  // ------------------------------------------------------------------
+  // Step 6: Build output collections.
+  //   Non-absorbed components -> one merged cluster with barycenter position.
+  //   Absorbed components     -> skipped (their hits+types are in the absorbing component).
+  //   Uses compHitMaps built/refined by Step 5.5.
+  // ------------------------------------------------------------------
+  for (int ci = 0; ci < nComp; ++ci) {
+    if (absorbed[ci] >= 0)
+      continue; // swallowed by another component
+
+    auto& hitMap = compHitMaps[ci];
+    if (hitMap.empty())
+      continue; // no hits left after redistribution - skip
+
+    auto merged = mergedOut.create();
+
+    auto bary = calcBarycenter(hitMap);
+    merged.setPosition({bary.x, bary.y, bary.z});
+    merged.setEnergy(bary.energy);
+    merged.setType(compTypes[ci]);
+
+    for (const auto& [cellID, hit] : hitMap)
+      merged.addToHits(hit);
+  } // loop over components
+
+  debug() << "ClusterSeedMerging: "
+          << mergedOut.size()  << " merged groups." << endmsg;
+
+  return std::make_tuple(std::move(mergedOut));
+}
+
+DECLARE_COMPONENT(ClusterSeedMerging)

--- a/RecFCCeeCalorimeter/src/components/ClusterSeedMerging.h
+++ b/RecFCCeeCalorimeter/src/components/ClusterSeedMerging.h
@@ -38,8 +38,8 @@
 
 #include "edm4hep/ClusterCollection.h"
 
-#include "k4FWCore/Transformer.h"
 #include "Gaudi/Property.h"
+#include "k4FWCore/Transformer.h"
 
 #include "ClusterSeedingBase.h"
 
@@ -53,56 +53,46 @@
 
 // helper functions
 namespace ClusterSeeding {
-  enum class SeedType {
-    CaloDrivenA = 0x1,
-    CaloDrivenB = 0x2,
-    TrackDrivenC = 0x4,
-    Unseeded = 0x8
-  };
+enum class SeedType { CaloDrivenA = 0x1, CaloDrivenB = 0x2, TrackDrivenC = 0x4, Unseeded = 0x8 };
 
-  // ---- Cluster::type bit-field layout ----
-  //   bits  0..15 : PDG ID  (NH=130, photon=22, ch=211, sat=0)    -- written by downstream PID algorithms
-  //   bits 16..31 : SeedType bitmask                              -- written by seeding components
-  inline int encodeType(int pdg, SeedType seed) {
-    return (pdg & 0xFFFF) | ((static_cast<int>(seed) & 0xFFFF) << 16);
-  }
-  inline int decodePdg(int t) {
-    return static_cast<int16_t>(t & 0xFFFF);
-  }
-  inline SeedType decodeSeed(int t) {
-    return static_cast<SeedType>((t >> 16) & 0xFFFF);
-  }
+// ---- Cluster::type bit-field layout ----
+//   bits  0..15 : PDG ID  (NH=130, photon=22, ch=211, sat=0)    -- written by downstream PID algorithms
+//   bits 16..31 : SeedType bitmask                              -- written by seeding components
+inline int encodeType(int pdg, SeedType seed) { return (pdg & 0xFFFF) | ((static_cast<int>(seed) & 0xFFFF) << 16); }
+inline int decodePdg(int t) { return static_cast<int16_t>(t & 0xFFFF); }
+inline SeedType decodeSeed(int t) { return static_cast<SeedType>((t >> 16) & 0xFFFF); }
 
-  // ---- Geometry helpers (free functions) ----
-  // Convert (x,y,z) to (theta, phi).  Returns (0,0) if |r| ~ 0.
-  inline std::pair<float, float> toThetaPhi(float x, float y, float z) {
-    const float r = std::sqrt(x * x + y * y + z * z);
-    if (r < std::numeric_limits<float>::epsilon()) return {0.f, 0.f};
-    return {std::acos(std::max(-1.f, std::min(1.f, z / r))), std::atan2(y, x)};
-  }
+// ---- Geometry helpers (free functions) ----
+// Convert (x,y,z) to (theta, phi).  Returns (0,0) if |r| ~ 0.
+inline std::pair<float, float> toThetaPhi(float x, float y, float z) {
+  const float r = std::sqrt(x * x + y * y + z * z);
+  if (r < std::numeric_limits<float>::epsilon())
+    return {0.f, 0.f};
+  return {std::acos(std::max(-1.f, std::min(1.f, z / r))), std::atan2(y, x)};
+}
 
-  // Phi difference ph1 - ph2 wrapped into [-pi, pi].
-  inline float deltaPhi(float ph1, float ph2) {
-    constexpr float pi = static_cast<float>(M_PI);
-    float d = ph1 - ph2;
-    if (d > pi)  d -= 2.f * pi;
-    if (d < -pi) d += 2.f * pi;
-    return d;
-  }
+// Phi difference ph1 - ph2 wrapped into [-pi, pi].
+inline float deltaPhi(float ph1, float ph2) {
+  constexpr float pi = static_cast<float>(M_PI);
+  float d = ph1 - ph2;
+  if (d > pi)
+    d -= 2.f * pi;
+  if (d < -pi)
+    d += 2.f * pi;
+  return d;
+}
 
-  // Angular distance sqrt(dTheta^2 + dPhi_wrapped^2).
-  inline float angularDist(float th1, float ph1, float th2, float ph2) {
-    const float dth = th1 - th2;
-    const float dph = deltaPhi(ph1, ph2);
-    return std::sqrt(dth * dth + dph * dph);
-  }
+// Angular distance sqrt(dTheta^2 + dPhi_wrapped^2).
+inline float angularDist(float th1, float ph1, float th2, float ph2) {
+  const float dth = th1 - th2;
+  const float dph = deltaPhi(ph1, ph2);
+  return std::sqrt(dth * dth + dph * dph);
+}
 } // namespace ClusterSeeding
 
-struct ClusterSeedMerging final
-    : ClusterSeedingBase<
-          std::tuple<edm4hep::ClusterCollection>( // merged output
-               const std::vector<const edm4hep::ClusterCollection*>&, // calo-driven seeds
-               const std::vector<const edm4hep::ClusterCollection*>&)> // track-driven seeds
+struct ClusterSeedMerging final : ClusterSeedingBase<std::tuple<edm4hep::ClusterCollection>(  // merged output
+                                      const std::vector<const edm4hep::ClusterCollection*>&,  // calo-driven seeds
+                                      const std::vector<const edm4hep::ClusterCollection*>&)> // track-driven seeds
 {
   ClusterSeedMerging(const std::string& name, ISvcLocator* svcLoc);
 
@@ -114,9 +104,8 @@ struct ClusterSeedMerging final
              const std::vector<const edm4hep::ClusterCollection*>& trackSeeds) const override;
 
   // ---- Merging criterion (configurable) ----
-  Gaudi::Property<float> m_mergeDistance{
-      this, "MergeDistance", 44.f,
-      "d in arctan(d / |pos_i|): half-angle cone size for adjacency (mm)"};
+  Gaudi::Property<float> m_mergeDistance{this, "MergeDistance", 44.f,
+                                         "d in arctan(d / |pos_i|): half-angle cone size for adjacency (mm)"};
 };
 
 #endif // ClusterSeedMerging_h

--- a/RecFCCeeCalorimeter/src/components/ClusterSeedMerging.h
+++ b/RecFCCeeCalorimeter/src/components/ClusterSeedMerging.h
@@ -1,0 +1,122 @@
+#ifndef ClusterSeedMerging_h
+#define ClusterSeedMerging_h 1
+
+/*
+ * ClusterSeedMerging
+ *
+ * Gaudi MultiTransformer that merges cluster seeds from the calorimeter-driven
+ * (Type A/B) and track-driven (Type C) seeding algorithms into a single set of
+ * merged clusters.
+ *
+ * Merging criterion
+ * -----------------
+ *   Two seeds i and j are spatially adjacent when the opening angle between
+ *   their position vectors is less than arctan(MergeDistance / |pos_i|):
+ *
+ *     alpha(i,j) < arctan(MergeDistance / |pos_i|)
+ *
+ *   This defines a fixed angular cone of half-angle arctan(d/r_i) around
+ *   seed i.  Adjacency is propagated transitively via BFS. The constraint
+ *   that at most one Type-C seed may belong to any merged group is enforced
+ *   during BFS (additional C seeds found while growing a component that
+ *   already contains one C seed are deferred to their own component).
+ *
+ * Outputs
+ * -------
+ *   OutputMergedSeeds  (edm4hep::ClusterCollection)
+ *       One cluster per merged group. The cluster position is set to the
+ *       energy-weighted barycenter of the constituent seed hits. All
+ *       constituent seed hits are attached.
+ *
+ * Inputs
+ * ------
+ *   CaloDrivenSeeds   (vector of edm4hep::ClusterCollection)
+ *       Output collections from CaloDrivenClusterSeeding (Type A/B).
+ *   TrackDrivenSeeds  (vector of edm4hep::ClusterCollection)
+ *       Output collections from TrackDrivenClusterSeeding (Type C).
+ */
+
+#include "edm4hep/ClusterCollection.h"
+
+#include "k4FWCore/Transformer.h"
+#include "Gaudi/Property.h"
+
+#include "ClusterSeedingBase.h"
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+#include <map>
+#include <tuple>
+#include <utility>
+#include <vector>
+
+// helper functions
+namespace ClusterSeeding {
+  enum class SeedType {
+    CaloDrivenA = 0x1,
+    CaloDrivenB = 0x2,
+    TrackDrivenC = 0x4,
+    Unseeded = 0x8
+  };
+
+  // ---- Cluster::type bit-field layout ----
+  //   bits  0..15 : PDG ID  (NH=130, photon=22, ch=211, sat=0)    -- written by downstream PID algorithms
+  //   bits 16..31 : SeedType bitmask                              -- written by seeding components
+  inline int encodeType(int pdg, SeedType seed) {
+    return (pdg & 0xFFFF) | ((static_cast<int>(seed) & 0xFFFF) << 16);
+  }
+  inline int decodePdg(int t) {
+    return static_cast<int16_t>(t & 0xFFFF);
+  }
+  inline SeedType decodeSeed(int t) {
+    return static_cast<SeedType>((t >> 16) & 0xFFFF);
+  }
+
+  // ---- Geometry helpers (free functions) ----
+  // Convert (x,y,z) to (theta, phi).  Returns (0,0) if |r| ~ 0.
+  inline std::pair<float, float> toThetaPhi(float x, float y, float z) {
+    const float r = std::sqrt(x * x + y * y + z * z);
+    if (r < std::numeric_limits<float>::epsilon()) return {0.f, 0.f};
+    return {std::acos(std::max(-1.f, std::min(1.f, z / r))), std::atan2(y, x)};
+  }
+
+  // Phi difference ph1 - ph2 wrapped into [-pi, pi].
+  inline float deltaPhi(float ph1, float ph2) {
+    constexpr float pi = static_cast<float>(M_PI);
+    float d = ph1 - ph2;
+    if (d > pi)  d -= 2.f * pi;
+    if (d < -pi) d += 2.f * pi;
+    return d;
+  }
+
+  // Angular distance sqrt(dTheta^2 + dPhi_wrapped^2).
+  inline float angularDist(float th1, float ph1, float th2, float ph2) {
+    const float dth = th1 - th2;
+    const float dph = deltaPhi(ph1, ph2);
+    return std::sqrt(dth * dth + dph * dph);
+  }
+} // namespace ClusterSeeding
+
+struct ClusterSeedMerging final
+    : ClusterSeedingBase<
+          std::tuple<edm4hep::ClusterCollection>( // merged output
+               const std::vector<const edm4hep::ClusterCollection*>&, // calo-driven seeds
+               const std::vector<const edm4hep::ClusterCollection*>&)> // track-driven seeds
+{
+  ClusterSeedMerging(const std::string& name, ISvcLocator* svcLoc);
+
+  StatusCode initialize() override;
+  StatusCode finalize() override { return StatusCode::SUCCESS; }
+
+  std::tuple<edm4hep::ClusterCollection>
+  operator()(const std::vector<const edm4hep::ClusterCollection*>& caloSeeds,
+             const std::vector<const edm4hep::ClusterCollection*>& trackSeeds) const override;
+
+  // ---- Merging criterion (configurable) ----
+  Gaudi::Property<float> m_mergeDistance{
+      this, "MergeDistance", 44.f,
+      "d in arctan(d / |pos_i|): half-angle cone size for adjacency (mm)"};
+};
+
+#endif // ClusterSeedMerging_h

--- a/RecFCCeeCalorimeter/src/components/ClusterSeedingBase.h
+++ b/RecFCCeeCalorimeter/src/components/ClusterSeedingBase.h
@@ -1,0 +1,327 @@
+#ifndef ClusterSeedingBase_h
+#define ClusterSeedingBase_h 1
+
+/*
+ * ClusterSeedingBase<Signature>
+ *
+ * CRTP-free templated base class for the calorimeter clustering functionals
+ *
+ * Each daughter class inherits from
+ *   ClusterSeedingBase<ReturnType(InputTypes...)>
+ * which itself inherits from
+ *   k4FWCore::MultiTransformer<ReturnType(InputTypes...)>
+ * so the Gaudi framework sees a fully-specified MultiTransformer with exactly
+ * the right signature.  The daughter only needs to declare its own
+ * constructor/operator() and any extra algorithm-specific properties or
+ * methods; everything shared lives here.
+ *
+ * Shared protected interface
+ * --------------------------
+ *   initialize() override
+ *       Retrieves GeoSvc, resolves the segmentation from ReadoutName, and
+ *       builds the internal m_decoder pointer.  Daughters that need additional
+ *       initialisation should call ClusterSeedingBase::initialize() first.
+ *
+ *   passSelection(cellID)
+ *       Returns true if the cell passes all (FieldStringsToFilter/Values) and
+ *       all (FieldStringsToInclude/Values) cuts.
+ *
+ *   vonNeumannNeighbors(cellID, half)
+ *       Returns the set of cellIDs that are reachable from cellID within Von
+ *       Neumann distance *half* using the segmentation's neighbour finder.
+ *
+ *   isConnected(cells)
+ *       Returns true if all cells in the set form one connected component
+ *       under VN-d1 adjacency.
+ *
+ *   calcBarycenter(hits)  /  calcBarycenter(hitMap)
+ *       Overloaded log-weighted barycenter helper returning a ClusterState.
+ *       w_i = max(0, W0 + ln(E_i / E_tot)).
+ *
+ * Shared protected properties (all configurable via Gaudi::Property)
+ * ------------------------------------------------------------------
+ *   ReadoutName            (std::string)
+ *   FieldStringsToFilter   (std::vector<std::string>)
+ *   FieldValuesToFilter    (std::vector<int>)
+ *   W0                     (float)   log-weight offset
+ *
+ * Shared protected data members
+ * ------------------------------
+ *   m_geoSvc       SmartIF<IGeoSvc>
+ *   m_segmentation dd4hep::DDSegmentation::Segmentation*
+ *   m_decoder      const dd4hep::DDSegmentation::BitFieldCoder*
+ */
+
+#include "edm4hep/CalorimeterHit.h"
+#include "edm4hep/CalorimeterHitCollection.h"
+#include "edm4hep/MutableCluster.h"
+
+#include "k4FWCore/Transformer.h"
+#include "k4Interface/IGeoSvc.h"
+#include "Gaudi/Property.h"
+
+#include "DD4hep/Detector.h"
+#include "DD4hep/Readout.h"
+#include "DDSegmentation/Segmentation.h"
+
+#include <cmath>
+#include <map>
+#include <queue>
+#include <set>
+#include <unordered_map>
+#include <vector>
+
+// forward declarations
+namespace dd4hep {
+  namespace DDSegmentation {
+    class Segmentation;
+    class BitFieldCoder;
+  }
+}
+
+// ============================================================
+//  ClusterSeedingBase
+// ============================================================
+
+template <typename Signature>
+struct ClusterSeedingBase : k4FWCore::MultiTransformer<Signature> {
+
+  // ---- Type aliases ----
+  // Convenience alias for a map of cellID -> CalorimeterHit, used as the
+  // standard hit-pool type throughout the clustering chain.
+  using Hitmap = std::unordered_map<uint64_t, edm4hep::CalorimeterHit>;
+
+  // ---- Lightweight cluster state used by barycenter ----
+  struct ClusterState {
+    float x{0.f}, y{0.f}, z{0.f}, energy{0.f};
+  };
+
+protected:
+  // ---- Constructor forwarding to MultiTransformer ----
+  // Daughters call:
+  //   ClusterSeedingBase(name, svcLoc, inputs, outputs)
+  // which forwards directly to MultiTransformer.
+  using Base = k4FWCore::MultiTransformer<Signature>;
+  using Base::Base;
+
+  // ---- Shared initialisation ----
+  // Retrieves GeoSvc, resolves segmentation from m_readoutName, and
+  // caches m_segmentation / m_decoder.  Daughters that override initialize()
+  // should call this first:
+  //   if (ClusterSeedingBase::initialize().isFailure()) return StatusCode::FAILURE;
+  StatusCode initialize() override {
+    m_geoSvc = this->service("GeoSvc");
+    if (!m_geoSvc) {
+      this->error() << "Unable to locate GeoSvc." << endmsg;
+      return StatusCode::FAILURE;
+    }
+
+    if (m_geoSvc->getDetector()->readouts().find(m_readoutName) ==
+        m_geoSvc->getDetector()->readouts().end()) {
+      this->error() << "Readout <<" << m_readoutName << ">> does not exist." << endmsg;
+      return StatusCode::FAILURE;
+    }
+
+    m_segmentation = m_geoSvc->getDetector()->readout(m_readoutName).segmentation().segmentation();
+    m_decoder      = m_geoSvc->getDetector()->readout(m_readoutName).segmentation().decoder();
+
+    if (m_fieldStringsToFilter.size() != m_fieldValuesToFilter.size()) {
+      this->error() << "FieldStringsToFilter and FieldValuesToFilter must have the same number of entries "
+              << "(got " << m_fieldStringsToFilter.size() << " vs " << m_fieldValuesToFilter.size() << ")." << endmsg;
+      return StatusCode::FAILURE;
+    }
+
+    return StatusCode::SUCCESS;
+  } // initialize
+
+  // ---- Cell-ID selection ----
+  // Returns false if:
+  //   for each (field, value) in FieldStringsToFilter:  decoder[field] != value
+  //   (i.e. the cell is filtered out)
+  bool passSelection(uint64_t cellID) const {
+    if (!m_decoder)
+      return true;
+
+    for (size_t i = 0; i < m_fieldStringsToFilter.size(); ++i) {
+      const int64_t value = m_decoder->get(cellID, m_fieldStringsToFilter[i]);
+      if (value != static_cast<int64_t>(m_fieldValuesToFilter[i]))
+        return false;
+    }
+
+    return true;
+  } // passSelection
+
+  // ---- Von Neumann neighbourhood ----
+  // Returns all cellIDs reachable from cellID within VN distance *half*
+  // using the segmentation's neighbour finder (BFS, *half* iterations).
+  std::set<uint64_t> vonNeumannNeighbors(uint64_t cellID, unsigned int half) const {
+    std::set<uint64_t> frontier{cellID};
+    std::set<uint64_t> visited{cellID};
+    for (unsigned int d = 0; d < half; ++d) {
+      std::set<uint64_t> nextFrontier;
+      for (uint64_t cid : frontier) {
+        std::set<dd4hep::DDSegmentation::CellID> temp;
+        m_segmentation->neighbours(cid, temp);
+
+        // filter out neighbors that fail passSelection
+        std::set<dd4hep::DDSegmentation::CellID> nbrs;
+        for (const auto& nb : temp) {
+          if (passSelection(nb))
+            nbrs.insert(nb);
+        }
+
+        // form next frontier with unvisited neighbors
+        for (auto nb : nbrs) {
+          if (visited.insert(nb).second)
+            nextFrontier.insert(nb);
+        }
+      }
+
+      frontier = std::move(nextFrontier);
+    } // for each layer
+
+    return visited;
+  } // vonNeumannNeighbors
+
+  // ---- Connectivity check (VN-d1) ----
+  // Returns true if all cellIDs in *cells* form a single connected component
+  // under VN distance-1 adjacency (shared-face neighbours only).
+  bool isConnected(const std::set<uint64_t>& cells) const {
+    if (cells.size() <= 1)
+      return true;
+
+    const uint64_t start = *cells.begin();
+    std::set<uint64_t> visited{start};
+    std::queue<uint64_t> q;
+    q.push(start);
+
+    while (!q.empty()) {
+      const uint64_t current = q.front();
+      q.pop();
+      std::set<uint64_t> nbrs;
+      m_segmentation->neighbours(current, nbrs);
+
+      std::set<uint64_t> filteredNbrs;
+      for (const auto& nb : nbrs) {
+        if (passSelection(nb))
+          filteredNbrs.insert(nb);
+      }
+
+      for (const uint64_t nb : filteredNbrs) {
+        if (cells.count(nb) && !visited.count(nb)) {
+          visited.insert(nb);
+          q.push(nb);
+        }
+      }
+    }
+
+    return visited.size() == cells.size();
+  } // isConnected
+
+  // ---- Log-weighted barycenter (vector<hit> overload) ----
+  ClusterState calcBarycenter(const std::vector<edm4hep::CalorimeterHit>& hits) const {
+    float totE = 0.f;
+    for (const auto& h : hits)
+      totE += h.getEnergy();
+
+    ClusterState s;
+    s.energy = totE;
+
+    // Guard against zero/negative total energy to avoid NaNs
+    if (totE <= 0.f)
+      return s;
+
+    float totW = 0.f;
+    for (const auto& h : hits) {
+      const float w = std::max(0.f, m_w0.value() + std::log(h.getEnergy() / totE));
+      totW += w;
+      const auto& p = h.getPosition();
+      s.x += w * p.x;
+      s.y += w * p.y;
+      s.z += w * p.z;
+    }
+    if (totW > 0.f) {
+      s.x /= totW;
+      s.y /= totW;
+      s.z /= totW;
+    }
+
+    return s;
+  } // calcBarycenter
+
+  // ---- Log-weighted barycenter (Hitmap overload) ----
+  ClusterState calcBarycenter(const Hitmap& hitMap) const {
+    float totE = 0.f;
+    for (const auto& [id, h] : hitMap)
+      totE += h.getEnergy();
+
+    ClusterState s;
+    s.energy = totE;
+
+    // Guard against zero/negative total energy to avoid NaNs
+    if (totE <= 0.f)
+      return s;
+
+    float totW = 0.f;
+    for (const auto& [id, h] : hitMap) {
+      const float w = std::max(0.f, m_w0.value() + std::log(h.getEnergy() / totE));
+      totW += w;
+      const auto& p = h.getPosition();
+      s.x += w * p.x;
+      s.y += w * p.y;
+      s.z += w * p.z;
+    }
+    if (totW > 0.f) {
+      s.x /= totW;
+      s.y /= totW;
+      s.z /= totW;
+    }
+
+    return s;
+  } // calcBarycenter
+
+  // ---- Opening-angle distance ----
+  // Returns 1 - cos(angle) between the cluster barycenter direction and (x,y,z).
+  // Returns std::numeric_limits<float>::max() if either vector is at the origin.
+  float openingAngleDist(const ClusterState& cs, float x, float y, float z) const {
+    const float rc = std::sqrt(cs.x * cs.x + cs.y * cs.y + cs.z * cs.z);
+    const float rh = std::sqrt(x * x + y * y + z * z);
+    if (rc < std::numeric_limits<float>::epsilon() || rh < std::numeric_limits<float>::epsilon()) {
+      this->error() << "ClusterSeedingBase::openingAngleDist: zero-length vector! "
+                    << "Cluster (x,y,z,E) = (" << cs.x << "," << cs.y << "," << cs.z << "," << cs.energy << ") "
+                    << "Point (x,y,z) = (" << x << "," << y << "," << z << ")" << endmsg;
+      return std::numeric_limits<float>::max();
+    }
+    float cosAngle = (cs.x * x + cs.y * y + cs.z * z) / (rc * rh);
+    cosAngle = std::max(-1.f, std::min(1.f, cosAngle));
+
+    return 1.f - cosAngle;
+  } // openingAngleDist
+
+  // ---- Shared protected properties ----
+
+  // Readout / cell-ID decoding
+  Gaudi::Property<std::string> m_readoutName{
+      this, "ReadoutName", "",
+      "Name of the calorimeter readout (used to retrieve the segmentation)"};
+
+  // Exclude cells matching any (field, value) pair
+  Gaudi::Property<std::vector<std::string>> m_fieldStringsToFilter{
+      this, "FieldStringsToFilter", {},
+      "BitField names used to filter (exclude) hits, e.g. 'cherenkov', 'layer'"};
+  Gaudi::Property<std::vector<int>> m_fieldValuesToFilter{
+      this, "FieldValuesToFilter", {},
+      "Values corresponding to FieldStringsToFilter"};
+
+  // Barycenter / distance parameters
+  Gaudi::Property<float> m_w0{
+      this, "W0", 4.6f,
+      "Log-weight offset in log-weighted barycenter: w_i = max(0, W0 + ln(E_i/E_tot))"};
+
+  // ---- Shared protected data members ----
+  SmartIF<IGeoSvc>                                   m_geoSvc;
+  dd4hep::DDSegmentation::Segmentation*              m_segmentation{nullptr};
+  const dd4hep::DDSegmentation::BitFieldCoder*       m_decoder{nullptr};
+};
+
+#endif // ClusterSeedingBase_h

--- a/RecFCCeeCalorimeter/src/components/ClusterSeedingBase.h
+++ b/RecFCCeeCalorimeter/src/components/ClusterSeedingBase.h
@@ -56,9 +56,9 @@
 #include "edm4hep/CalorimeterHitCollection.h"
 #include "edm4hep/MutableCluster.h"
 
+#include "Gaudi/Property.h"
 #include "k4FWCore/Transformer.h"
 #include "k4Interface/IGeoSvc.h"
-#include "Gaudi/Property.h"
 
 #include "DD4hep/Detector.h"
 #include "DD4hep/Readout.h"
@@ -73,11 +73,11 @@
 
 // forward declarations
 namespace dd4hep {
-  namespace DDSegmentation {
-    class Segmentation;
-    class BitFieldCoder;
-  }
-}
+namespace DDSegmentation {
+  class Segmentation;
+  class BitFieldCoder;
+} // namespace DDSegmentation
+} // namespace dd4hep
 
 // ============================================================
 //  ClusterSeedingBase
@@ -116,18 +116,18 @@ protected:
       return StatusCode::FAILURE;
     }
 
-    if (m_geoSvc->getDetector()->readouts().find(m_readoutName) ==
-        m_geoSvc->getDetector()->readouts().end()) {
+    if (m_geoSvc->getDetector()->readouts().find(m_readoutName) == m_geoSvc->getDetector()->readouts().end()) {
       this->error() << "Readout <<" << m_readoutName << ">> does not exist." << endmsg;
       return StatusCode::FAILURE;
     }
 
     m_segmentation = m_geoSvc->getDetector()->readout(m_readoutName).segmentation().segmentation();
-    m_decoder      = m_geoSvc->getDetector()->readout(m_readoutName).segmentation().decoder();
+    m_decoder = m_geoSvc->getDetector()->readout(m_readoutName).segmentation().decoder();
 
     if (m_fieldStringsToFilter.size() != m_fieldValuesToFilter.size()) {
       this->error() << "FieldStringsToFilter and FieldValuesToFilter must have the same number of entries "
-              << "(got " << m_fieldStringsToFilter.size() << " vs " << m_fieldValuesToFilter.size() << ")." << endmsg;
+                    << "(got " << m_fieldStringsToFilter.size() << " vs " << m_fieldValuesToFilter.size() << ")."
+                    << endmsg;
       return StatusCode::FAILURE;
     }
 
@@ -301,27 +301,23 @@ protected:
   // ---- Shared protected properties ----
 
   // Readout / cell-ID decoding
-  Gaudi::Property<std::string> m_readoutName{
-      this, "ReadoutName", "",
-      "Name of the calorimeter readout (used to retrieve the segmentation)"};
+  Gaudi::Property<std::string> m_readoutName{this, "ReadoutName", "",
+                                             "Name of the calorimeter readout (used to retrieve the segmentation)"};
 
   // Exclude cells matching any (field, value) pair
   Gaudi::Property<std::vector<std::string>> m_fieldStringsToFilter{
-      this, "FieldStringsToFilter", {},
-      "BitField names used to filter (exclude) hits, e.g. 'cherenkov', 'layer'"};
+      this, "FieldStringsToFilter", {}, "BitField names used to filter (exclude) hits, e.g. 'cherenkov', 'layer'"};
   Gaudi::Property<std::vector<int>> m_fieldValuesToFilter{
-      this, "FieldValuesToFilter", {},
-      "Values corresponding to FieldStringsToFilter"};
+      this, "FieldValuesToFilter", {}, "Values corresponding to FieldStringsToFilter"};
 
   // Barycenter / distance parameters
-  Gaudi::Property<float> m_w0{
-      this, "W0", 4.6f,
-      "Log-weight offset in log-weighted barycenter: w_i = max(0, W0 + ln(E_i/E_tot))"};
+  Gaudi::Property<float> m_w0{this, "W0", 4.6f,
+                              "Log-weight offset in log-weighted barycenter: w_i = max(0, W0 + ln(E_i/E_tot))"};
 
   // ---- Shared protected data members ----
-  SmartIF<IGeoSvc>                                   m_geoSvc;
-  dd4hep::DDSegmentation::Segmentation*              m_segmentation{nullptr};
-  const dd4hep::DDSegmentation::BitFieldCoder*       m_decoder{nullptr};
+  SmartIF<IGeoSvc> m_geoSvc;
+  dd4hep::DDSegmentation::Segmentation* m_segmentation{nullptr};
+  const dd4hep::DDSegmentation::BitFieldCoder* m_decoder{nullptr};
 };
 
 #endif // ClusterSeedingBase_h

--- a/RecFCCeeCalorimeter/src/components/TrackDrivenClusterSeeding.cpp
+++ b/RecFCCeeCalorimeter/src/components/TrackDrivenClusterSeeding.cpp
@@ -1,0 +1,174 @@
+#include "TrackDrivenClusterSeeding.h"
+
+#include "edm4hep/CalorimeterHit.h"
+#include "edm4hep/MutableCluster.h"
+#include "edm4hep/Track.h"
+#include "edm4hep/TrackState.h"
+
+#include "DD4hep/Detector.h"
+#include "DDSegmentation/Segmentation.h"
+
+#include <cmath>
+#include <limits>
+#include <set>
+#include <unordered_map>
+#include <vector>
+
+// ============================================================
+//  TrackDrivenClusterSeeding
+// ============================================================
+
+TrackDrivenClusterSeeding::TrackDrivenClusterSeeding(const std::string& name,
+                                                     ISvcLocator*      svcLoc)
+    : ClusterSeedingBase(name, svcLoc,
+                       {KeyValue ("InputTrackCollection",   "TracksFromGenParticles"),
+                        KeyValues("InputCaloHitCollections", {})},
+                       {KeyValue ("OutputSeedsC", "TrackDrivenSeedsC")}) {}
+
+// ------------------------------------------------------------
+
+StatusCode TrackDrivenClusterSeeding::initialize() {
+  return ClusterSeedingBase::initialize();
+}
+
+// ------------------------------------------------------------
+
+std::tuple<edm4hep::ClusterCollection>
+TrackDrivenClusterSeeding::operator()(
+    const edm4hep::TrackCollection&                                  trackColl,
+    const std::vector<const edm4hep::CalorimeterHitCollection*>& caloHitColls) const {
+
+  edm4hep::ClusterCollection seedsC;
+
+  const float thr    = m_seedEnergyThreshold.value();
+  const float window = m_trackWindow.value();
+
+  // ------------------------------------------------------------------
+  // Step 1: Build energy and position maps for above-threshold hits
+  //         that pass the cell-ID selection filter.
+  // ------------------------------------------------------------------
+  std::unordered_map<uint64_t, float> energyMap;
+  ClusterSeedingBase::Hitmap hitMap;
+
+  for (const auto* coll : caloHitColls) {
+    if (!coll) continue;
+    for (const auto& hit : *coll) {
+      const uint64_t cellID = hit.getCellID();
+      if (!passSelection(cellID)) continue;
+      energyMap[cellID] += hit.getEnergy();
+      hitMap.try_emplace(cellID, hit);
+    }
+  }
+
+  // ------------------------------------------------------------------
+  // Step 2: Pre-compute (theta, phi) for each hit to avoid repeated
+  //         sqrt/atan2 calls during the per-track search.
+  // ------------------------------------------------------------------
+
+  std::unordered_map<uint64_t, std::pair<float,float>> posMap; // cellID -> (theta, phi)
+  posMap.reserve(hitMap.size());
+  for (const auto& [cellID, hit] : hitMap) {
+    const auto& p = hit.getPosition();
+    posMap[cellID] = ClusterSeeding::toThetaPhi(p.x, p.y, p.z);
+  }
+
+  // ------------------------------------------------------------------
+  // Step 3: Collect all track states at the calorimeter surface.
+  //         edm4hep TrackState location == 4: AtCalorimeter.
+  // ------------------------------------------------------------------
+  std::vector<std::pair<float,float>> trackImpacts; // (theta, phi)
+  for (const auto& track : trackColl) {
+    for (const auto& ts : track.getTrackStates()) {
+      if (ts.location != edm4hep::TrackState::AtCalorimeter)
+        continue; // AtCalorimeter only
+
+      const auto& rp = ts.referencePoint;
+      trackImpacts.push_back(ClusterSeeding::toThetaPhi(rp.x, rp.y, rp.z));
+      break;
+    }
+  } // loop over tracks
+
+  // ------------------------------------------------------------------
+  // Step 4: For each track state on calo, find the best seed candidate.
+  // ------------------------------------------------------------------
+  std::set<uint64_t> usedSeeds; // avoid duplicating a seed for two close tracks
+
+  for (const auto& [tth, tph] : trackImpacts) {
+    uint64_t bestCell = 0;
+    std::set<uint64_t> bestNbrs; // best seed + VN-d1 neighbors that pass selection
+    float bestDist = std::numeric_limits<float>::max();
+
+    for (const auto& [cellID, energy] : energyMap) {
+      if (energy < thr)
+        continue;
+
+      auto posIt = posMap.find(cellID);
+      if (posIt == posMap.end())
+        continue;
+
+      const auto& [cth, cph] = posIt->second;
+
+      // Angular distance from track impact
+      const float dist = ClusterSeeding::angularDist(cth, cph, tth, tph);
+      if (dist >= window)
+        continue;
+
+      // Local maximum check within VN neighbourhood
+      std::set<uint64_t> rawNbrs;
+      m_segmentation->neighbours(cellID, rawNbrs);
+      // filter neighbors through passSelection
+      std::set<uint64_t> filteredNbrs;
+      for (const auto& nb : rawNbrs) {
+        if (passSelection(nb))
+          filteredNbrs.insert(nb);
+      }
+  
+      bool isLocalMax = true;
+      for (const uint64_t nb : filteredNbrs) {
+        if (nb == cellID)
+          continue;
+
+        auto it = energyMap.find(nb);
+        if (it != energyMap.end() && it->second > energy) {
+          isLocalMax = false;
+          break;
+        }
+      } // for filtered neighbors
+
+      if (!isLocalMax)
+        continue;
+
+      if (dist < bestDist) {
+        bestDist = dist;
+        bestCell = cellID;
+        bestNbrs = std::move(filteredNbrs);
+      }
+    } // loop over hits
+
+    if (bestCell == 0)
+      continue; // no candidate found for this track
+    if (usedSeeds.count(bestCell))
+      continue; // already seeded by another track
+    usedSeeds.insert(bestCell);
+
+    // Build the cluster: seed hit + above-threshold VN-d1 neighbourhood
+    auto cluster = seedsC.create();
+    cluster.setType(static_cast<int>(ClusterSeeding::SeedType::TrackDrivenC)); // Type C seed (track-driven)
+    // use the seed hit position as the cluster position
+    cluster.setPosition(hitMap[bestCell].getPosition());
+
+    for (const auto& id : bestNbrs) {
+      auto it = hitMap.find(id);
+      if (it != hitMap.end())
+        cluster.addToHits(it->second);
+    }
+  } // loop over track impacts
+
+  debug() << "TrackDrivenClusterSeeding: found " << seedsC.size()
+          << " Type-C seeds from " << trackImpacts.size()
+          << " track states." << endmsg;
+
+  return std::make_tuple(std::move(seedsC));
+}
+
+DECLARE_COMPONENT(TrackDrivenClusterSeeding)

--- a/RecFCCeeCalorimeter/src/components/TrackDrivenClusterSeeding.cpp
+++ b/RecFCCeeCalorimeter/src/components/TrackDrivenClusterSeeding.cpp
@@ -18,29 +18,25 @@
 //  TrackDrivenClusterSeeding
 // ============================================================
 
-TrackDrivenClusterSeeding::TrackDrivenClusterSeeding(const std::string& name,
-                                                     ISvcLocator*      svcLoc)
-    : ClusterSeedingBase(name, svcLoc,
-                       {KeyValue ("InputTrackCollection",   "TracksFromGenParticles"),
-                        KeyValues("InputCaloHitCollections", {})},
-                       {KeyValue ("OutputSeedsC", "TrackDrivenSeedsC")}) {}
+TrackDrivenClusterSeeding::TrackDrivenClusterSeeding(const std::string& name, ISvcLocator* svcLoc)
+    : ClusterSeedingBase(
+          name, svcLoc,
+          {KeyValue("InputTrackCollection", "TracksFromGenParticles"), KeyValues("InputCaloHitCollections", {})},
+          {KeyValue("OutputSeedsC", "TrackDrivenSeedsC")}) {}
 
 // ------------------------------------------------------------
 
-StatusCode TrackDrivenClusterSeeding::initialize() {
-  return ClusterSeedingBase::initialize();
-}
+StatusCode TrackDrivenClusterSeeding::initialize() { return ClusterSeedingBase::initialize(); }
 
 // ------------------------------------------------------------
 
 std::tuple<edm4hep::ClusterCollection>
-TrackDrivenClusterSeeding::operator()(
-    const edm4hep::TrackCollection&                                  trackColl,
-    const std::vector<const edm4hep::CalorimeterHitCollection*>& caloHitColls) const {
+TrackDrivenClusterSeeding::operator()(const edm4hep::TrackCollection& trackColl,
+                                      const std::vector<const edm4hep::CalorimeterHitCollection*>& caloHitColls) const {
 
   edm4hep::ClusterCollection seedsC;
 
-  const float thr    = m_seedEnergyThreshold.value();
+  const float thr = m_seedEnergyThreshold.value();
   const float window = m_trackWindow.value();
 
   // ------------------------------------------------------------------
@@ -51,10 +47,12 @@ TrackDrivenClusterSeeding::operator()(
   ClusterSeedingBase::Hitmap hitMap;
 
   for (const auto* coll : caloHitColls) {
-    if (!coll) continue;
+    if (!coll)
+      continue;
     for (const auto& hit : *coll) {
       const uint64_t cellID = hit.getCellID();
-      if (!passSelection(cellID)) continue;
+      if (!passSelection(cellID))
+        continue;
       energyMap[cellID] += hit.getEnergy();
       hitMap.try_emplace(cellID, hit);
     }
@@ -65,7 +63,7 @@ TrackDrivenClusterSeeding::operator()(
   //         sqrt/atan2 calls during the per-track search.
   // ------------------------------------------------------------------
 
-  std::unordered_map<uint64_t, std::pair<float,float>> posMap; // cellID -> (theta, phi)
+  std::unordered_map<uint64_t, std::pair<float, float>> posMap; // cellID -> (theta, phi)
   posMap.reserve(hitMap.size());
   for (const auto& [cellID, hit] : hitMap) {
     const auto& p = hit.getPosition();
@@ -76,7 +74,7 @@ TrackDrivenClusterSeeding::operator()(
   // Step 3: Collect all track states at the calorimeter surface.
   //         edm4hep TrackState location == 4: AtCalorimeter.
   // ------------------------------------------------------------------
-  std::vector<std::pair<float,float>> trackImpacts; // (theta, phi)
+  std::vector<std::pair<float, float>> trackImpacts; // (theta, phi)
   for (const auto& track : trackColl) {
     for (const auto& ts : track.getTrackStates()) {
       if (ts.location != edm4hep::TrackState::AtCalorimeter)
@@ -122,7 +120,7 @@ TrackDrivenClusterSeeding::operator()(
         if (passSelection(nb))
           filteredNbrs.insert(nb);
       }
-  
+
       bool isLocalMax = true;
       for (const uint64_t nb : filteredNbrs) {
         if (nb == cellID)
@@ -164,8 +162,7 @@ TrackDrivenClusterSeeding::operator()(
     }
   } // loop over track impacts
 
-  debug() << "TrackDrivenClusterSeeding: found " << seedsC.size()
-          << " Type-C seeds from " << trackImpacts.size()
+  debug() << "TrackDrivenClusterSeeding: found " << seedsC.size() << " Type-C seeds from " << trackImpacts.size()
           << " track states." << endmsg;
 
   return std::make_tuple(std::move(seedsC));

--- a/RecFCCeeCalorimeter/src/components/TrackDrivenClusterSeeding.cpp
+++ b/RecFCCeeCalorimeter/src/components/TrackDrivenClusterSeeding.cpp
@@ -155,7 +155,14 @@ TrackDrivenClusterSeeding::operator()(const edm4hep::TrackCollection& trackColl,
     // use the seed hit position as the cluster position
     cluster.setPosition(hitMap[bestCell].getPosition());
 
+    // Add the seed cell itself. m_segmentation->neighbours() returns only the
+    // surrounding cells, so bestCell (the local-max that defines the seed) is NOT in
+    // bestNbrs and would otherwise be dropped -- leaving isolated MIP seeds with 0 hits.
+    cluster.addToHits(hitMap[bestCell]);
+
     for (const auto& id : bestNbrs) {
+      if (id == bestCell)
+        continue; // guard against double-add if neighbours() ever includes the query cell
       auto it = hitMap.find(id);
       if (it != hitMap.end())
         cluster.addToHits(it->second);

--- a/RecFCCeeCalorimeter/src/components/TrackDrivenClusterSeeding.h
+++ b/RecFCCeeCalorimeter/src/components/TrackDrivenClusterSeeding.h
@@ -1,0 +1,82 @@
+#ifndef TrackDrivenClusterSeeding_h
+#define TrackDrivenClusterSeeding_h 1
+
+/*
+ * TrackDrivenClusterSeeding
+ *
+ * Gaudi MultiTransformer that identifies cluster seeds driven by charged-
+ * particle track states at the calorimeter surface (Type-C seeds).
+ *
+ * Algorithm
+ * ---------
+ *   For each track state at the calorimeter surface (TrackState::AtCalorimeter,
+ *   location == 4):
+ *     1. Find all calorimeter hits (filtered by FieldStrings/FieldValues) whose
+ *        angular distance from the track impact point is less than TrackWindow.
+ *     2. Among those, keep only hits with E > SeedEnergyThreshold that are a
+ *        local maximum within their Von Neumann distance-1 neighbourhood.
+ *     3. Retain only the single closest hit to the track impact point.
+ *
+ *   One cluster (containing the single seed hit and its VN-d1 neighbourhood
+ *   hits) is produced per track state, at most.  Two track states that resolve
+ *   to the same seed crystal produce only one cluster.
+ *
+ * Input
+ * -----
+ *   edm4hep::TrackCollection
+ *       Reconstructed charged-particle tracks.  All TrackState entries with
+ *       location == AtCalorimeter (4) are used.
+ *
+ *   std::vector<const edm4hep::CalorimeterHitCollection*>
+ *       Digitised calorimeter hit collections.  Filtered internally via
+ *       FieldStrings / FieldValues (same mechanism as CaloDrivenClusterSeeding).
+ *
+ * Output
+ * ------
+ *   edm4hep::ClusterCollection
+ *       One cluster per accepted track seed.  Each cluster holds the seed
+ *       crystal plus all above-threshold hits from its VN-d1 neighbourhood.
+ */
+
+#include "edm4hep/CalorimeterHitCollection.h"
+#include "edm4hep/ClusterCollection.h"
+#include "edm4hep/TrackCollection.h"
+
+#include "k4FWCore/Transformer.h"
+#include "Gaudi/Property.h"
+
+#include "ClusterSeedingBase.h"
+#include "ClusterSeedMerging.h" // for SeedType enum
+
+#include <cmath>
+#include <limits>
+#include <set>
+#include <tuple>
+#include <vector>
+
+struct TrackDrivenClusterSeeding final
+    : ClusterSeedingBase<
+          std::tuple<edm4hep::ClusterCollection>(
+              const edm4hep::TrackCollection&,
+              const std::vector<const edm4hep::CalorimeterHitCollection*>&)> {
+
+  TrackDrivenClusterSeeding(const std::string& name, ISvcLocator* svcLoc);
+
+  StatusCode initialize() override;
+  StatusCode finalize() override { return StatusCode::SUCCESS; }
+
+  std::tuple<edm4hep::ClusterCollection>
+  operator()(const edm4hep::TrackCollection& trackColl,
+             const std::vector<const edm4hep::CalorimeterHitCollection*>& caloHitColls) const override;
+
+  // ---- Algorithm parameters ----
+  Gaudi::Property<float> m_seedEnergyThreshold{
+      this, "SeedEnergyThreshold", 0.020f,
+      "Minimum crystal energy [GeV] to be considered as a Type-C seed candidate"};
+  Gaudi::Property<float> m_trackWindow{
+      this, "TrackWindow", 0.05f,
+      "Angular search cone half-angle [rad] around the track impact point: "
+      "sqrt(dTheta^2 + dPhi^2) < TrackWindow"};
+};
+
+#endif // TrackDrivenClusterSeeding_h

--- a/RecFCCeeCalorimeter/src/components/TrackDrivenClusterSeeding.h
+++ b/RecFCCeeCalorimeter/src/components/TrackDrivenClusterSeeding.h
@@ -42,11 +42,11 @@
 #include "edm4hep/ClusterCollection.h"
 #include "edm4hep/TrackCollection.h"
 
-#include "k4FWCore/Transformer.h"
 #include "Gaudi/Property.h"
+#include "k4FWCore/Transformer.h"
 
-#include "ClusterSeedingBase.h"
 #include "ClusterSeedMerging.h" // for SeedType enum
+#include "ClusterSeedingBase.h"
 
 #include <cmath>
 #include <limits>
@@ -55,10 +55,8 @@
 #include <vector>
 
 struct TrackDrivenClusterSeeding final
-    : ClusterSeedingBase<
-          std::tuple<edm4hep::ClusterCollection>(
-              const edm4hep::TrackCollection&,
-              const std::vector<const edm4hep::CalorimeterHitCollection*>&)> {
+    : ClusterSeedingBase<std::tuple<edm4hep::ClusterCollection>(
+          const edm4hep::TrackCollection&, const std::vector<const edm4hep::CalorimeterHitCollection*>&)> {
 
   TrackDrivenClusterSeeding(const std::string& name, ISvcLocator* svcLoc);
 
@@ -71,12 +69,10 @@ struct TrackDrivenClusterSeeding final
 
   // ---- Algorithm parameters ----
   Gaudi::Property<float> m_seedEnergyThreshold{
-      this, "SeedEnergyThreshold", 0.020f,
-      "Minimum crystal energy [GeV] to be considered as a Type-C seed candidate"};
-  Gaudi::Property<float> m_trackWindow{
-      this, "TrackWindow", 0.05f,
-      "Angular search cone half-angle [rad] around the track impact point: "
-      "sqrt(dTheta^2 + dPhi^2) < TrackWindow"};
+      this, "SeedEnergyThreshold", 0.020f, "Minimum crystal energy [GeV] to be considered as a Type-C seed candidate"};
+  Gaudi::Property<float> m_trackWindow{this, "TrackWindow", 0.05f,
+                                       "Angular search cone half-angle [rad] around the track impact point: "
+                                       "sqrt(dTheta^2 + dPhi^2) < TrackWindow"};
 };
 
 #endif // TrackDrivenClusterSeeding_h

--- a/RecFCCeeCalorimeter/tests/options/IDEA_o2_v01_reco.py
+++ b/RecFCCeeCalorimeter/tests/options/IDEA_o2_v01_reco.py
@@ -1,0 +1,210 @@
+from Gaudi.Configuration import *
+import os
+
+# CI mode -> barrel wedge (IDEA_o2_v01_CI.xml); otherwise the full detector.
+CI = bool(os.environ.get("IDEA_O2_CI"))
+
+# ---- I/O ----
+from k4FWCore import IOSvc, ApplicationMgr
+from Configurables import EventDataSvc
+
+io_svc = IOSvc("IOSvc")
+io_svc.Input = "testIDEA_o2_v01_sim.root"
+io_svc.Output = "testIDEA_o2_v01_reco.root"
+io_svc.outputCommands = ["keep *"]
+
+# ---- Geometry ----
+from Configurables import GeoSvc
+
+geoservice = GeoSvc("GeoSvc")
+geoservice.detectors = [
+    os.path.join(
+        os.environ.get("K4GEO", ""),
+        "FCCee/IDEA/compact/IDEA_o2_v01",
+        "IDEA_o2_v01_CI.xml" if CI else "IDEA_o2_v01.xml",
+    )
+]
+geoservice.OutputLevel = INFO
+
+# ---- Tracks from gen particles ----
+from Configurables import TracksFromGenParticles
+
+tracksFromGenParticles = TracksFromGenParticles(
+    "CreateTracksFromGenParticles",
+    InputGenParticles=["MCParticles"],
+    InputSimTrackerHits=[
+        "VertexBarrelCollection",
+        "VertexEndcapCollection",
+        "DCHCollection",
+        "SiWrBCollection",
+        "SiWrDCollection",
+    ],
+    OutputTracks=["TracksFromGenParticles"],
+    OutputMCRecoTrackParticleAssociation=["TracksFromGenParticlesAssociation"],
+    ExtrapolateToECal=True,
+    OnlyCaloReachingParticles=True,
+    OutputLevel=INFO,
+)
+
+# ---- Optical calo digitization ----
+from Configurables import CreateOpticalCaloCells
+
+
+def optical_digi(name, optical, truth, out, link, calib, mask=False):
+    return CreateOpticalCaloCells(
+        name,
+        OpticalHits=optical,
+        TruthHits=truth,
+        OutputCollection=out,
+        OutputLinks=link,
+        calibrationConstant=calib,
+        maskCherenkovForTruthLink=mask,
+        OutputLevel=INFO,
+    )
+
+
+# ECAL crystals: scint & Cherenkov share one deposit -> mask cherenkov in the link
+ecalDigis = [
+    optical_digi("createEcalScintCells", "SCEPCal_MainScounts", "SCEPCal_MainEdep",
+                 "SCEPCal_digi_scint", "SCEPCal_scint_link", 1.0 / 1965.0, mask=True),
+    optical_digi("createEcalCherenCells", "SCEPCal_MainCcounts", "SCEPCal_MainEdep",
+                 "SCEPCal_digi_cheren", "SCEPCal_cheren_link", 1.0 / 97.75, mask=True),
+]
+
+# HCAL tubes: scint & Cherenkov are distinct cells -> full-cellID link (default)
+hcalDigis = [
+    optical_digi("createHcalBarrelScintCells", "DRBTScin", "DRTubeEdep",
+                 "DRBTScin_digi", "DRBTScin_link", 1.0 / 206.25),
+    optical_digi("createHcalBarrelCherenCells", "DRBTCher", "DRTubeEdep",
+                 "DRBTCher_digi", "DRBTCher_link", 1.0 / 68.25),
+]
+if not CI:  # DR endcap exists only in the full geometry
+    hcalDigis += [
+        optical_digi("createHcalEndcapRScintCells", "DRETScinRight", "DRTubeEdep",
+                     "DRETScinRight_digi", "DRETScinRight_link", 1.0 / 206.25),
+        optical_digi("createHcalEndcapRCherenCells", "DRETCherRight", "DRTubeEdep",
+                     "DRETCherRight_digi", "DRETCherRight_link", 1.0 / 68.25),
+        optical_digi("createHcalEndcapLScintCells", "DRETScinLeft", "DRTubeEdep",
+                     "DRETScinLeft_digi", "DRETScinLeft_link", 1.0 / 206.25),
+        optical_digi("createHcalEndcapLCherenCells", "DRETCherLeft", "DRTubeEdep",
+                     "DRETCherLeft_digi", "DRETCherLeft_link", 1.0 / 68.25),
+    ]
+
+# ---- Seed -> merge -> grow clustering (SCEPCal) ----
+from Configurables import (
+    CaloDrivenClusterSeeding,
+    TrackDrivenClusterSeeding,
+    ClusterSeedMerging,
+    ClusterSeedGrower,
+)
+
+caloDrivenClusterSeed = CaloDrivenClusterSeeding(
+    "CaloDrivenClusterSeed",
+    InputCaloHitCollections=["SCEPCal_digi_scint"],
+    OutputSeedsA="CaloDrivenSeedsA",
+    OutputSeedsB="CaloDrivenSeedsB",
+    ReadoutName="SCEPCal_Main",
+    FieldStringsToFilter=["depth"],
+    FieldValuesToFilter=[0],
+    SeedEnergyThresholdA=0.04,
+    SeedEnergyThresholdB=0.02,
+    MinAboveThresholdNeighbours=2,
+    VonNeumannDistance=2,
+    OutputLevel=INFO,
+)
+
+trackDrivenClusterSeed = TrackDrivenClusterSeeding(
+    "TrackDrivenClusterSeed",
+    InputTrackCollection="TracksFromGenParticles",
+    InputCaloHitCollections=["SCEPCal_digi_scint"],
+    OutputSeedsC="TrackDrivenSeedsC",
+    ReadoutName="SCEPCal_Main",
+    FieldStringsToFilter=["depth"],
+    FieldValuesToFilter=[0],
+    SeedEnergyThreshold=0.02,
+    TrackWindow=0.05,
+    OutputLevel=INFO,
+)
+
+clusterSeedMerge = ClusterSeedMerging(
+    "ClusterSeedMerge",
+    CaloDrivenSeeds=["CaloDrivenSeedsA", "CaloDrivenSeedsB"],
+    TrackDrivenSeeds=["TrackDrivenSeedsC"],
+    OutputMergedSeeds="MergedSeeds",
+    MergeDistance=45.0,
+    W0=4.6,
+    OutputLevel=INFO,
+)
+
+topoClusterGrower = ClusterSeedGrower(
+    "TopoClusterGrower",
+    InputSeeds=["MergedSeeds"],
+    InputHits=["SCEPCal_digi_cheren", "SCEPCal_digi_scint"],
+    OutputClusters="TopoGrownClusters",
+    ReadoutName="SCEPCal_Main",
+    FieldStringsToFilter=[],
+    FieldValuesToFilter=[],
+    FieldStringsToInclude=[],
+    FieldValuesToInclude=[],
+    GrowThreshold=0.0,
+    HardThreshold=0.0,
+    UnseededThreshold=0.02,
+    W0=4.6,
+    VNDistSeeded=2,
+    VNDistUnseeded=2,
+    MinUnseededHits=2,
+    MaxOpeningAngle=0.3,
+    AttachIsolatedHits=False,
+    OutputLevel=INFO,
+)
+
+# ---- Truth links ----
+from Configurables import CreateTruthLinks
+
+createTruthLinksECAL = CreateTruthLinks(
+    "CreateTruthLinksECAL",
+    cell_hit_links=["SCEPCal_scint_link"],
+    clusters=["TopoGrownClusters"],
+    mcparticles="MCParticles",
+    cell_mcparticle_links="SCEPCal_CaloHitMCParticleLinks",
+    cluster_mcparticle_links="EcalClusterMCParticleLinks",
+    OutputLevel=INFO,
+)
+
+hcal_links = ["DRBTScin_link", "DRBTCher_link"]
+if not CI:
+    hcal_links += [
+        "DRETScinRight_link", "DRETCherRight_link",
+        "DRETScinLeft_link", "DRETCherLeft_link",
+    ]
+
+createTruthLinksHCAL = CreateTruthLinks(
+    "CreateTruthLinksHCAL",
+    cell_hit_links=hcal_links,
+    clusters=[],
+    mcparticles="MCParticles",
+    cell_mcparticle_links="DRTube_CaloHitMCParticleLinks",
+    cluster_mcparticle_links="empty_ClusterMCParticleLinks",
+    OutputLevel=INFO,
+)
+
+# ---- Services + app ----
+from Configurables import UniqueIDGenSvc
+
+ApplicationMgr(
+    TopAlg=[tracksFromGenParticles]
+    + ecalDigis
+    + hcalDigis
+    + [
+        caloDrivenClusterSeed,
+        trackDrivenClusterSeed,
+        clusterSeedMerge,
+        topoClusterGrower,
+        createTruthLinksECAL,
+        createTruthLinksHCAL,
+    ],
+    EvtSel="NONE",
+    EvtMax=-1,
+    ExtSvc=[EventDataSvc("EventDataSvc"), geoservice, UniqueIDGenSvc("uidSvc")],
+    StopOnSignal=True,
+)

--- a/RecFCCeeCalorimeter/tests/options/IDEA_o2_v01_reco.py
+++ b/RecFCCeeCalorimeter/tests/options/IDEA_o2_v01_reco.py
@@ -65,29 +65,79 @@ def optical_digi(name, optical, truth, out, link, calib, mask=False):
 
 # ECAL crystals: scint & Cherenkov share one deposit -> mask cherenkov in the link
 ecalDigis = [
-    optical_digi("createEcalScintCells", "SCEPCal_MainScounts", "SCEPCal_MainEdep",
-                 "SCEPCal_digi_scint", "SCEPCal_scint_link", 1.0 / 1965.0, mask=True),
-    optical_digi("createEcalCherenCells", "SCEPCal_MainCcounts", "SCEPCal_MainEdep",
-                 "SCEPCal_digi_cheren", "SCEPCal_cheren_link", 1.0 / 97.75, mask=True),
+    optical_digi(
+        "createEcalScintCells",
+        "SCEPCal_MainScounts",
+        "SCEPCal_MainEdep",
+        "SCEPCal_digi_scint",
+        "SCEPCal_scint_link",
+        1.0 / 1965.0,
+        mask=True,
+    ),
+    optical_digi(
+        "createEcalCherenCells",
+        "SCEPCal_MainCcounts",
+        "SCEPCal_MainEdep",
+        "SCEPCal_digi_cheren",
+        "SCEPCal_cheren_link",
+        1.0 / 97.75,
+        mask=True,
+    ),
 ]
 
 # HCAL tubes: scint & Cherenkov are distinct cells -> full-cellID link (default)
 hcalDigis = [
-    optical_digi("createHcalBarrelScintCells", "DRBTScin", "DRTubeEdep",
-                 "DRBTScin_digi", "DRBTScin_link", 1.0 / 206.25),
-    optical_digi("createHcalBarrelCherenCells", "DRBTCher", "DRTubeEdep",
-                 "DRBTCher_digi", "DRBTCher_link", 1.0 / 68.25),
+    optical_digi(
+        "createHcalBarrelScintCells",
+        "DRBTScin",
+        "DRTubeEdep",
+        "DRBTScin_digi",
+        "DRBTScin_link",
+        1.0 / 206.25,
+    ),
+    optical_digi(
+        "createHcalBarrelCherenCells",
+        "DRBTCher",
+        "DRTubeEdep",
+        "DRBTCher_digi",
+        "DRBTCher_link",
+        1.0 / 68.25,
+    ),
 ]
 if not CI:  # DR endcap exists only in the full geometry
     hcalDigis += [
-        optical_digi("createHcalEndcapRScintCells", "DRETScinRight", "DRTubeEdep",
-                     "DRETScinRight_digi", "DRETScinRight_link", 1.0 / 206.25),
-        optical_digi("createHcalEndcapRCherenCells", "DRETCherRight", "DRTubeEdep",
-                     "DRETCherRight_digi", "DRETCherRight_link", 1.0 / 68.25),
-        optical_digi("createHcalEndcapLScintCells", "DRETScinLeft", "DRTubeEdep",
-                     "DRETScinLeft_digi", "DRETScinLeft_link", 1.0 / 206.25),
-        optical_digi("createHcalEndcapLCherenCells", "DRETCherLeft", "DRTubeEdep",
-                     "DRETCherLeft_digi", "DRETCherLeft_link", 1.0 / 68.25),
+        optical_digi(
+            "createHcalEndcapRScintCells",
+            "DRETScinRight",
+            "DRTubeEdep",
+            "DRETScinRight_digi",
+            "DRETScinRight_link",
+            1.0 / 206.25,
+        ),
+        optical_digi(
+            "createHcalEndcapRCherenCells",
+            "DRETCherRight",
+            "DRTubeEdep",
+            "DRETCherRight_digi",
+            "DRETCherRight_link",
+            1.0 / 68.25,
+        ),
+        optical_digi(
+            "createHcalEndcapLScintCells",
+            "DRETScinLeft",
+            "DRTubeEdep",
+            "DRETScinLeft_digi",
+            "DRETScinLeft_link",
+            1.0 / 206.25,
+        ),
+        optical_digi(
+            "createHcalEndcapLCherenCells",
+            "DRETCherLeft",
+            "DRTubeEdep",
+            "DRETCherLeft_digi",
+            "DRETCherLeft_link",
+            1.0 / 68.25,
+        ),
     ]
 
 # ---- Seed -> merge -> grow clustering (SCEPCal) ----
@@ -174,8 +224,10 @@ createTruthLinksECAL = CreateTruthLinks(
 hcal_links = ["DRBTScin_link", "DRBTCher_link"]
 if not CI:
     hcal_links += [
-        "DRETScinRight_link", "DRETCherRight_link",
-        "DRETScinLeft_link", "DRETCherLeft_link",
+        "DRETScinRight_link",
+        "DRETCherRight_link",
+        "DRETScinLeft_link",
+        "DRETCherLeft_link",
     ]
 
 createTruthLinksHCAL = CreateTruthLinks(

--- a/RecFCCeeCalorimeter/tests/options/test_IDEAo2_reco.sh
+++ b/RecFCCeeCalorimeter/tests/options/test_IDEAo2_reco.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+# CI: IDEA_o2_v01 dual-readout calorimeter reco on a barrel wedge.
+#   ddsim pions into the CI wedge -> optical digi + seed/grow clustering -> check clusters.
+set -e
+
+SOURCE_DIR=$(dirname "$0")
+COMPACT="$K4GEO/FCCee/IDEA/compact/IDEA_o2_v01/IDEA_o2_v01_CI.xml"
+
+# Steering wires the DR/SCEPCal SDs; use $K4GEO's copy if present, else fetch it.
+STEERING="$K4GEO/example/SteeringFile_IDEA_o2_v01.py"
+if [ ! -f "$STEERING" ]; then
+  [ -d k4geo ] || { git clone --no-checkout https://github.com/key4hep/k4geo && ( cd k4geo && git checkout HEAD example ); }
+  STEERING="k4geo/example/SteeringFile_IDEA_o2_v01.py"
+fi
+
+# IDEA_O2_CI=1 selects the CI wedge in both the steering and the reco config.
+export IDEA_O2_CI=1
+ddsim --compactFile="$COMPACT" --steeringFile="$STEERING" \
+      --runType batch -G --numberOfEvents 5 \
+      --gun.particle pi- --gun.energy 10*GeV \
+      --gun.direction "0.966,0.259,0.01" --random.seed 1988301045 \
+      --outputFile testIDEA_o2_v01_sim.root
+
+k4run "$SOURCE_DIR/IDEA_o2_v01_reco.py"
+
+# Sanity: at least one topo cluster must have been grown.
+python3 - <<'EOF'
+import sys, podio.reading
+r = podio.reading.get_reader("testIDEA_o2_v01_reco.root")
+n = sum(len(f.get("TopoGrownClusters")) for f in r.get("events"))
+print("TopoGrownClusters produced:", n)
+sys.exit(0 if n > 0 else 1)
+EOF


### PR DESCRIPTION

BEGINRELEASENOTES
- Add "seeded" ECAL clustering algorithms (`CaloDrivenClusterSeeding`, `TrackDrivenClusterSeeding`, `ClusterSeedMerging`, and `ClusterSeedGrower`)
- Add CI test for the IDEA o2 reconstruction chain

ENDRELEASENOTES

Adds the calorimeter reconstruction chain for the IDEA o2 dual-readout calorimeter (segmented-crystal ECAL + capillary-tube HCAL).

#### CreateOpticalCaloCells (RecCalorimeter)
Turns optical-photon SimCalorimeterHits into CalorimeterHits (energy = signal × calibration, position from the SimHit) and links each cell to its truth energy-deposit SimHit. Truth matching uses the full cellID by default; `maskCherenkovForTruthLink` drops the `cherenkov` field so the crystal ECAL's scint and Cherenkov readings link to their shared deposit, while the tube HCAL keeps its distinct scint/Cherenkov cells.

#### Seeded ECAL clustering (RecFCCeeCalorimeter)
A seed → merge → grow topological clustering for the segmented crystal ECAL:
  - CaloDrivenClusterSeeding — seeds from calorimeter energy (two thresholds + neighbour counting).
  - TrackDrivenClusterSeeding — seeds from tracks extrapolated to the ECAL.
  - ClusterSeedMerging — merges calo/track seeds within a distance.
  - ClusterSeedGrower — grows the merged seeds into clusters (shared logic in ClusterSeedingBase.h).

#### CI
Runs the chain (digitize → seed → merge → grow → truth links) on a ddsim barrel wedge and checks clusters are produced. The reco config is dual-mode: CI wedge under `IDEA_O2_CI=1`, full detector otherwise.

This PR requires key4hep/k4geo#611, key4hep/k4RecTracker#86 to pass the CI test. 