### PR TITLE
Fix phi wrapping in topo cluster barycenter calculation.

### DIFF
--- a/RecCaloCommon/CMakeLists.txt
+++ b/RecCaloCommon/CMakeLists.txt
@@ -3,6 +3,7 @@
 ################################################################################
 
 find_package(boost_timer REQUIRED)
+find_package(boost_unit_test_framework REQUIRED)
 file(GLOB _sources src/*.cpp )
 
 gaudi_add_library(RecCaloCommon
@@ -46,4 +47,11 @@ if(BUILD_TESTING)
     LINK DD4hep::DDCore k4FWCore::k4Interface k4FWCore::k4FWCore
     TEST)
   target_include_directories(MultiIndexer_test.exe AFTER PUBLIC include)
+
+
+  gaudi_add_executable(phihelper_test.exe
+    SOURCES tests/phihelper_test.cpp
+    LINK Boost::unit_test_framework
+    TEST)
+  target_include_directories(phihelper_test.exe AFTER PUBLIC include)
 endif()

--- a/RecCaloCommon/include/RecCaloCommon/phihelper.h
+++ b/RecCaloCommon/include/RecCaloCommon/phihelper.h
@@ -22,26 +22,44 @@ namespace k4::recCalo {
  * Wrap angle in radians to [-pi, pi]
  *
  * Odd positive (negative) multiples of pi map to (-)pi.
+ * (May not always be true for the long double case.)
+ *
+ * If phi is too large (larger than the largest integer that can be
+ * represented exactly as a T), this may fail to produce a value
+ * in the specified range.
  */
 template <std::floating_point T>
-inline T wrapToPi(T phi) {
-  constexpr T PI = std::numbers::pi_v<T>;
-  // For large values this is faster:
-  if (phi < -100 || phi > 100) {
-    return std::remainder(phi, 2 * PI);
+inline constexpr T wrapToPi(T phi) {
+  constexpr T TWOPI = 2 * std::numbers::pi_v<T>;
+  constexpr T INV2PI = std::numbers::inv_pi_v<T> / 2;
+  T x = phi * INV2PI;
+
+  // Round x to the nearest integer.
+  // https://stackoverflow.com/questions/17035464/a-fast-method-to-round-a-double-to-a-32-bit-int-explained
+  static_assert(std::numeric_limits<T>::digits <= sizeof(long int) * CHAR_BIT);
+  constexpr T TOINT = 0x1.8p0 * (1ul << (std::numeric_limits<T>::digits - 1));
+  T ix = (x + TOINT) - TOINT;
+
+  // Above gives banker's rounding; that is, halves round to even integers.
+  // However, to get the cases of phi=Npi right, we want halves to round
+  // towards zero.  Fix up the rounding in that case.  Is there a
+  // better way of doing this?
+  T diff = ix - x;
+  if (std::abs(diff) == 0.5) {
+    if (ix > 0)
+      --ix;
+    else if (ix < 0)
+      ++ix;
   }
-  while (phi > PI)
-    phi -= 2 * PI;
-  while (phi < -PI)
-    phi += 2 * PI;
-  return phi;
+
+  return phi - TWOPI * ix;
 }
 
 /**
  * Return difference phiA - phiB in range [-pi, pi]
  */
 template <std::floating_point T>
-inline T deltaPhi(T phiA, T phiB) {
+inline constexpr T deltaPhi(T phiA, T phiB) {
   return wrapToPi(phiA - phiB);
 }
 
@@ -57,7 +75,7 @@ inline T deltaPhi(T phiA, T phiB) {
  * The returned value is within the range [-pi, pi].
  */
 template <std::floating_point T>
-inline T phiMean(T phiA, T phiB) {
+inline constexpr T phiMean(T phiA, T phiB) {
   const T diff = wrapToPi(phiA - phiB);
   return wrapToPi(phiB + 0.5 * diff);
 }
@@ -72,7 +90,7 @@ inline T phiMean(T phiA, T phiB) {
  * The returned value is within the range [-pi, pi].
  */
 template <std::floating_point T>
-inline T phiBisect(T phiA, T phiB) {
+inline constexpr T phiBisect(T phiA, T phiB) {
   T phi = 0.5 * (phiA + phiB);
   if (phiA > phiB)
     phi += std::numbers::pi;

--- a/RecCaloCommon/include/RecCaloCommon/phihelper.h
+++ b/RecCaloCommon/include/RecCaloCommon/phihelper.h
@@ -1,0 +1,84 @@
+/*
+  Copyright (C) 2002-2026 CERN for the benefit of the ATLAS collaboration
+*/
+/**
+ * @file RecCaloCommon/include/RecCaloCommon/phihelper.h
+ *
+ * Adapted from CxxUtils/phihelper.h from ATLAS:
+ * @author Frank Winklmeier
+ * @date May 2019
+ * @brief Helper for azimuthal angle calculations
+ */
+#ifndef RECCALOCOMMON_PHIHELPER_H
+#define RECCALOCOMMON_PHIHELPER_H
+
+#include <cmath>
+#include <numbers>
+#include <type_traits>
+
+namespace k4::recCalo {
+
+/**
+ * Wrap angle in radians to [-pi, pi]
+ *
+ * Odd positive (negative) multiples of pi map to (-)pi.
+ */
+template <std::floating_point T>
+inline T wrapToPi(T phi) {
+  constexpr T PI = std::numbers::pi_v<T>;
+  // For large values this is faster:
+  if (phi < -100 || phi > 100) {
+    return std::remainder(phi, 2 * PI);
+  }
+  while (phi > PI)
+    phi -= 2 * PI;
+  while (phi < -PI)
+    phi += 2 * PI;
+  return phi;
+}
+
+/**
+ * Return difference phiA - phiB in range [-pi, pi]
+ */
+template <std::floating_point T>
+inline T deltaPhi(T phiA, T phiB) {
+  return wrapToPi(phiA - phiB);
+}
+
+/**
+ * Calculate average of two angles
+ *
+ * The average is calculated as the angle of the sum of the two unit vectors
+ * with angles phiA and phiB. As such it always returns the angle in the
+ * narrower of the two complimentary regions spanned by phiA and phiB. If the
+ * vector sum is zero, return the angle within [-pi/2, pi/2]. This method is
+ * symmetric in its arguments except if |mean| equals pi.
+ *
+ * The returned value is within the range [-pi, pi].
+ */
+template <std::floating_point T>
+inline T phiMean(T phiA, T phiB) {
+  const T diff = wrapToPi(phiA - phiB);
+  return wrapToPi(phiB + 0.5 * diff);
+}
+
+/**
+ * Bisect (average) the angle spanned by phiA and phiB
+ *
+ * The average is calculated by rotating phiA half-way counter-clockwise onto
+ * phiB. Note that his method is not symmetric in its arguments. Typical
+ * use-cases are to determine the centre of a region in the detector.
+ *
+ * The returned value is within the range [-pi, pi].
+ */
+template <std::floating_point T>
+inline T phiBisect(T phiA, T phiB) {
+  T phi = 0.5 * (phiA + phiB);
+  if (phiA > phiB)
+    phi += std::numbers::pi;
+  return wrapToPi(phi);
+}
+
+} // namespace k4::recCalo
+
+#endif // not RECCALOCOMMON_PHIHELPER_H

--- a/RecCaloCommon/tests/phihelper_test.cpp
+++ b/RecCaloCommon/tests/phihelper_test.cpp
@@ -1,0 +1,134 @@
+/*
+  Copyright (C) 2002-2026 CERN for the benefit of the ATLAS collaboration
+*/
+/**
+ * @file RecCaloCommon/tests/phihelper_test.cxx
+ *
+ * Adapted from CxxUtils/tests/phihelper_test.h from ATLAS:
+ * @file CxxUtils/test/phihelper_test.cxx
+ * @author Frank Winklmeier
+ * @date May 2019
+ * @brief Regression tests for phihelper
+ */
+#define BOOST_TEST_DYN_LINK
+#define BOOST_TEST_MODULE phihelper_test
+#include <boost/mpl/list.hpp>
+#include <boost/test/unit_test.hpp>
+
+#include "RecCaloCommon/phihelper.h"
+#include <cmath>
+#include <tuple>
+#include <utility>
+#include <vector>
+
+namespace utf = boost::unit_test;
+using k4::recCalo::deltaPhi;
+using k4::recCalo::phiBisect;
+using k4::recCalo::phiMean;
+using k4::recCalo::wrapToPi;
+
+// Types we want to test
+typedef boost::mpl::list<float, double, long double> test_types;
+
+// Tolerance for floating point comparisons (float, double, long double)
+#define TOLERANCE *utf::tolerance(1e-4f) * utf::tolerance(1e-8) * utf::tolerance(1e-8L)
+
+// cppcheck-suppress unknownMacro
+BOOST_TEST_DECORATOR(TOLERANCE)
+BOOST_AUTO_TEST_CASE_TEMPLATE(test_wrap, T, test_types) {
+  // Needed for boost to apply the correct tolerance in the comparison.
+  // Also note the use of floats for all literals (0.0f) when used
+  // in a comparison to ensure the lowest common type is float.
+  constexpr T PI = std::numbers::pi_v<T>;
+
+  // No wrapping for values within |pi|
+  BOOST_TEST(wrapToPi<T>(3.0) == 3.0f);
+  BOOST_TEST(wrapToPi<T>(-3.0) == -3.0f);
+  // Corner cases
+  BOOST_TEST(wrapToPi<T>(0.0) == 0.0f);
+  BOOST_TEST(wrapToPi<T>(PI) == PI);
+  BOOST_TEST(wrapToPi<T>(-PI) == -PI);
+  BOOST_TEST(wrapToPi<T>(2 * PI) == 0.0f);
+  BOOST_TEST(wrapToPi<T>(-2 * PI) == 0.0f);
+  if constexpr (sizeof(T) <= sizeof(double)) {
+    // With long double rounding, we have PI+PI+PI-PI-PI > PI, so this
+    // test doesn't work out in that case.
+    BOOST_TEST(wrapToPi<T>(3 * PI) == PI);
+    BOOST_TEST(wrapToPi<T>(-3 * PI) == -PI);
+  }
+  // Wrap once
+  BOOST_TEST(wrapToPi<T>(4.0) == 4.0f - 2 * PI);
+  BOOST_TEST(wrapToPi<T>(-4.0) == -4.0f + 2 * PI);
+  // Wrap many times
+  BOOST_TEST(wrapToPi<T>(10 * PI) == 0.0f);
+  BOOST_TEST(wrapToPi<T>(100 * PI) == 0.0f);
+  // Check consistency between loop and remainder solution
+  BOOST_TEST(wrapToPi<T>(40.1 * PI) == wrapToPi<T>(10.1 * PI));
+  BOOST_TEST(wrapToPi<T>(-40.1 * PI) == wrapToPi<T>(-10.1 * PI));
+}
+
+// cppcheck-suppress unknownMacro
+BOOST_TEST_DECORATOR(TOLERANCE)
+BOOST_AUTO_TEST_CASE_TEMPLATE(test_delta, T, test_types) {
+  constexpr T PI = std::numbers::pi_v<T>;
+  BOOST_TEST(deltaPhi<T>(3.0, 2.0) == 1.0f);
+  BOOST_TEST(deltaPhi<T>(3 * M_PI, 2 * PI) == PI);
+  BOOST_TEST(deltaPhi<T>(30 * M_PI, 25 * PI) == PI);
+}
+
+BOOST_TEST_DECORATOR(TOLERANCE)
+BOOST_AUTO_TEST_CASE_TEMPLATE(test_mean, T, test_types) {
+  constexpr T PI = std::numbers::pi_v<T>;
+  // Check values against unit vector addition
+  std::vector<std::pair<T, T>> v = {{0, 0},
+                                    {-1, 1},
+                                    {-1, -1},
+                                    {1, 2},
+                                    {5, 8},
+                                    {0.25 * PI, 0.75 * PI},
+                                    {-0.25 * PI, -0.75 * PI},
+                                    {-0.25 * PI, -0.75 * PI},
+                                    {9 * PI / 4, 11 * PI / 4}};
+  for (const auto& [a, b] : v) {
+    // Check symmetry
+    const T r1 = phiMean<T>(a, b);
+    const T r2 = phiMean<T>(b, a);
+    BOOST_TEST(r1 == r2, "phiMean(" << a << "," << b << ") not symmetric: " << r1 << " != " << r2);
+
+    // Compare to trigonometric result
+    const T mean = atan2(sin(a) + sin(b), cos(a) + cos(b));
+    BOOST_TEST(phiMean<T>(a, b) == mean);
+  }
+
+  // If mean is |pi| we can only check the absolute value
+  BOOST_TEST(std::abs(phiMean<T>(0.75 * PI, -0.75 * PI)) == PI);
+
+  // Check values that result in zero unit vector, i.e. atan2(0,0)
+  // Our algorithm always returns values within [-pi/2, pi/2]
+  std::vector<std::tuple<T, T, T>> w = {{0.0, 1.0 * PI, 0.5 * PI},
+                                        {0.25 * PI, -0.75 * PI, -0.25 * PI},
+                                        {0.5 * PI, -0.5 * PI, 0.0},
+                                        {0.75 * PI, -0.25 * PI, 0.25 * PI},
+                                        {0.0, -1.0 * PI, -0.5 * PI}};
+  for (const auto& [a, b, r] : w) {
+    // Check symmetry and result
+    const auto result = phiMean<T>(a, b);
+    BOOST_TEST(result == phiMean<T>(b, a));
+    BOOST_TEST(result == r, "phiMean(" << a << "," << b << ") = " << result << " != " << r);
+  }
+}
+
+BOOST_TEST_DECORATOR(TOLERANCE)
+BOOST_AUTO_TEST_CASE_TEMPLATE(test_bisect, T, test_types) {
+  constexpr T PI = std::numbers::pi_v<T>;
+  BOOST_TEST(phiBisect<T>(-1.0, 1.0) == 0.0f);
+  BOOST_TEST(phiBisect<T>(1.0, -1.0) == PI);
+  BOOST_TEST(phiBisect<T>(-1.0, -1.0) == -1.0f);
+  BOOST_TEST(phiBisect<T>(0.0, PI) == 0.5f * PI);
+  BOOST_TEST(phiBisect<T>(PI, 0.0) == -0.5f * PI);
+  BOOST_TEST(phiBisect<T>(0.25 * PI, 0.75 * PI) == 0.5f * PI);
+  BOOST_TEST(phiBisect<T>(-0.25 * PI, -0.75 * PI) == 0.5f * PI);
+  BOOST_TEST(phiBisect<T>(0.75 * PI, -0.75 * PI) == PI);
+  BOOST_TEST(phiBisect<T>(-0.75 * PI, 0.75 * PI) == 0.0f);
+  BOOST_TEST(phiBisect<T>(9 * PI / 4, 11 * PI / 4) == 0.5f * PI);
+}

--- a/RecFCCeeCalorimeter/src/components/CaloTopoClusterFCCee.cpp
+++ b/RecFCCeeCalorimeter/src/components/CaloTopoClusterFCCee.cpp
@@ -13,6 +13,8 @@
 
 #include "k4FWCore/MetadataUtils.h"
 
+#include "RecCaloCommon/phihelper.h"
+
 // EDM4hep
 #include "edm4hep/CalorimeterHitCollection.h"
 #include "edm4hep/ClusterCollection.h"
@@ -225,6 +227,7 @@ StatusCode CaloTopoClusterFCCee::execute(const EventContext&) const {
 
     double sumCellPhi = 0.;
     double sumCellTheta = 0.;
+    double phi0 = 0;
 
     double deltaR = 0.;
 
@@ -235,6 +238,8 @@ StatusCode CaloTopoClusterFCCee::execute(const EventContext&) const {
     cellPhi.reserve(cluster.size());
     cellTheta.reserve(cluster.size());
     cellEnergy.reserve(cluster.size());
+
+    using k4::recCalo::deltaPhi, k4::recCalo::wrapToPi;
 
     for (const auto& fastcell : cluster) {
 
@@ -253,7 +258,9 @@ StatusCode CaloTopoClusterFCCee::execute(const EventContext&) const {
       cellTheta.push_back(theta);
       cellEnergy.push_back(energy);
 
-      sumCellPhi += phi * energy;
+      if (sumCellPhi == 0)
+        phi0 = phi;
+      sumCellPhi += deltaPhi(phi, phi0) * energy;
       sumCellTheta += theta * energy;
 
       // attach cell
@@ -274,12 +281,12 @@ StatusCode CaloTopoClusterFCCee::execute(const EventContext&) const {
       outCluster.setPosition(
           edm4hep::Vector3f(clusterPosX / clusterEnergy, clusterPosY / clusterEnergy, clusterPosZ / clusterEnergy));
 
-      sumCellPhi /= clusterEnergy;
+      sumCellPhi = wrapToPi(sumCellPhi / clusterEnergy + phi0);
       sumCellTheta /= clusterEnergy;
 
       for (size_t i = 0; i < cellEnergy.size(); ++i) {
-        deltaR +=
-            std::sqrt(std::pow(cellTheta[i] - sumCellTheta, 2) + std::pow(cellPhi[i] - sumCellPhi, 2)) * cellEnergy[i];
+        deltaR += std::sqrt(std::pow(cellTheta[i] - sumCellTheta, 2) + std::pow(deltaPhi(cellPhi[i], sumCellPhi), 2)) *
+                  cellEnergy[i];
       }
       outCluster.addToShapeParameters(deltaR / clusterEnergy);
     } else {


### PR DESCRIPTION
Take phi wrapping into account when calculating the barycenter and width of topo clusters.

In the process, adapt some code from ATLAS to help with phi calculations.

BEGINRELEASENOTES
- Topo clustering wasn't taking phi wrapping into account, meaning that clusters very near +-pi could have catastrophically wrong phi positions and widths. 
ENDRELEASENOTES
