### PR TITLE
Fix SW clustering sensitivity to cell ordering.

### DIFF
--- a/RecFCCeeCalorimeter/src/components/CaloTowerToolFCCee.cpp
+++ b/RecFCCeeCalorimeter/src/components/CaloTowerToolFCCee.cpp
@@ -129,6 +129,8 @@ uint CaloTowerToolFCCee::CellsIntoTowers(std::vector<std::vector<float>>& aTower
   int iPhi = 0;
   uint clusteredCells = 0;
 
+  std::vector<double> dTowers(m_nThetaTower * m_nPhiTower);
+
   for (const auto& cell : *aCells) {
     float cellX = cell.getPosition().x;
     float cellY = cell.getPosition().y;
@@ -150,7 +152,8 @@ uint CaloTowerToolFCCee::CellsIntoTowers(std::vector<std::vector<float>>& aTower
     // debug() << "Cell: theta = " << cellTheta << " phi = " << cellPhi << endmsg;
     // debug() << "Cell: iTheta = " << iTheta << " iPhi = " << iPhi << " iPhi(cyclic) = " << phiIndexTower(iPhi) <<
     // endmsg;
-    aTowers[iTheta][phiIndexTower(iPhi)] += cell.getEnergy() * sin(cellTheta);
+    double et = cell.getEnergy() * sin(cellTheta);
+    dTowers[iTheta * m_nPhiTower + phiIndexTower(iPhi)] += et;
     if (fillTowersCells) {
       clusteredCells++;
       m_cellsInTowers[std::make_pair(iTheta, phiIndexTower(iPhi))].push_back(cell);
@@ -158,6 +161,12 @@ uint CaloTowerToolFCCee::CellsIntoTowers(std::vector<std::vector<float>>& aTower
 
       if (ncells > 5)
         verbose() << "NUM CELLs IN TOWER : " << ncells << endmsg;
+    }
+  }
+
+  for (size_t jTheta = 0; (int)jTheta < m_nThetaTower; ++jTheta) {
+    for (size_t jPhi = 0; (int)jPhi < m_nPhiTower; ++jPhi) {
+      aTowers[jTheta][jPhi] = dTowers[jTheta * m_nPhiTower + jPhi];
     }
   }
 

--- a/RecFCCeeCalorimeter/src/components/CreateCaloClustersSlidingWindowFCCee.cpp
+++ b/RecFCCeeCalorimeter/src/components/CreateCaloClustersSlidingWindowFCCee.cpp
@@ -94,10 +94,10 @@ StatusCode CreateCaloClustersSlidingWindowFCCee::execute(const EventContext&) co
   m_preClusters.clear();
   int halfThetaPos = floor(m_nThetaPosition / 2.);
   int halfPhiPos = floor(m_nPhiPosition / 2.);
-  float posX = 0;
-  float posY = 0;
-  float posZ = 0;
-  float sumEnergyPos = 0;
+  double posX = 0;
+  double posY = 0;
+  double posZ = 0;
+  double sumEnergyPos = 0;
   std::map<std::pair<uint, uint>, std::vector<edm4hep::CalorimeterHit>> cellsInTowersMap = m_towerTool->cellsInTowers();
 
   // final cluster window


### PR DESCRIPTION
The results of SW clustering depend on the order in which cells are listed in the input container, due to FP non-associativity in sums over cells. These sums are done in single-precision, so we can fix this in practice by doing the sums in double precision and only rounding to single precision at the end.

BEGINRELEASENOTES
- Fix SW clustering to avoid depending on the order in which cells appear in the input container.
ENDRELEASENOTES
