### PR TITLE
More efficient data storage for ReadCaloCrosstalkMap.

### DIFF
--- a/RecCalorimeter/CMakeLists.txt
+++ b/RecCalorimeter/CMakeLists.txt
@@ -58,6 +58,7 @@ gaudi_add_module(k4RecCalorimeterTests
                  SOURCES
                    tests/src/CaloCellConstantsSvcTestAlg.cpp
                    tests/src/CaloCellIndexerSvcTestAlg.cpp
+                   tests/src/ReadCaloCrosstalkMapTestAlg.cpp
                  LINK k4FWCore::k4FWCore
                       k4FWCore::k4Interface
                       Gaudi::GaudiKernel
@@ -74,6 +75,12 @@ add_test(NAME CaloCellIndexerSvc_test
          WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/Testing/Temporary
 )
 set_test_env(CaloCellIndexerSvc_test)
+
+add_test(NAME ReadCaloCrosstalkMap_test
+         COMMAND k4run ${PROJECT_SOURCE_DIR}/RecCalorimeter/tests/options/ReadCaloCrosstalkMap_test.py
+         WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/Testing/Temporary
+)
+set_test_env(ReadCaloCrosstalkMap_test)
 
 
 #install(DIRECTORY ${CMAKE_CURRENT_LIST_DIR}/tests/options DESTINATION ${CMAKE_INSTALL_DATADIR}/${CMAKE_PROJECT_NAME}/Reconstruction/RecCalorimeter)

--- a/RecCalorimeter/src/components/ReadCaloCrosstalkMap.cpp
+++ b/RecCalorimeter/src/components/ReadCaloCrosstalkMap.cpp
@@ -1,5 +1,8 @@
 #include "ReadCaloCrosstalkMap.h"
-#include "RecCaloCommon/k4RecCalorimeter_check.h"
+#include "k4FWCore/GaudiChecks.h"
+#include "k4Interface/IGeoSvc.h"
+
+#include "DD4hep/Detector.h"
 
 #include "TBranch.h"
 #include "TFile.h"
@@ -8,38 +11,84 @@
 
 DECLARE_COMPONENT(ReadCaloCrosstalkMap)
 
+/**
+ * Standard Gaudi initialization method.
+ */
 StatusCode ReadCaloCrosstalkMap::initialize() {
-  // prevent to initialize the tool if not intended (input file path empty)
-  // otherwise things will crash if m_fileName is not available
-  // not a perfect solution but tools seems to not be meant to be optional
-  if (m_fileName == "") {
-    debug() << "Empty 'fileName' provided, it means cross-talk map is not needed, exitting ReadCaloCrosstalkMap "
-               "initilization"
+  // Do nothing if no file name.
+  if (m_fileName.empty()) {
+    debug() << "Empty 'fileName' provided, it means cross-talk map is not needed, exiting ReadCaloCrosstalkMap "
+               "initialization"
             << endmsg;
     return StatusCode::SUCCESS;
   }
 
-  info() << "Loading crosstalk map..." << endmsg;
+  K4_GAUDI_CHECK(AlgTool::initialize());
+  K4_GAUDI_CHECK(m_constantsSvc.retrieve());
+  K4_GAUDI_CHECK(m_indexerSvc.retrieve());
 
-  K4RECCALORIMETER_CHECK(AlgTool::initialize());
+  // Find our subdetector ID.
+  // If defaulted, get the ECAL_Barrel ID from the geometry service.
+  int detID = m_detID;
+  if (detID < 0) {
+    ServiceHandle<IGeoSvc> geoSvc("GeoSvc", name());
+    K4_GAUDI_CHECK(geoSvc.retrieve());
+    detID = geoSvc->getDetector()->constantAsDouble("DetID_ECAL_Barrel");
+  }
 
-  // Check if crosstalk file exists
-  if (gSystem->AccessPathName(m_fileName.value().c_str())) {
-    error() << "Provided file with the crosstalk map not found!" << endmsg;
-    error() << "File path: " << m_fileName.value() << endmsg;
-    return StatusCode::FAILURE;
+  // Find the indexer for this subdetector.
+  m_indexer = m_indexerSvc->indexer(detID);
+  K4_GAUDI_CHECK(m_indexer != nullptr);
+
+  // See if we've already read this data file.
+  m_data = m_constantsSvc->getObj<CrosstalkData>(m_fileName);
+  if (!m_data) {
+    // No --- need to read it.
+    info() << "Loading crosstalk map " << m_fileName << endmsg;
+    // Check if crosstalk file exists
+    if (gSystem->AccessPathName(m_fileName.value().c_str())) {
+      error() << "Provided file with the crosstalk map not found!" << endmsg;
+      error() << "File path: " << m_fileName.value() << endmsg;
+      return StatusCode::FAILURE;
+    }
+    std::unique_ptr<TFile> xtalkFile(TFile::Open(m_fileName.value().c_str(), "READ"));
+    if (xtalkFile->IsZombie()) {
+      error() << "Unable to read the file with the crosstalk map!" << endmsg;
+      error() << "File path: " << m_fileName.value() << endmsg;
+      return StatusCode::FAILURE;
+    } else {
+      info() << "Using the following file with the crosstalk map: " << m_fileName.value() << endmsg;
+    }
+
+    // Read the file and make the data object.
+    CrosstalkData data = readData(*xtalkFile);
+
+    // Store it in the constants service and get back the pointer.
+    K4_GAUDI_CHECK(m_constantsSvc->putObj(m_fileName, std::move(data)));
+    m_data = m_constantsSvc->getObj<CrosstalkData>(m_fileName);
+    K4_GAUDI_CHECK(m_data != nullptr);
   }
-  std::unique_ptr<TFile> xtalkFile(TFile::Open(m_fileName.value().c_str(), "READ"));
-  if (xtalkFile->IsZombie()) {
-    error() << "Unable to read the file with the crosstalk map!" << endmsg;
-    error() << "File path: " << m_fileName.value() << endmsg;
-    return StatusCode::FAILURE;
-  } else {
-    info() << "Using the following file with the crosstalk map: " << m_fileName.value() << endmsg;
-  }
+
+  return StatusCode::SUCCESS;
+}
+
+/// Given a cell ID, return a span of neighbouring cell IDs.
+auto ReadCaloCrosstalkMap::getNeighbours(CellID aCellId) const -> std::span<const CellID> {
+  return m_data->getNeighbours(m_indexer->index(aCellId));
+}
+
+/// Given a cell ID, return a span of crosstalk coeffients,
+/// one per neighbour cell.
+std::span<const double> ReadCaloCrosstalkMap::getCrosstalks(CellID aCellId) const {
+  return m_data->getCrosstalks(m_indexer->index(aCellId));
+}
+
+/// Read crosstalk data from a file.
+auto ReadCaloCrosstalkMap::readData(TFile& xtalkFile) const -> CrosstalkData {
+  CrosstalkData data;
 
   TTree* tree = nullptr;
-  xtalkFile->GetObject("crosstalk_neighbours", tree);
+  xtalkFile.GetObject("crosstalk_neighbours", tree);
   ULong64_t read_cellId;
   std::vector<uint64_t>* read_neighbours = nullptr;
   std::vector<double>* read_crosstalks = nullptr;
@@ -47,36 +96,40 @@ StatusCode ReadCaloCrosstalkMap::initialize() {
   tree->SetBranchAddress("cellId", &read_cellId);
   tree->SetBranchAddress("list_crosstalk_neighbours", &read_neighbours);
   tree->SetBranchAddress("list_crosstalks", &read_crosstalks);
-  for (uint i = 0; i < tree->GetEntries(); i++) {
+
+  size_t ncells = m_indexer->cellIDs().size();
+  data.m_neighbourIndices.resize(ncells);
+  data.m_crosstalkIndices.resize(ncells);
+
+  unsigned nent = tree->GetEntries();
+  for (uint i = 0; i < nent; i++) {
     tree->GetEntry(i);
-    m_mapNeighbours.insert(std::pair<CellID, std::vector<CellID>>(read_cellId, *read_neighbours));
-    m_mapCrosstalks.insert(std::pair<CellID, std::vector<double>>(read_cellId, *read_crosstalks));
+
+    unsigned ndx = m_indexer->index(read_cellId);
+    if (ndx == k4::recCalo::ICaloIndexer::INVALID || ndx >= ncells) {
+      error() << "Read bad cell ID " << read_cellId << " giving index " << ndx << " at entry " << i << endmsg;
+      continue;
+    }
+    {
+      size_t oldsz = data.m_neighbours.size();
+      data.m_neighbours.insert(data.m_neighbours.end(), read_neighbours->begin(), read_neighbours->end());
+      data.m_neighbourIndices.at(ndx) = std::make_pair(oldsz, data.m_neighbours.size() - oldsz);
+    }
+    {
+      size_t oldsz = data.m_crosstalks.size();
+      data.m_crosstalks.insert(data.m_crosstalks.end(), read_crosstalks->begin(), read_crosstalks->end());
+      data.m_crosstalkIndices.at(ndx) = std::make_pair(oldsz, data.m_crosstalks.size() - oldsz);
+    }
   }
 
-  info() << "Crosstalk input: " << m_fileName.value().c_str() << endmsg;
-  info() << "Total number of cells = " << tree->GetEntries()
-         << ", Size of crosstalk neighbours = " << m_mapNeighbours.size()
-         << ", Size of coefficients = " << m_mapCrosstalks.size() << endmsg;
+  info() << "Crosstalk input: " << xtalkFile.GetName() << endmsg;
+  info() << "Total number of cells = " << tree->GetEntries() << endmsg;
+  //<< ", Size of crosstalk neighbours = " << data.m_mapNeighbours.size()
+  //<< ", Size of coefficients = " << data.m_mapCrosstalks.size() << endmsg;
   delete tree;
   delete read_neighbours;
   delete read_crosstalks;
-  xtalkFile->Close();
+  xtalkFile.Close();
 
-  return StatusCode::SUCCESS;
-}
-
-auto ReadCaloCrosstalkMap::getNeighbours(CellID aCellId) const -> std::span<const CellID> {
-  auto it = m_mapNeighbours.find(aCellId);
-  if (it != m_mapNeighbours.end()) {
-    return it->second;
-  }
-  return std::span<const CellID>();
-}
-
-std::span<const double> ReadCaloCrosstalkMap::getCrosstalks(CellID aCellId) const {
-  auto it = m_mapCrosstalks.find(aCellId);
-  if (it != m_mapCrosstalks.end()) {
-    return it->second;
-  }
-  return std::span<const double>();
+  return data;
 }

--- a/RecCalorimeter/src/components/ReadCaloCrosstalkMap.h
+++ b/RecCalorimeter/src/components/ReadCaloCrosstalkMap.h
@@ -1,3 +1,10 @@
+/**
+ * @file RecCalorimeter/src/components/ReadCaloCrosstalkMap.h
+ * @author Zhibo Wu, scott snyder <snyder@bnl.gov>
+ * @date Updated Jul, 2026
+ * @brief Return crosstalk information for a subdetector read from a TTree.
+ */
+
 #ifndef RECCALORIMETER_READCALOXTALKMAP_H
 #define RECCALORIMETER_READCALOXTALKMAP_H
 
@@ -5,49 +12,101 @@
 #include "GaudiKernel/AlgTool.h"
 
 // Interface
+#include "RecCaloCommon/ICaloCellConstantsSvc.h"
+#include "RecCaloCommon/ICaloCellIndexerSvc.h"
 #include "RecCaloCommon/ICaloReadCrosstalkMap.h"
 #include <span>
 
 class IGeoSvc;
+class TFile;
 
-/** @class ReadCaloCrosstalkMap Reconstruction/RecCalorimeter/src/components/ReadCaloCrosstalkMap.h
- *TopoCaloNeighbours.h
+/**
+ * @brief Return crosstalk information for a subdetector read from a TTree.
  *
- *  Tool that reads a ROOT file containing the TTree with branches "cellId", "list_crosstalk_neighbours" and
- *"list_crosstalks". This tools reads the tree, creates two maps, and allows a lookup of all crosstalk neighbours as
- *well as the corresponding crosstalk coefficients for a given cell.
+ * Reads a ROOT file containing the TTree with branches "cellId",
+ * "list_crosstalk_neighbours" and "list_crosstalks".   The data are
+ * read from the tree into a CrosstalkData object, which is stored
+ * in the CaloCellConstantsSvc.   Allows returning the neighbours
+ * and crosstalk coefficients for a given cell.
  *
  *  @author Zhibo Wu
  */
-
 class ReadCaloCrosstalkMap : public extends<AlgTool, k4::recCalo::ICaloReadCrosstalkMap> {
 public:
   using base_class::base_class;
   virtual ~ReadCaloCrosstalkMap() = default;
 
+  /**
+   * Standard Gaudi initialization method.
+   */
   virtual StatusCode initialize() override final;
 
   /** Function to be called for the crosstalk neighbours of a cell.
    *   @param[in] aCellId, cellid of the cell of interest.
-   *   @return vector of cellIDs, corresponding to the crosstalk neighbours.
+   *   @return span of cellIDs, corresponding to the crosstalk neighbours.
    */
   virtual std::span<const CellID> getNeighbours(CellID aCellId) const final override;
 
   /** Function to be called for the crosstalk coefficients between the input cell and its neighbouring cells.
    *   @param[in] aCellId, cellid of the cell of interest.
-   *   @return vector of crosstalk coefficients.
+   *   @return span of crosstalk coefficients.
    */
   virtual std::span<const double> getCrosstalks(CellID aCellId) const final override;
 
 private:
-  /// Name of input root file that contains the TTree with cellID->vec<list_crosstalk_neighboursCellID> and
+  /// Name of input root file that contains the TTree with
+  /// cellID->vec<list_crosstalk_neighboursCellID> and
   /// cellId->vec<list_crosstalksCellID>
-  Gaudi::Property<std::string> m_fileName{this, "fileName", "",
-                                          "Name of the file that contains the crosstalk map. Leave the default empty "
-                                          "to avoid crashes when cross-talk is not needed."};
-  /// Output maps to be used for the fast lookup in the creating calo-cells algorithm
-  std::unordered_map<CellID, std::vector<CellID>> m_mapNeighbours;
-  std::unordered_map<CellID, std::vector<double>> m_mapCrosstalks;
+  Gaudi::Property<std::string> m_fileName{this, "fileName", "", "Name of the file that contains the crosstalk map."};
+
+  /// Our subdetector ID.  If defaulted, ECAL_Barrel will be used.
+  Gaudi::Property<int> m_detID{this, "detID", -1, "Subsystem ID for this detector.  Defaults to ECAL_Barrel."};
+
+  /// Cell constants service.
+  ServiceHandle<k4::recCalo::ICaloCellConstantsSvc> m_constantsSvc{
+      this, "CaloCellConstantsSvc", "k4::recCalo::CaloCellConstantsSvc", "The cell constants service"};
+
+  /// Cell indexing service.
+  ServiceHandle<k4::recCalo::ICaloCellIndexerSvc> m_indexerSvc{
+      this, "CaloCellIndexerSvc", "k4::recCalo::CaloCellIndexerSvc", "The cell indexing service."};
+
+  /// Structure storing the crosstalk data.
+  // We store both ID and coefficient data in flat vectors.
+  struct CrosstalkData {
+    /// This vector is indexed by the cell index.  It gives
+    /// (INDEX,SIZE) pairs in m_neighbours giving the neighbour IDS
+    /// for each cellID.
+    std::vector<std::pair<size_t, size_t>> m_neighbourIndices;
+    /// Neighbour cellID data.
+    std::vector<CellID> m_neighbours;
+    /// This vector is indexed by the cell index.  It gives
+    /// (INDEX,SIZE) pairs in m_crosstalks giving the crosstalk coefficients
+    /// for each cellID.
+    std::vector<std::pair<size_t, size_t>> m_crosstalkIndices;
+    /// Crosstalk coefficient data.
+    std::vector<double> m_crosstalks;
+
+    /// Given a cell index, return a span of neighbouring cell IDs.
+    std::span<const CellID> getNeighbours(size_t cellNdx) const {
+      const auto& indices = m_neighbourIndices.at(cellNdx);
+      return std::span<const CellID>(m_neighbours.data() + indices.first, indices.second);
+    }
+
+    /// Given a cell index, return a span of crosstalk coefficients.
+    std::span<const double> getCrosstalks(size_t cellNdx) const {
+      const auto& indices = m_crosstalkIndices.at(cellNdx);
+      return std::span<const double>(m_crosstalks.data() + indices.first, indices.second);
+    }
+  };
+
+  /// Pointer to the crosstalk data.
+  const CrosstalkData* m_data = nullptr;
+
+  /// Pointer to the cell indexer.
+  const k4::recCalo::ICaloIndexer* m_indexer = nullptr;
+
+  /// Read crosstalk data from a file.
+  CrosstalkData readData(TFile& xtalkFile) const;
 };
 
 #endif /* RECCALORIMETER_READCALOXTALKMAP_H */

--- a/RecCalorimeter/tests/options/ReadCaloCrosstalkMap_test.py
+++ b/RecCalorimeter/tests/options/ReadCaloCrosstalkMap_test.py
@@ -1,0 +1,46 @@
+#
+# File: RecCalorimeter/tests/options/ReadCaloCrosstalkMap_test.py
+# Author: scott snyder <snyder@bnl.gov>
+# Date: Jun, 2026
+# Purpose: Test for ReadCaloCrosstalkMap
+#
+
+import os
+import Configurables as C
+
+fileName = "crosstalkTest.root"
+ECAL_Barrel = 4
+
+compactFile = "ALLEGRO_o1_v03.xml"
+pathToDetector = (
+    os.environ.get("K4GEO", "")
+    + "/FCCee/ALLEGRO/compact/"
+    + os.path.splitext(compactFile)[0]
+)
+
+geoSvc = C.GeoSvc("GeoSvc", detectors=[os.path.join(pathToDetector, compactFile)])
+
+ecalBarrelTool = C.TubeLayerModuleThetaCaloTool(
+    "ecalBarrelGeometryTool",
+    readoutName="ECalBarrelModuleThetaMerged",
+    activeVolumeName="LAr_sensitive",
+    activeFieldName="layer",
+    activeVolumesNumber=11,
+    fieldNames=["system"],
+    fieldValues=[ECAL_Barrel],
+)
+
+indexerSvc = C.k4__recCalo__CaloCellIndexerSvc(GeoTools=[ecalBarrelTool])
+
+crosstalkTool = C.ReadCaloCrosstalkMap(
+    "ReadCaloCrosstalkMap", fileName=fileName, detID=ECAL_Barrel
+)
+
+appmgr = C.ApplicationMgr(
+    TopAlg=[
+        C.k4__recCalo__ReadCaloCrosstalkMapTestAlg(
+            Tool=crosstalkTool, fileName=fileName, detID=ECAL_Barrel
+        )
+    ],
+    ExtSvc=[geoSvc, indexerSvc],
+)

--- a/RecCalorimeter/tests/src/ReadCaloCrosstalkMapTestAlg.cpp
+++ b/RecCalorimeter/tests/src/ReadCaloCrosstalkMapTestAlg.cpp
@@ -1,0 +1,132 @@
+/**
+ * @file ReadCaloCrosstalkMapTestAlg.cpp
+ * @author scott snyder <snyder@bnl.gov>
+ * @date Jul, 2026
+ * @brief Test for ReadCaloCrosstalkMap.
+ */
+
+#include "RecCaloCommon/ICaloCellIndexerSvc.h"
+#include "RecCaloCommon/ICaloReadCrosstalkMap.h"
+
+#include "k4FWCore/GaudiChecks.h"
+
+#include "GaudiKernel/Algorithm.h"
+#include "GaudiKernel/ServiceHandle.h"
+#include "GaudiKernel/ToolHandle.h"
+
+#include "TFile.h"
+#include "TTree.h"
+#include <memory>
+
+namespace k4::recCalo {
+
+class ReadCaloCrosstalkMapTestAlg : public Algorithm {
+public:
+  using CellID = k4::recCalo::ICaloIndexer::CellID;
+  using Algorithm::Algorithm;
+
+  virtual StatusCode initialize() override;
+  virtual StatusCode execute() override;
+
+private:
+  ToolHandle<ICaloReadCrosstalkMap> m_tool{this, "Tool", "ReadCaloCrosstalkMap", ""};
+
+  /// Cell indexing service.
+  ServiceHandle<k4::recCalo::ICaloCellIndexerSvc> m_indexerSvc{
+      this, "CaloCellIndexerSvc", "k4::recCalo::CaloCellIndexerSvc", "The cell indexing service."};
+
+  Gaudi::Property<std::string> m_fileName{this, "fileName", "crosstalkTest.root", ""};
+
+  Gaudi::Property<int> m_detID{this, "detID", -1, ""};
+
+  Gaudi::Property<unsigned> m_ncells{this, "ncells", 100, ""};
+
+  StatusCode writeFile(unsigned int ncells, const std::string& filename,
+                       const k4::recCalo::ICaloIndexer& indexer) const;
+  StatusCode checkCrosstalk(unsigned int ncells, const ICaloReadCrosstalkMap& tool,
+                            const k4::recCalo::ICaloIndexer& indexer) const;
+};
+
+DECLARE_COMPONENT(k4::recCalo::ReadCaloCrosstalkMapTestAlg);
+
+StatusCode ReadCaloCrosstalkMapTestAlg::initialize() {
+  K4_GAUDI_CHECK(m_indexerSvc.retrieve());
+
+  const k4::recCalo::ICaloIndexer* indexer = m_indexerSvc->indexer(m_detID);
+  K4_GAUDI_CHECK(indexer != nullptr);
+  K4_GAUDI_CHECK(writeFile(m_ncells, m_fileName, *indexer));
+  K4_GAUDI_CHECK(m_tool.retrieve());
+  K4_GAUDI_CHECK(checkCrosstalk(m_ncells, *m_tool, *indexer));
+
+  return StatusCode::SUCCESS;
+}
+
+StatusCode ReadCaloCrosstalkMapTestAlg::execute() { return StatusCode::SUCCESS; }
+
+StatusCode ReadCaloCrosstalkMapTestAlg::writeFile(unsigned int ncells, const std::string& fileName,
+                                                  const k4::recCalo::ICaloIndexer& indexer) const {
+  std::unique_ptr<TFile> xtalkFile(TFile::Open(fileName.c_str(), "RECREATE"));
+  auto tree = std::make_unique<TTree>("crosstalk_neighbours", "crosstalk_neighbours");
+
+  ULong64_t write_cellId = 0;
+  std::vector<uint64_t> write_neighbours;
+  std::vector<double> write_crosstalks;
+  tree->Branch("cellId", &write_cellId);
+  tree->Branch("list_crosstalk_neighbours", &write_neighbours);
+  tree->Branch("list_crosstalks", &write_crosstalks);
+
+  std::span<const CellID> cellIDs = indexer.cellIDs();
+  for (size_t icell = 0; icell < ncells; icell++) {
+    write_cellId = cellIDs[icell];
+    unsigned nneigh = 6 + (icell % 4);
+    unsigned ineigh = icell * 10 + 100;
+    if (ineigh + nneigh >= cellIDs.size()) {
+      error() << "Too many cells requested." << endmsg;
+      return StatusCode::FAILURE;
+    }
+
+    write_neighbours.assign(cellIDs.begin() + ineigh, cellIDs.begin() + ineigh + nneigh);
+    write_crosstalks.clear();
+    for (size_t i = 0; i < nneigh; i++) {
+      write_crosstalks.push_back(ineigh + i + 0.5);
+    }
+    tree->Fill();
+  }
+
+  tree->Write();
+  xtalkFile->Close();
+  tree.release();
+  return StatusCode::SUCCESS;
+}
+
+StatusCode ReadCaloCrosstalkMapTestAlg::checkCrosstalk(unsigned int ncells, const ICaloReadCrosstalkMap& tool,
+                                                       const k4::recCalo::ICaloIndexer& indexer) const {
+  std::span<const CellID> cellIDs = indexer.cellIDs();
+  for (size_t icell = 0; icell < ncells; icell++) {
+    std::span<const CellID> neighs = tool.getNeighbours(cellIDs[icell]);
+    std::span<const double> xtalk = tool.getCrosstalks(cellIDs[icell]);
+
+    unsigned nneigh = 6 + (icell % 4);
+    if (neighs.size() != nneigh || xtalk.size() != nneigh) {
+      error() << "Size mismatch for cell index " << icell << " ID " << cellIDs[icell] << " expected " << nneigh
+              << " got " << neighs.size() << " " << xtalk.size() << endmsg;
+      return StatusCode::FAILURE;
+    }
+    unsigned ineigh = icell * 10 + 100;
+    for (unsigned i = 0; i < nneigh; i++) {
+      if (neighs[i] != cellIDs[ineigh + i]) {
+        error() << "Neighbour mismatch for cell index " << icell << " ID " << cellIDs[icell] << " offset " << i
+                << " expected " << cellIDs[ineigh + i] << " got " << neighs[i] << endmsg;
+        return StatusCode::FAILURE;
+      }
+      if (xtalk[i] != ineigh + i + 0.5) {
+        error() << "Crosstalk mismatch for cell index " << icell << " ID " << cellIDs[icell] << " offset " << i
+                << " expected " << ineigh + i + 0.5 << " got " << xtalk[i] << endmsg;
+        return StatusCode::FAILURE;
+      }
+    }
+  }
+  return StatusCode::SUCCESS;
+}
+
+} // namespace k4::recCalo


### PR DESCRIPTION
Change ReadCaloCrosstalkMap to store data in flat vectors rather then in hash maps., using the indexing service.  This is faster and takes much less space.  Also use CaloCellConstantsSvc to avoid duplicating the data, and add a unit test.

BEGINRELEASENOTES
- Rework crosstalk tool to store data more efficiently.
ENDRELEASENOTES
