### PR TITLE
Fix FCCSWEndcapTurbine method calls after k4geo API change

### DIFF
--- a/RecFCCeeCalorimeter/src/components/CreateFCCeeCaloNeighbours.cpp
+++ b/RecFCCeeCalorimeter/src/components/CreateFCCeeCaloNeighbours.cpp
@@ -593,7 +593,7 @@ StatusCode CreateFCCeeCaloNeighbours::initialize() {
                     }
                   }
                   (*endcapDecoder)["rho"].set(endcapCellId, iMatchRho);
-                  if (ecalEndcapTurbineSegmentation->rho(endcapCellId) +
+                  if (ecalEndcapTurbineSegmentation->getGlobalRho(endcapCellId) +
                           ecalEndcapTurbineSegmentation->gridSizeRho(iWheel) / 2. <
                       m_eCalBarrelMinRho)
                     continue;
@@ -676,7 +676,7 @@ StatusCode CreateFCCeeCaloNeighbours::initialize() {
                 decoder->set(cellId, "rho", irho);
                 decoder->set(cellId, "z", iz);
 
-                double endcapRho = ecalEndcapTurbineSegmentation->rho(cellId);
+                double endcapRho = ecalEndcapTurbineSegmentation->getGlobalRho(cellId);
                 if (iWheel == 2 && iz == 0 && (endcapRho > m_eCalBarrelMinRho)) {
                   nextToEMBarrel = true;
                 }
@@ -1900,8 +1900,8 @@ StatusCode CreateFCCeeCaloNeighbours::initialize_lookups() {
 
             double endcapPhi = TMath::ATan2(ecalEndcapTurbineSegmentation->position(endcapCellId).y(),
                                             ecalEndcapTurbineSegmentation->position(endcapCellId).x());
-            double endcapRho = ecalEndcapTurbineSegmentation->rho(endcapCellId);
-            double endcapZ = ecalEndcapTurbineSegmentation->z(endcapCellId);
+            double endcapRho = ecalEndcapTurbineSegmentation->getGlobalRho(endcapCellId);
+            double endcapZ = ecalEndcapTurbineSegmentation->getGlobalZ(endcapCellId);
             double endcapTheta = TMath::ATan2(endcapRho, endcapZ);
 
             if (iSide == -1) {


### PR DESCRIPTION
BEGINRELEASENOTES
- Update method calls in CreateFCCeeCaloNeighbours to use the new API from FCCSWEndcapTurbine_k4geo introduced in https://github.com/key4hep/k4geo/pull/608.

ENDRELEASENOTES

The following methods were renamed:
- `rho()` → `getGlobalRho()`
- `z()` → `getGlobalZ()`
- `phi()` → `getGlobalPhi()`

Errors:
```
/k4RecCalorimeter/RecFCCeeCalorimeter/src/components/CreateFCCeeCaloNeighbours.cpp:596:54: error: no member named 'rho' in 'dd4hep::DDSegmentation::FCCSWEndcapTurbine_k4geo'
  596 |                   if (ecalEndcapTurbineSegmentation->rho(endcapCellId) +
      |                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  ^
/k4RecCalorimeter/RecFCCeeCalorimeter/src/components/CreateFCCeeCaloNeighbours.cpp:679:67: error: no member named 'rho' in 'dd4hep::DDSegmentation::FCCSWEndcapTurbine_k4geo'
  679 |                 double endcapRho = ecalEndcapTurbineSegmentation->rho(cellId);
      |                                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  ^
/k4RecCalorimeter/RecFCCeeCalorimeter/src/components/CreateFCCeeCaloNeighbours.cpp:1903:63: error: no member named 'rho' in 'dd4hep::DDSegmentation::FCCSWEndcapTurbine_k4geo'
 1903 |             double endcapRho = ecalEndcapTurbineSegmentation->rho(endcapCellId);
      |                                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  ^
/k4RecCalorimeter/RecFCCeeCalorimeter/src/components/CreateFCCeeCaloNeighbours.cpp:1904:61: error: no member named 'z' in 'dd4hep::DDSegmentation::FCCSWEndcapTurbine_k4geo'
 1904 |             double endcapZ = ecalEndcapTurbineSegmentation->z(endcapCellId);
      |                              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  ^
```